### PR TITLE
Add API for smooth scrolling

### DIFF
--- a/src/data-editor/data-editor-stories.tsx
+++ b/src/data-editor/data-editor-stories.tsx
@@ -30,7 +30,7 @@ export default {
         (fn: StoryFn<StoryFnReactReturnType>, context: StoryContext) => (
             <div style={{ overflow: "hidden" }}>
                 <BuilderThemeWrapper width={1000} height={800} context={context}>
-                    <DataEditorContainer width={500} height={500}>
+                    <DataEditorContainer width={1000} height={800}>
                         {fn()}
                     </DataEditorContainer>
                 </BuilderThemeWrapper>
@@ -209,6 +209,12 @@ function getData([col, row]: readonly [number, number]): GridCell {
 
 export function Minimal() {
     return <DataEditor getCellContent={getData} columns={columns} rows={1000} />;
+}
+
+export function Smooth() {
+    const [cols] = React.useState(getDummyCols);
+
+    return <DataEditor getCellContent={getDummyData} columns={cols} rows={1000} smoothScrollY={true} smoothScrollX={true} />;
 }
 
 export function ManualControl() {

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -49,10 +49,14 @@ interface Handled {
     readonly scrollRef?: React.MutableRefObject<HTMLDivElement | null>;
 
     readonly onSearchResultsChanged?: (results: readonly (readonly [number, number])[], navIndex: number) => void;
+    readonly onVisibleRegionChanged?: (range: Rectangle, tx?: number, ty?: number) => void;
     readonly searchColOffset: number;
 
     readonly cellXOffset: number;
     readonly cellYOffset: number;
+
+    readonly translateX?: number;
+    readonly translateY?: number;
 }
 
 type ImageEditorType = React.ComponentType<OverlayImageEditorProps>;
@@ -77,6 +81,7 @@ export interface DataEditorProps extends Subtract<DataGridSearchProps, Handled> 
 
     readonly gridSelection?: GridSelection;
     readonly onGridSelectionChange?: (newSelection: GridSelection | undefined) => void;
+    readonly onVisibleRegionChanged?: (range: Rectangle) => void;
 }
 
 const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
@@ -336,13 +341,13 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
         [onHeaderMenuClick, rowMarkerOffset]
     );
 
-    const [visibileRegion, setVisibleRegion] = React.useState<Rectangle>({ x: 0, y: 0, width: 1, height: 1 });
+    const [visibileRegion, setVisibleRegion] = React.useState<Rectangle & {tx?: number, ty?: number}>({ x: 0, y: 0, width: 1, height: 1 });
 
     const cellXOffset = xOff ?? visibileRegion.x;
     const cellYOffset = yOff ?? visibileRegion.y;
 
     const onVisibleRegionChangedImpl = React.useCallback(
-        (visibleRegion: Rectangle) => {
+        (visibleRegion: Rectangle, tx?: number, ty?: number) => {
             const newRegion = {
                 ...visibleRegion,
                 x: visibleRegion.x - rowMarkerOffset,
@@ -350,6 +355,8 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
                     showTrailingBlankRow && visibleRegion.y + visibleRegion.height >= rows
                         ? visibleRegion.height - 1
                         : visibleRegion.height,
+                tx,
+                ty
             };
             setVisibleRegion(newRegion);
             onVisibleRegionChanged?.(newRegion);
@@ -870,6 +877,8 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
                 canvasRef={canvasRef}
                 cellXOffset={(cellXOffset ?? visibileRegion.x) + rowMarkerOffset}
                 cellYOffset={cellYOffset ?? visibileRegion.y}
+                translateX={visibileRegion.tx}
+                translateY={visibileRegion.ty}
                 columns={mangledCols}
                 rows={mangledRows}
                 firstColSticky={rowMarkers}

--- a/src/data-grid/data-grid-lib.ts
+++ b/src/data-grid/data-grid-lib.ts
@@ -8,6 +8,7 @@ import { assertNever } from "../common/support";
 
 interface MappedGridColumn extends GridColumn {
     sourceIndex: number;
+    sticky: boolean;
 }
 
 export function makeEditCell(cell: GridCell): GridCell {
@@ -62,11 +63,13 @@ export function getEffectiveColumns(
     dndState?: {
         src: number;
         dest: number;
-    }
+    },
+    tx?: number
 ): readonly MappedGridColumn[] {
     const mappedCols = columns.map((c, i) => ({
         ...c,
         sourceIndex: i,
+        sticky: firstColSticky && i === 0
     }));
 
     if (dndState !== undefined) {
@@ -84,7 +87,7 @@ export function getEffectiveColumns(
         width -= mappedCols[0].width;
     }
     let endIndex = cellXOffset;
-    let curX = 0;
+    let curX = tx ?? 0;
 
     while (curX <= width && endIndex < mappedCols.length) {
         curX += mappedCols[endIndex].width;

--- a/src/data-grid/data-grid-lib.ts
+++ b/src/data-grid/data-grid-lib.ts
@@ -130,7 +130,7 @@ export function getRowIndexForY(
 ): number | undefined {
     if (targetY <= headerHeight) return -1;
 
-    let ty = targetY - (translateY ?? 0);
+    const ty = targetY - (translateY ?? 0);
     if (typeof rowHeight === "number") {
         const target = Math.floor((ty - headerHeight) / rowHeight) + cellYOffset;
         if (target >= rows) return undefined;

--- a/src/data-grid/data-grid-lib.ts
+++ b/src/data-grid/data-grid-lib.ts
@@ -108,10 +108,11 @@ export function getEffectiveColumns(
     return effectiveCols;
 }
 
-export function getColumnIndexForX(targetX: number, effectiveColumns: readonly MappedGridColumn[]): number {
+export function getColumnIndexForX(targetX: number, effectiveColumns: readonly MappedGridColumn[], translateX?: number): number {
     let x = 0;
     for (const c of effectiveColumns) {
-        if (targetX <= x + c.width) {
+        const cx = c.sticky ? x : x + (translateX ?? 0);
+        if (targetX <= cx + c.width) {
             return c.sourceIndex;
         }
         x += c.width;
@@ -124,19 +125,21 @@ export function getRowIndexForY(
     headerHeight: number,
     rows: number,
     rowHeight: number | ((index: number) => number),
-    cellYOffset: number
+    cellYOffset: number,
+    translateY?: number
 ): number | undefined {
     if (targetY <= headerHeight) return -1;
 
+    let ty = targetY - (translateY ?? 0);
     if (typeof rowHeight === "number") {
-        const target = Math.floor((targetY - headerHeight) / rowHeight) + cellYOffset;
+        const target = Math.floor((ty - headerHeight) / rowHeight) + cellYOffset;
         if (target >= rows) return undefined;
         return target;
     } else {
         let curY = headerHeight;
         for (let i = cellYOffset; i < rows; i++) {
             const rh = rowHeight(i);
-            if (targetY <= curY + rh) return i;
+            if (ty <= curY + rh) return i;
             curY += rh;
         }
         return undefined;

--- a/src/data-grid/data-grid.tsx
+++ b/src/data-grid/data-grid.tsx
@@ -340,8 +340,8 @@ const DataGrid: React.FunctionComponent<Props> = p => {
         ctx.scale(dpr, dpr);
 
         const damage = damageRegion.current;
+        const drawRegions: Rectangle[] = [];
         let blittedYOnly = false;
-        let drawRegions: Rectangle[] = [];
 
         const effectiveCols = getEffectiveColumns(columns, cellXOffset, width, firstColSticky, dragAndDropState, translateX);
 
@@ -527,7 +527,7 @@ const DataGrid: React.FunctionComponent<Props> = p => {
             // horizontal lines
             let y = headerHeight + 0.5;
             let row = cellYOffset;
-            var isHeader = true;
+            let isHeader = true;
             while (y <= height) {
                 const ty = isHeader ? y : y + translateY;
                 ctx.moveTo(0, ty);

--- a/src/data-grid/data-grid.tsx
+++ b/src/data-grid/data-grid.tsx
@@ -528,7 +528,7 @@ const DataGrid: React.FunctionComponent<Props> = p => {
             let y = headerHeight + 0.5;
             let row = cellYOffset;
             let isHeader = true;
-            while (y <= height) {
+            while (y + translateY <= height) {
                 const ty = isHeader ? y : y + translateY;
                 ctx.moveTo(0, ty);
                 ctx.lineTo(width, ty);

--- a/src/data-grid/data-grid.tsx
+++ b/src/data-grid/data-grid.tsx
@@ -142,7 +142,7 @@ const DataGrid: React.FunctionComponent<Props> = p => {
 
             const result: Rectangle = {
                 x: rect.x,
-                y: rect.y + headerHeight,
+                y: rect.y + headerHeight + translateY,
                 width: 0,
                 height: 0,
             };
@@ -150,7 +150,11 @@ const DataGrid: React.FunctionComponent<Props> = p => {
 
             for (const c of effectiveCols) {
                 result.width = c.width + 1;
-                if (c.sourceIndex === col) break;
+                if (c.sourceIndex === col) {
+                    if (!c.sticky)
+                        result.x += translateX;
+                    break;
+                }
                 result.x += c.width;
             }
 
@@ -166,7 +170,7 @@ const DataGrid: React.FunctionComponent<Props> = p => {
 
             return result;
         },
-        [cellXOffset, cellYOffset, columns, firstColSticky, headerHeight, rowHeight, width]
+        [cellXOffset, cellYOffset, columns, firstColSticky, headerHeight, rowHeight, width, translateX, translateY]
     );
 
     const getMouseArgsForPosition = React.useCallback(
@@ -179,11 +183,11 @@ const DataGrid: React.FunctionComponent<Props> = p => {
             const effectiveCols = getEffectiveColumns(columns, cellXOffset, width, firstColSticky, undefined, translateX);
 
             // -1 === off right edge
-            const col = getColumnIndexForX(x, effectiveCols);
+            const col = getColumnIndexForX(x, effectiveCols, translateX);
 
             // -1: header or above
             // undefined: offbottom
-            const row = getRowIndexForY(y, headerHeight, rows, rowHeight, cellYOffset);
+            const row = getRowIndexForY(y, headerHeight, rows, rowHeight, cellYOffset, translateY);
 
             const shiftKey = ev?.shiftKey === true;
 
@@ -250,6 +254,8 @@ const DataGrid: React.FunctionComponent<Props> = p => {
             rowHeight,
             rows,
             width,
+            translateX,
+            translateY
         ]
     );
 

--- a/src/data-grid/data-grid.tsx
+++ b/src/data-grid/data-grid.tsx
@@ -401,9 +401,9 @@ const DataGrid: React.FunctionComponent<Props> = p => {
                     );
                     drawRegions.push({
                         x: 0,
-                        y: headerHeight + 1,
+                        y: headerHeight,
                         width: width,
-                        height: deltaY
+                        height: deltaY + 1
                     });
                 } else if (deltaY < 0) {
                     // scrolling down
@@ -441,9 +441,9 @@ const DataGrid: React.FunctionComponent<Props> = p => {
                         height
                     );
                     drawRegions.push({
-                        x: stickyWidth,
+                        x: stickyWidth - 1,
                         y: 0,
-                        width: deltaX,
+                        width: deltaX + 1,
                         height: height
                     });
                 } else if (deltaX < 0) {

--- a/src/scroll-region/scroll-region.tsx
+++ b/src/scroll-region/scroll-region.tsx
@@ -36,7 +36,7 @@ const ScrollRegion: React.FunctionComponent<Props> = p => {
         update({
             clientHeight: el.clientHeight - (isFirefox ? 4 : 0),
             clientWidth: el.clientWidth,
-            scrollLeft: el.scrollLeft,
+            scrollLeft: Math.max(0, el.scrollLeft),
             scrollTop: Math.max(0, el.scrollTop),
         });
     }, [update]);

--- a/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
+++ b/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
@@ -6,7 +6,7 @@ import { StoryFnReactReturnType } from "@storybook/react/dist/client/preview/typ
 import { BuilderThemeWrapper } from "../stories/story-utils";
 import GridScroller from "./scrolling-data-grid";
 import { styled } from "../common/styles";
-import { GridCellKind, Rectangle } from "../data-grid/data-grid-types";
+import { GridCell, GridCellKind, Rectangle } from "../data-grid/data-grid-types";
 
 const InnerContainer = styled.div`
     width: 100%;
@@ -51,6 +51,18 @@ export function Simplenotest() {
         setTy(ty);
     }, []);
 
+    const columns = React.useMemo(() => ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map(t => ({
+        title: t,
+        width: 122 + (j += 50),
+    })), []);
+
+    const getCellContent = React.useCallback(([col, row]: readonly [number, number]): GridCell => ({
+        kind: GridCellKind.Text,
+        displayData: `${col},${row} Testing things that are way too long`,
+        data: `${col},${row} Testing things that are way too long`,
+        allowOverlay: true,
+    }), []);
+
     return (
         <GridScroller
             rows={10000}
@@ -62,19 +74,11 @@ export function Simplenotest() {
             allowResize={true}
             rowHeight={34}
             onVisibleRegionChanged={onVisibleRegionChanged}
-            columns={["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map(t => ({
-                title: t,
-                width: 122 + (j += 50),
-            }))}
-            getCellContent={([col, row]) => ({
-                kind: GridCellKind.Text,
-                displayData: `${col},${row} Testing things that are way too long`,
-                data: `${col},${row} Testing things that are way too long`,
-                allowOverlay: true,
-            })}
-            firstColSticky={false}
-            smoothScrollX={false}
-            smoothScrollY={false}
+            columns={columns}
+            getCellContent={getCellContent}
+            firstColSticky={true}
+            smoothScrollX={true}
+            smoothScrollY={true}
         />
     );
 }

--- a/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
+++ b/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
@@ -37,12 +37,10 @@ export default {
 };
 
 export function Simplenotest() {
-    let j = 0;
-
     const [x, setX] = React.useState<number>(0);
     const [y, setY] = React.useState<number>(0);
-    const [tx, setTx] = React.useState<number | undefined>(0);
-    const [ty, setTy] = React.useState<number | undefined>(0);
+    const [translateX, setTx] = React.useState<number | undefined>(0);
+    const [translateY, setTy] = React.useState<number | undefined>(0);
 
     const onVisibleRegionChanged = React.useCallback((range: Rectangle, tx?: number, ty?: number) => {
         setX(range.x);
@@ -51,10 +49,13 @@ export function Simplenotest() {
         setTy(ty);
     }, []);
 
-    const columns = React.useMemo(() => ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map(t => ({
-        title: t,
-        width: 122 + (j += 50),
-    })), []);
+    const columns = React.useMemo(() => {
+        let j = 0;
+        return ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map(t => ({
+            title: t,
+            width: 122 + (j += 50),
+        }));
+    }, []);
 
     const getCellContent = React.useCallback(([col, row]: readonly [number, number]): GridCell => ({
         kind: GridCellKind.Text,
@@ -68,8 +69,8 @@ export function Simplenotest() {
             rows={10000}
             cellXOffset={x}
             cellYOffset={y}
-            translateX={tx}
-            translateY={ty}
+            translateX={translateX}
+            translateY={translateY}
             headerHeight={44}
             allowResize={true}
             rowHeight={34}

--- a/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
+++ b/src/scrolling-data-grid/scrolling-data-grid-stories.tsx
@@ -41,10 +41,14 @@ export function Simplenotest() {
 
     const [x, setX] = React.useState<number>(0);
     const [y, setY] = React.useState<number>(0);
+    const [tx, setTx] = React.useState<number | undefined>(0);
+    const [ty, setTy] = React.useState<number | undefined>(0);
 
-    const onVisibleRegionChanged = React.useCallback((range: Rectangle) => {
+    const onVisibleRegionChanged = React.useCallback((range: Rectangle, tx?: number, ty?: number) => {
         setX(range.x);
         setY(range.y);
+        setTx(tx);
+        setTy(ty);
     }, []);
 
     return (
@@ -52,13 +56,15 @@ export function Simplenotest() {
             rows={10000}
             cellXOffset={x}
             cellYOffset={y}
+            translateX={tx}
+            translateY={ty}
             headerHeight={44}
             allowResize={true}
             rowHeight={34}
             onVisibleRegionChanged={onVisibleRegionChanged}
             columns={["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"].map(t => ({
                 title: t,
-                width: 122 + (j += 10),
+                width: 122 + (j += 50),
             }))}
             getCellContent={([col, row]) => ({
                 kind: GridCellKind.Text,
@@ -67,6 +73,8 @@ export function Simplenotest() {
                 allowOverlay: true,
             })}
             firstColSticky={false}
+            smoothScrollX={false}
+            smoothScrollY={false}
         />
     );
 }

--- a/src/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/src/scrolling-data-grid/scrolling-data-grid.tsx
@@ -53,7 +53,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             const stickyColWidth = firstColSticky ? columns[0].width : 0;
 
             for (const c of columns) {
-                let cx = x - stickyColWidth;
+                const cx = x - stickyColWidth;
                 if (args.scrollLeft >= cx + c.width) {
                     x += c.width;
                     cellX++;
@@ -142,7 +142,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 lastY.current = ty;
             }
         },
-        [columns, rowHeight, rows, onVisibleRegionChanged, firstColSticky]
+        [columns, rowHeight, rows, onVisibleRegionChanged, firstColSticky, smoothScrollX, smoothScrollY]
     );
 
     return (

--- a/src/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/src/scrolling-data-grid/scrolling-data-grid.tsx
@@ -10,18 +10,23 @@ interface Handled {
 }
 
 export interface ScrollingDataGridProps extends Subtract<DataGridDndProps, Handled> {
-    readonly onVisibleRegionChanged?: (range: Rectangle) => void;
+    readonly onVisibleRegionChanged?: (range: Rectangle, tx?: number, ty?: number) => void;
     readonly scrollToEnd?: boolean;
     readonly scrollRef?: React.MutableRefObject<HTMLDivElement | null>;
+    readonly smoothScrollX?: boolean;
+    readonly smoothScrollY?: boolean;
 }
 
 const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
     const { columns, rows, rowHeight, headerHeight, firstColSticky } = p;
     const { className, onVisibleRegionChanged, scrollToEnd, scrollRef, ...dateGridProps } = p;
+    const { smoothScrollX, smoothScrollY } = p;
 
     const [clientWidth, setClientWidth] = React.useState<number>(10);
     const [clientHeight, setClientHeight] = React.useState<number>(10);
     const last = React.useRef<Rectangle | undefined>();
+    const lastX = React.useRef<number | undefined>();
+    const lastY = React.useRef<number | undefined>();
 
     let width = 0;
     columns.forEach(c => (width += c.width));
@@ -41,17 +46,27 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             setClientWidth(args.clientWidth);
 
             let x = 0;
+            let tx = 0;
             let cellRight = 0;
             let cellX = 0;
 
             const stickyColWidth = firstColSticky ? columns[0].width : 0;
 
             for (const c of columns) {
-                if (args.scrollLeft > x - stickyColWidth) {
+                let cx = x - stickyColWidth;
+                if (args.scrollLeft >= cx + c.width) {
                     x += c.width;
                     cellX++;
                     cellRight++;
-                } else if (args.scrollLeft + args.clientWidth > x - stickyColWidth) {
+                } else if (args.scrollLeft > cx) {
+                    x += c.width;
+                    if (smoothScrollX) {
+                        tx += cx - args.scrollLeft;
+                    } else {
+                        cellX++;
+                    }
+                    cellRight++;
+                } else if (args.scrollLeft + args.clientWidth > cx) {
                     x += c.width;
                     cellRight++;
                 } else {
@@ -59,18 +74,35 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 }
             }
 
+            let ty = 0;
             let cellY = 0;
             let cellBottom = 0;
             if (typeof rowHeight === "number") {
-                cellY = Math.ceil(args.scrollTop / rowHeight);
+                if (smoothScrollY) {
+                    cellY = Math.floor(args.scrollTop / rowHeight);
+                    ty = (cellY * rowHeight) - args.scrollTop;
+                } else {
+                    cellY = Math.ceil(args.scrollTop / rowHeight);
+                }
                 cellBottom = Math.ceil(args.clientHeight / rowHeight) + cellY;
+                if (ty < 0)
+                    cellBottom++;
             } else {
                 let y = 0;
                 for (let row = 0; row < rows; row++) {
                     const rh = rowHeight(row);
-                    if (args.scrollTop > rh / 2 + y) {
+                    const cy = y + (smoothScrollY ? 0 : rh / 2);
+                    if (args.scrollTop >= y + rh) {
                         y += rh;
                         cellY++;
+                        cellBottom++;
+                    } else if (args.scrollTop > cy) {
+                        y += rh;
+                        if (smoothScrollY) {
+                            ty += cy - args.scrollTop;
+                        } else {
+                            cellY++;
+                        }
                         cellBottom++;
                     } else if (args.scrollTop + args.clientHeight > rh / 2 + y) {
                         y += rh;
@@ -95,15 +127,19 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 oldRect.y !== rect.y ||
                 oldRect.x !== rect.x ||
                 oldRect.height !== rect.height ||
-                oldRect.width !== rect.width
+                oldRect.width !== rect.width ||
+                lastX.current !== tx ||
+                lastY.current !== ty
             ) {
                 onVisibleRegionChanged?.({
                     x: cellX,
                     y: cellY,
                     width: cellRight - cellX,
                     height: cellBottom - cellY,
-                });
+                }, tx, ty);
                 last.current = rect;
+                lastX.current = tx;
+                lastY.current = ty;
             }
         },
         [columns, rowHeight, rows, onVisibleRegionChanged, firstColSticky]


### PR DESCRIPTION
Set `smoothScrollX` or `smoothScrollY` to `true` on `DataEditor` to have smooth scrolling on the respective axis(es).

Under the hood this has the following effects:

- Setting `smoothScrollX` or `smoothScrollY` to `true` on `GridScroller`, which causes
       `onVisibleRegionChanged` to fire with more granularity, passing
       `tx` and/or `ty` arguments as appropriate.

- Those are passed into `translateX` and `translateY` props on the data grid
       to specify a pixel translation on top of the cellXOffset/cellYOffset


If you don't do the above, it should work exactly as before, with the minor difference that `scrollLeft` is now clamped to be >= 0 in `ScrollRegion` update callback.