### PR TITLE
Fix number editor in Data Editor is black on dark in Dark Mode [INTERNAL]

### DIFF
--- a/src/data-grid-overlay-editor/private/number-overlay-editor-style.tsx
+++ b/src/data-grid-overlay-editor/private/number-overlay-editor-style.tsx
@@ -2,4 +2,5 @@ import { styled } from "../../common/styles";
 
 export const NumberOverlayEditorStyle = styled.div`
     display: flex;
+    color: ${p => p.theme.fgColorDark};
 `;


### PR DESCRIPTION
fix #9805 for https://github.com/quicktype/glide/issues/9805
Img of bug: 
<img width="352" alt="Screen Shot 2021-06-17 at 1 18 13 PM" src="https://user-images.githubusercontent.com/11837954/122478983-3b712880-cf7f-11eb-97db-9219686f225d.png">
With Fix:
<img width="167" alt="Screen Shot 2021-06-17 at 3 21 30 PM" src="https://user-images.githubusercontent.com/11837954/122479311-b63a4380-cf7f-11eb-89f6-00411c21b4e9.png">
