### PR TITLE
Improve newline behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "description": "Super fast, pure canvas Data Grid Editor",
     "main": "dist/js/index.js",
     "types": "dist/ts/index.d.ts",

--- a/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -80,8 +80,26 @@ const DataGridOverlayEditor: React.FunctionComponent<Props> = p => {
         (event: React.KeyboardEvent) => {
             if (event.key === "Escape") {
                 onFinishEditing(undefined, [0, 0]);
-            } else if (event.key === "Enter" && !event.ctrlKey) {
+            } else if (event.key === "Enter") {
                 onFinishEditing(tempValue, [0, event.shiftKey ? -1 : 1]);
+                event.stopPropagation();
+                event.preventDefault();
+            } else if (event.key === "Tab") {
+                onFinishEditing(tempValue, [event.shiftKey ? -1 : 1, 0]);
+                event.stopPropagation();
+                event.preventDefault();
+            }
+        },
+        [onFinishEditing, tempValue]
+    );
+
+    // The only difference is that `shift + enter` enters a newline
+    const onKeyDownMultiline = React.useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === "Escape") {
+                onFinishEditing(undefined, [0, 0]);
+            } else if (event.key === "Enter" && !event.shiftKey) {
+                onFinishEditing(tempValue, [0, 1]);
                 event.stopPropagation();
                 event.preventDefault();
             } else if (event.key === "Tab") {
@@ -102,8 +120,7 @@ const DataGridOverlayEditor: React.FunctionComponent<Props> = p => {
             editor = (
                 <GrowingEntry
                     autoFocus={true}
-                    allowCtrlEnter={true}
-                    onKeyDown={onKeyDown}
+                    onKeyDown={onKeyDownMultiline}
                     value={targetValue.data}
                     onChange={onStringValueChange}
                 />
@@ -148,7 +165,7 @@ const DataGridOverlayEditor: React.FunctionComponent<Props> = p => {
                 <MarkdownOverlayEditor
                     targetRect={target}
                     markdown={targetValue.data}
-                    onKeyDown={onKeyDown}
+                    onKeyDown={onKeyDownMultiline}
                     onChange={onStringValueChange}
                     forceEditMode={forceEditMode}
                     createNode={markdownDivCreateNode}
@@ -161,8 +178,10 @@ const DataGridOverlayEditor: React.FunctionComponent<Props> = p => {
         ev.stopPropagation();
     };
 
+    // Consider imperatively creating and adding the element to the dom?
     const portalElement = document.getElementById("portal");
     if (portalElement === null) {
+        // eslint-disable-next-line no-console
         console.error(
             'Cannot open Data Grid overlay editor, because portal not found.  Please add `<div id="portal" />` as the last child of your `<body>`.'
         );

--- a/src/growing-entry/growing-entry.tsx
+++ b/src/growing-entry/growing-entry.tsx
@@ -7,11 +7,10 @@ import { assert } from "../common/support";
 interface Props
     extends React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> {
     readonly placeholder?: string;
-    readonly allowCtrlEnter?: boolean;
 }
 
 const GrowingEntryImpl: React.FunctionComponent<Props> = (props: Props) => {
-    const { placeholder, value, ref, onKeyDown, allowCtrlEnter, ...rest } = props;
+    const { placeholder, value, onKeyDown, ...rest } = props;
     const { onChange, className } = rest;
 
     const inputRef = React.useRef<HTMLTextAreaElement | null>(null);
@@ -30,30 +29,13 @@ const GrowingEntryImpl: React.FunctionComponent<Props> = (props: Props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const onKeyDownImpl = React.useCallback(
-        (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-            if (event.ctrlKey && event.key === "Enter" && allowCtrlEnter === true && inputRef.current !== null) {
-                const newValue = inputRef.current.value + `\n`;
-                const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-                    window.HTMLTextAreaElement.prototype,
-                    "value"
-                )?.set;
-                nativeInputValueSetter?.call(inputRef.current, newValue);
-
-                inputRef.current.dispatchEvent(new Event("change", { bubbles: true }));
-            }
-            onKeyDown?.(event);
-        },
-        [onKeyDown, allowCtrlEnter]
-    );
-
     return (
         <GrowingEntryStyle>
             <ShadowBox className={className}>{useText + "\n"}</ShadowBox>
             <InputBox
                 {...rest}
                 ref={inputRef}
-                onKeyDown={onKeyDownImpl}
+                onKeyDown={onKeyDown}
                 value={useText}
                 placeholder={placeholder}
                 dir="auto"


### PR DESCRIPTION
Currently, there's _some_ support for `ctrl+enter` in text inputs, where it'll add a newline at the end and move the cursor there. That is some pretty frustrating UX. Also, by default `ctrl+enter` alone does nothing.

This PR drops support for `ctrl+enter` in favor of `shift+enter`, and adds multiline support in Markdown inputs. `shift+enter` is a well known default to introduce newlines without submits, and has better support out of the box (i.e, the browser just does the newline in place)

A con of this is that we used to do `shift+enter` to "submit and go up". Now there's no shortcut for that in multiline inputs. We _can_ use ctrl+enter for that. That would have to change in all input types for consistency.