### PR TITLE
[FEATURE] Row selection state can now be managed externally

### DIFF
--- a/src/data-editor/data-editor-stories.tsx
+++ b/src/data-editor/data-editor-stories.tsx
@@ -5,7 +5,14 @@ import { StoryFn, StoryContext } from "@storybook/addons";
 import { StoryFnReactReturnType } from "@storybook/react/dist/client/preview/types";
 import { BuilderThemeWrapper } from "../stories/story-utils";
 // import { styled } from "../common/styles";
-import { GridCell, GridCellKind, GridColumn, GridSelection, Rectangle } from "../data-grid/data-grid-types";
+import {
+    GridCell,
+    GridCellKind,
+    GridColumn,
+    GridSelection,
+    Rectangle,
+    RowSelection,
+} from "../data-grid/data-grid-types";
 import DataEditor from "./data-editor";
 import DataEditorContainer from "../data-editor-container/data-grid-container";
 
@@ -298,6 +305,34 @@ export function IdealSize() {
             showTrailingBlankRow={false}
             rowMarkers={false}
             rows={9}
+        />
+    );
+}
+
+export function RowSelectionStateLivesOutside() {
+    const cols: GridColumn[] = [
+        { title: "Number", width: 250 },
+        { title: "Square", width: 250 },
+    ];
+
+    const [selected_rows, setSelectedRows] = React.useState<RowSelection>([]);
+    const cb = (newRows: RowSelection | undefined) => {
+        if (newRows != undefined) {
+            setSelectedRows(newRows);
+        }
+    };
+
+    return (
+        <DataEditor
+            selectedRows={selected_rows}
+            onSelectedRowsChange={cb}
+            isDraggable={true}
+            onDragStart={args => {
+                args.setData("text", "testing");
+            }}
+            getCellContent={getData}
+            columns={columns}
+            rows={1000}
         />
     );
 }

--- a/src/data-grid/data-grid-types.ts
+++ b/src/data-grid/data-grid-types.ts
@@ -6,6 +6,8 @@ export interface GridSelection {
     readonly range: Readonly<Rectangle>;
 }
 
+export type RowSelection = readonly number[];
+
 export type GridMouseEventArgs = GridMouseCellEventArgs | GridMouseHeaderEventArgs | GridMouseOutOfBoundsEventArgs;
 
 interface BaseGridMouseEventArgs {


### PR DESCRIPTION
### Checklist

-   [x] PR title is human readable is postfixed with [FIX] | [FEATURE] | [INTERNAL] | [TRIVIAL]. [PR Naming](https://www.notion.so/glideapps/Github-PR-Format-25201c2506e54d298da66de253c63d42).
-   [x] Include any relevant links (ex. Github issues, Intercom conversations, or community forum posts)
-   [x] PR is not targeted to prod or make sure release notes are generated after merging. [Generating Release Notes](https://www.notion.so/glideapps/Release-Notes-7429b85b7ab74db6849f50329f9efac0).
-   [x] Not unit testable or is unit testable and you have added test(s)
-   [x] No new data stored or if new data is being stored, add an additional engineer to help review for GDPR compliance
-   [x] No new services or packages or if new services or packages, add an additional engineer to help review for GDPR compliance

### Links

 - https://github.com/quicktype/glide/issues/8789

### Changes
<DataEditor> can now take two additional props: selectedRows: number[], and setSelectedRows ()=> number[].

-   Fixes #
https://github.com/quicktype/glide/issues/8789