### PR TITLE
Fix crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "2.1.15",
+    "version": "2.1.16",
     "description": "Super fast, pure canvas Data Grid Editor",
     "main": "dist/js/index.js",
     "types": "dist/ts/index.d.ts",

--- a/src/data-editor/data-editor-stories.tsx
+++ b/src/data-editor/data-editor-stories.tsx
@@ -410,9 +410,9 @@ export function ColSelectionStateLivesOutside() {
     );
 }
 
-export function GridSelectionOutOfRange() {
+export function GridSelectionOutOfRangeNoColumns() {
     const dummyCols = useMemo(
-        () => getDummyCols().map(v => ({ ...v, width: 300, title: "Make me smaller to crash!" })),
+        () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
         []
     );
 
@@ -440,6 +440,42 @@ export function GridSelectionOutOfRange() {
                     setCols(dummyCols);
                 } else {
                     setCols([]);
+                }
+            }}
+        />
+    );
+}
+
+export function GridSelectionOutOfRangeLessColumnsThanSelection() {
+    const dummyCols = useMemo(
+        () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
+        []
+    );
+
+    const [selected, setSelected] = useState<GridSelection | undefined>({
+        cell: [2, 8],
+        range: { width: 1, height: 1, x: 2, y: 8 },
+    });
+
+    const [cols, setCols] = useState(dummyCols);
+
+    const onSelected = useCallback((newSel?: GridSelection) => {
+        setSelected(newSel);
+    }, []);
+
+    return (
+        <DataEditor
+            getCellContent={getDummyData}
+            columns={cols}
+            rows={1000}
+            allowResize={true}
+            onGridSelectionChange={onSelected}
+            gridSelection={selected}
+            onColumnResized={(_col, newSize) => {
+                if (newSize > 300) {
+                    setCols(dummyCols);
+                } else {
+                    setCols([dummyCols[0]]);
                 }
             }}
         />

--- a/src/data-editor/data-editor-stories.tsx
+++ b/src/data-editor/data-editor-stories.tsx
@@ -420,3 +420,15 @@ export function ColSelectionStateLivesOutside() {
         />
     );
 }
+
+export function GridSelectionOutOfRange() {
+    return (
+        <DataEditor
+            getCellContent={getDummyData}
+            columns={[]}
+            rows={1000}
+            allowResize={true}
+            gridSelection={{ cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 } }}
+        />
+    );
+}

--- a/src/data-editor/data-editor-stories.tsx
+++ b/src/data-editor/data-editor-stories.tsx
@@ -18,17 +18,6 @@ import AutoSizer from "react-virtualized-auto-sizer";
 import DataEditor from "./data-editor";
 import DataEditorContainer from "../data-editor-container/data-grid-container";
 
-// const InnerContainer = styled.div`
-//     width: 100%;
-//     height: 100px;
-
-//     > :first-child {
-//         position: absolute;
-//         width: 100%;
-//         height: 100%;
-//     }
-// `;
-
 export default {
     title: "Designer/DateViewer/DataEditor",
 
@@ -422,13 +411,16 @@ export function ColSelectionStateLivesOutside() {
 }
 
 export function GridSelectionOutOfRange() {
+    const [cols, setCols] = useState([{ width: 300, title: "Resize me and I should not crash" }]);
+
     return (
         <DataEditor
             getCellContent={getDummyData}
-            columns={[]}
+            columns={cols}
             rows={1000}
             allowResize={true}
             gridSelection={{ cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 } }}
+            onColumnResized={() => setCols([])}
         />
     );
 }

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -179,6 +179,9 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
     );
 
     const mangledCols = React.useMemo(() => {
+        // Clear the grid selection to handle the case where changing columns
+        // can highlight new unexpected selections
+        setGridSelection(undefined);
         if (!rowMarkers) return columns;
         return [
             {
@@ -190,7 +193,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
             },
             ...columns,
         ];
-    }, [columns, rowMarkerWidth, rowMarkers]);
+    }, [columns, rowMarkerWidth, rowMarkers, setGridSelection]);
 
     const getMangedCellContent = React.useCallback(
         ([col, row]: readonly [number, number]): GridCell => {

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -179,9 +179,6 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
     );
 
     const mangledCols = React.useMemo(() => {
-        // Clear the grid selection to handle the case where changing columns
-        // can highlight new unexpected selections
-        setGridSelection(undefined);
         if (!rowMarkers) return columns;
         return [
             {
@@ -193,7 +190,7 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
             },
             ...columns,
         ];
-    }, [columns, rowMarkerWidth, rowMarkers, setGridSelection]);
+    }, [columns, rowMarkerWidth, rowMarkers]);
 
     const getMangedCellContent = React.useCallback(
         ([col, row]: readonly [number, number]): GridCell => {

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -905,6 +905,11 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
     React.useEffect(() => {
         if (gridSelection === undefined) return;
         const [col, row] = gridSelection.cell;
+
+        // Check that the grid selection is in range before updating the selected cell
+        const selectionColInRange = mangledCols[col];
+        if (selectionColInRange === undefined) return;
+
         updateSelectedCell(col, row);
     }, [mangledCols, rows, gridSelection, updateSelectedCell]);
 


### PR DESCRIPTION
- Fix crash for undefined index when columns change
~~Clear grid selection when columns change~~ Not a good way to do this currently since columns are maintained by the client of the lib