### PR TITLE
Allow a maximum column width to be specified

### DIFF
--- a/API.md
+++ b/API.md
@@ -195,6 +195,13 @@ onDragStart?: (args: GridDragEventArgs) => void;
 
 If `isDraggable` is set, the whole Grid is draggable, and `onDragStart` will be called when dragging starts. You can use this to build a UI where the user can drag the Grid around.
 
+```
+maxColumnWidth?: number;
+```
+
+If `maxColumnWidth` is set with a value greater than 50, then columns will have a maximum size of that many pixels.
+If the value is less than 50, it will be increased to 50.  If it isn't set, the default value will be 500.
+
 ## Types
 
 ### Cell coordinates

--- a/src/data-grid-dnd/data-grid-dnd.tsx
+++ b/src/data-grid-dnd/data-grid-dnd.tsx
@@ -17,6 +17,7 @@ export interface DataGridDndProps extends Subtract<DataGridProps, Handled> {
     readonly onColumnMoved?: (startIndex: number, endIndex: number) => void;
     readonly onColumnResized?: (column: GridColumn, newSize: number) => void;
     readonly gridRef?: React.Ref<DataGridRef>;
+    readonly maxColumnWidth?: number;
 }
 
 const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
@@ -35,6 +36,7 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
         columns,
         onColumnResized,
         gridRef,
+        maxColumnWidth,
     } = p;
 
     const onItemHoveredImpl = React.useCallback(
@@ -96,14 +98,16 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
         };
     }, [dragCol, dropCol]);
 
+    const maxColumnWidthValue = maxColumnWidth === undefined ? 500 : (maxColumnWidth < 50 ? 50 : maxColumnWidth);
+
     const onMouseMove = React.useCallback(
         (event: MouseEvent) => {
             if (resizeCol === undefined || resizeColStartX === undefined) return;
             const column = columns[resizeCol];
-            const newWidth = clamp(event.clientX - resizeColStartX, 50, 500);
+            const newWidth = clamp(event.clientX - resizeColStartX, 50, maxColumnWidthValue);
             onColumnResized?.(column, newWidth);
         },
-        [resizeCol, resizeColStartX, columns, onColumnResized]
+        [resizeCol, resizeColStartX, columns, onColumnResized, maxColumnWidthValue]
     );
 
     return (


### PR DESCRIPTION
Previously, the column size would hit a hard cap at 500 pixels.  We would like to have columns that are wider than this, so I've made it a prop.