### PR TITLE
Allocate image space only after image loads [FIX]

### DIFF
--- a/src/data-grid/data-grid-lib.ts
+++ b/src/data-grid/data-grid-lib.ts
@@ -451,7 +451,13 @@ export function drawDrilldownCell(
     for (const el of data) {
         if (renderX > x + width) break;
         const textWidth = measureTextWidth(el.text, ctx);
-        const imgWidth = el.img === undefined ? 0 : bubbleHeight - 8 + 4;
+        let imgWidth = 0;
+        if (el.img !== undefined) {
+            const img = imageLoader.loadOrGetImage(el.img, col, row);
+            if (img !== undefined) {
+                imgWidth = bubbleHeight - 8 + 4;
+            }
+        }
         const renderWidth = textWidth + imgWidth + bubblePad * 2;
         renderBoxes.push({
             x: renderX,


### PR DESCRIPTION
Previously, the space was allocated so long as the image was specified, and in the event that an image failed to load or specified an invalid URL, would leave an empty space to the right of the text.  This fixes that issue.