### PR TITLE
Don't hastily pre-reserve image space in drilldown [FIX]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "2.2.13",
+    "version": "2.2.14",
     "description": "Super fast, pure canvas Data Grid Editor",
     "main": "dist/js/index.js",
     "types": "dist/ts/index.d.ts",

--- a/src/data-grid/data-grid-lib.ts
+++ b/src/data-grid/data-grid-lib.ts
@@ -383,8 +383,7 @@ export function drawDrilldownCell(
     for (const el of data) {
         if (renderX > x + width) break;
         const textWidth = measureTextWidth(el.text, ctx);
-        const imgWidth = el.img === undefined ? 0 : bubbleHeight - 8 + 4;
-        const renderWidth = textWidth + imgWidth + bubblePad * 2;
+        const renderWidth = textWidth + bubblePad * 2;
         renderBoxes.push({
             x: renderX,
             width: renderWidth,
@@ -394,9 +393,6 @@ export function drawDrilldownCell(
     }
 
     ctx.beginPath();
-    renderBoxes.forEach(rectInfo => {
-        roundedRect(ctx, rectInfo.x, y + (height - bubbleHeight) / 2, rectInfo.width, bubbleHeight, 6);
-    });
 
     ctx.shadowColor = "rgba(24, 25, 34, 0.4)";
     ctx.shadowBlur = 1;
@@ -416,6 +412,7 @@ export function drawDrilldownCell(
     renderBoxes.forEach((rectInfo, i) => {
         const d = data[i];
         let drawX = rectInfo.x + bubblePad;
+        let drawWidth = rectInfo.width;
 
         if (d.img !== undefined) {
             const img = imageLoader.loadOrGetImage(d.img, col, row);
@@ -448,9 +445,11 @@ export function drawDrilldownCell(
                 );
 
                 drawX += imgSize + 4;
+                drawWidth += imgSize + 4;
             }
         }
 
+        roundedRect(ctx, rectInfo.x, y + (height - bubbleHeight) / 2, drawWidth, bubbleHeight, 6);
         ctx.beginPath();
         ctx.fillStyle = theme.fgColorDark;
         ctx.fillText(d.text, drawX, y + height / 2 + 4);


### PR DESCRIPTION
Fixes an edge case where a bad URL is passed into the DrillDown cell type. The bubbles would reserve space for the image before it actually loaded, which would leave an ugly space to the right of the text if the image didn't load.

Annoyingly, I don't know if this works, because I have no idea how to test this.

For quicktype/glide#11158, fixes when data grid is updated in that repo.