### PR TITLE
Fix UI bug when trying to resize last column

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "2.2.9",
+    "version": "2.2.10",
     "description": "Super fast, pure canvas Data Grid Editor",
     "main": "dist/js/index.js",
     "types": "dist/ts/index.d.ts",

--- a/src/data-editor/data-editor.stories.tsx
+++ b/src/data-editor/data-editor.stories.tsx
@@ -498,6 +498,60 @@ export function GridSelectionOutOfRangeNoColumns() {
     );
 }
 
+type ResizableColumnsSizeMap = Record<string, number>;
+
+function getResizableColumnsInitSize(): ResizableColumnsSizeMap {
+    return {
+        "resize me 0": 120,
+        "resize me 1": 120,
+        "resize me 2": 120,
+        "resize me 3": 120,
+        "resize me 4": 120,
+        "resize me 5": 120,
+        "resize me 6": 120,
+        "resize me 7": 120,
+    };
+}
+
+function getResizableColumns(sizeMap: ResizableColumnsSizeMap): GridColumn[] {
+    return Object.entries(sizeMap).map(([title, width]) => ({
+        title,
+        width,
+        icon: "headerString",
+        hasMenu: true,
+    }));
+}
+
+export function ResizableColumns() {
+    const [colSizes, setColSizes] = useState(getResizableColumnsInitSize);
+
+    const cols = useMemo(() => {
+        return getResizableColumns(colSizes);
+    }, [colSizes]);
+
+    const onColumnResized = useCallback((column: GridColumn, newSize: number) => {
+        setColSizes(prevColSizes => {
+            return {
+                ...prevColSizes,
+                [column.title]: newSize,
+            };
+        });
+    }, []);
+
+    return (
+        <DataEditor
+            getCellContent={getDummyData}
+            columns={cols}
+            rows={20}
+            isDraggable={false}
+            smoothScrollX={true}
+            smoothScrollY={true}
+            allowResize={true}
+            onColumnResized={onColumnResized}
+        />
+    );
+}
+
 export function GridSelectionOutOfRangeLessColumnsThanSelection() {
     const dummyCols = useMemo(
         () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),

--- a/src/data-grid/data-grid.tsx
+++ b/src/data-grid/data-grid.tsx
@@ -1024,9 +1024,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, Props> = (p, forward
                 setHoveredItem(args.kind === "out-of-bounds" ? undefined : args.location);
                 hoveredRef.current = args;
             }
-            if (args.kind !== "out-of-bounds") {
-                setHoveredOnEdge(args.isEdge && allowResize === true);
-            }
+
+            setHoveredOnEdge(args.kind !== "out-of-bounds" && args.isEdge && allowResize === true);
 
             onMouseMove?.(ev);
         },


### PR DESCRIPTION
Closes a papercut in the main Glide repo https://github.com/quicktype/glide/issues/10098

It looked like column resizes were buggy, but it was actually a UI bug.