### PR TITLE
Update selection after editing trailing row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "2.2.5",
+    "version": "2.2.6",
     "description": "Super fast, pure canvas Data Grid Editor",
     "main": "dist/js/index.js",
     "types": "dist/ts/index.d.ts",

--- a/src/data-editor/data-editor.stories.tsx
+++ b/src/data-editor/data-editor.stories.tsx
@@ -476,6 +476,57 @@ export function GridSelectionOutOfRangeLessColumnsThanSelection() {
     );
 }
 
+export function GridAddNewRows() {
+    const cols = useMemo(getDummyCols, []);
+
+    const [rowsCount, setRowsCount] = useState(10);
+
+    const onRowAppended = useCallback(() => {
+        setRowsCount(r => r + 1);
+    }, []);
+
+    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
+
+    const onSelected = useCallback((newSel?: GridSelection) => {
+        setSelected(newSel);
+    }, []);
+
+    return (
+        <DataEditor
+            getCellContent={getDummyData}
+            columns={cols}
+            rows={rowsCount}
+            allowResize={true}
+            onRowAppended={onRowAppended}
+            onGridSelectionChange={onSelected}
+            gridSelection={selected}
+            showTrailingBlankRow={true}
+        />
+    );
+}
+
+export function GridNoTrailingBlankRow() {
+    const cols = useMemo(getDummyCols, []);
+
+    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
+
+    const onSelected = useCallback((newSel?: GridSelection) => {
+        setSelected(newSel);
+    }, []);
+
+    return (
+        <DataEditor
+            getCellContent={getDummyData}
+            columns={cols}
+            rows={100}
+            allowResize={true}
+            showTrailingBlankRow={false}
+            onGridSelectionChange={onSelected}
+            gridSelection={selected}
+        />
+    );
+}
+
 export function MarkdownEdits() {
     const dummyCols: GridColumn[] = useMemo(() => {
         return [

--- a/src/data-editor/data-editor.tsx
+++ b/src/data-editor/data-editor.tsx
@@ -570,9 +570,11 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
     );
 
     const updateSelectedCell = React.useCallback(
-        (col: number, row: number): boolean => {
+        (col: number, row: number, fromEditingTrailingRow: boolean = false): boolean => {
+            const rowMax = mangledRows - (fromEditingTrailingRow ? 0 : 1);
             col = clamp(rowMarkerOffset, columns.length, col);
-            row = clamp(0, mangledRows - 1, row);
+            row = clamp(0, rowMax, row);
+
             if (col === gridSelection?.cell[0] && row === gridSelection?.cell[1]) return false;
             setGridSelection({ cell: [col, row], range: { x: col, y: row, width: 1, height: 1 } });
 
@@ -638,9 +640,9 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
             return true;
         },
         [
+            mangledRows,
             rowMarkerOffset,
             columns,
-            mangledRows,
             gridSelection?.cell,
             setGridSelection,
             rowMarkers,
@@ -667,10 +669,11 @@ const DataEditor: React.FunctionComponent<DataEditorProps> = p => {
 
             const [movX, movY] = movement;
             if (gridSelection !== undefined && (movX !== 0 || movY !== 0)) {
-                updateSelectedCell(gridSelection.cell[0] + movX, gridSelection.cell[1] + movY);
+                const isEditingTrailingRow = gridSelection.cell[1] === mangledRows - 1 && newValue !== undefined;
+                updateSelectedCell(gridSelection.cell[0] + movX, gridSelection.cell[1] + movY, isEditingTrailingRow);
             }
         },
-        [gridSelection, focus, mangledOnCellEdited, rowMarkerOffset, updateSelectedCell]
+        [gridSelection, focus, mangledOnCellEdited, rowMarkerOffset, mangledRows, updateSelectedCell]
     );
 
     const onCellFocused = React.useCallback(


### PR DESCRIPTION
Fixes a papercut in glide's repo https://github.com/quicktype/glide/issues/10796

When pressing Enter after editing a cell in the trailing row, move the selection down.
