### PR TITLE
Allow usage of `onItemHovered`

### DIFF
--- a/API.md
+++ b/API.md
@@ -138,6 +138,12 @@ onDeleteRows?: (rows: readonly number[]) => void;
 
 `onDeleteRows` is called when the user deletes one or more rows. `rows` is an array with the absolute indexes of the deletes rows. Note that it is on you to actually effect the deletion of those rows.
 
+```ts
+onItemHovered?: (args: GridMouseEventArgs) => void;
+```
+
+`onItemHovered` is called when the user hovers over a cell, a header, or outside the grid.
+
 ```
 showTrailingBlankRow?: boolean;
 onRowAppended?: (cell: readonly [number, number], newValue: EditableGridCell) => void;
@@ -303,5 +309,35 @@ export enum GridCellKind {
     Loading = "loading",
     Markdown = "markdown",
     Protected = "protected",
+}
+```
+
+### GridMouseEventArgs
+
+```ts
+export type GridMouseEventArgs = GridMouseCellEventArgs | GridMouseHeaderEventArgs | GridMouseOutOfBoundsEventArgs;
+
+interface BaseGridMouseEventArgs {
+    shiftKey: boolean;
+}
+
+interface GridMouseCellEventArgs extends BaseGridMouseEventArgs {
+    readonly kind: "cell";
+    readonly location: readonly [number, number];
+    readonly bounds: Rectangle;
+    readonly isEdge: boolean;
+}
+
+interface GridMouseHeaderEventArgs extends BaseGridMouseEventArgs {
+    readonly kind: "header";
+    readonly location: readonly [number, undefined];
+    readonly bounds: Rectangle;
+    readonly isEdge: boolean;
+}
+
+interface GridMouseOutOfBoundsEventArgs extends BaseGridMouseEventArgs {
+    readonly kind: "out-of-bounds";
+    readonly location: readonly [number, number];
+    readonly direction: readonly [-1 | 0 | 1, -1 | 0 | 1];
 }
 ```

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -40,7 +40,6 @@ interface Handled {
     readonly selectedColumns?: readonly number[];
     readonly selectedCell?: GridSelection;
 
-    readonly onItemHovered?: (args: GridMouseEventArgs) => void;
     readonly onMouseDown?: (args: GridMouseEventArgs) => void;
     readonly onMouseUp?: (args: GridMouseEventArgs) => void;
 
@@ -137,6 +136,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
         onDeleteRows,
         onDragStart,
         onHeaderMenuClick,
+        onItemHovered,
         onVisibleRegionChanged,
         selectedColumns: selectedColumnsOuter,
         onSelectedColumnsChange: setSelectedColumnsOuter,
@@ -407,7 +407,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
         [onDragStart, rowMarkerOffset]
     );
 
-    const onItemHovered = React.useCallback(
+    const onItemHoveredImpl = React.useCallback(
         (args: GridMouseEventArgs) => {
             if (args.kind === "cell") {
                 setHoveredCell(args.location);
@@ -465,8 +465,10 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
                     }
                 }
             }
+
+            onItemHovered?.(args);
         },
-        [gridSelection, isDraggable, rowMarkers, setGridSelection, columns, rowHeight]
+        [onItemHovered, gridSelection, isDraggable, rowMarkers, setGridSelection, columns, rowHeight]
     );
 
     const copyToClipboard = React.useCallback((cells: readonly (readonly GridCell[])[]) => {
@@ -928,7 +930,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
                 onDragStart={onDragStartImpl}
                 onCellFocused={onCellFocused}
                 onHeaderMenuClick={onHeaderMenuClickInner}
-                onItemHovered={onItemHovered}
+                onItemHovered={onItemHoveredImpl}
                 onKeyDown={onKeyDown}
                 onMouseDown={onMouseDown}
                 onMouseUp={onMouseUp}


### PR DESCRIPTION
My team wanted to display a menu over specific cells on hover, which I discovered could be implemented pretty easily if your existing `onItemHovered` event was exposed. Hopefully I did the docs right, and thanks!