### PR TITLE
Make default rowMarkerWidth 36 instead of 50

### DIFF
--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -116,7 +116,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
 
     const rowHeight = p.rowHeight ?? 34;
     const headerHeight = p.headerHeight ?? 36;
-    const rowMarkerWidth = p.rowMarkerWidth ?? 50;
+    const rowMarkerWidth = p.rowMarkerWidth ?? 36;
 
     const { isDraggable, getCellsForSelection } = p;
 


### PR DESCRIPTION
This tightens up the default spacing around rowMarker column:
<img width="517" alt="Screen Shot 2021-03-26 at 5 08 33 PM" src="https://user-images.githubusercontent.com/417203/112692802-e75e1880-8e55-11eb-8f90-567d15ccbf34.png">
