### PR TITLE
Rescale to 1x when scrolling in firefox to boost performance on large canvases

### DIFF
--- a/core/src/common/browser-detect.ts
+++ b/core/src/common/browser-detect.ts
@@ -16,6 +16,7 @@ function lazy<T>(fn: () => T) {
     return new Lazy(fn);
 }
 
+export const browserIsFirefox = userAgent.includes("Firefox");
 export const browserIsSafari =
     userAgent.indexOf("Mac OS") > -1 && userAgent.indexOf("Safari") > -1 && userAgent.indexOf("Chrome") < 0;
 

--- a/core/src/data-grid/data-grid-types.ts
+++ b/core/src/data-grid/data-grid-types.ts
@@ -470,7 +470,8 @@ export class CompactSelection {
     };
 
     hasIndex = (index: number): boolean => {
-        for (const [start, end] of this.items) {
+        for (let i = 0; i < this.items.length; i++) {
+            const [start, end] = this.items[i];
             if (index >= start && index < end) return true;
         }
         return false;

--- a/core/src/data-grid/data-grid.tsx
+++ b/core/src/data-grid/data-grid.tsx
@@ -190,10 +190,12 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, Props> = (p, forward
     const scrollingStopRef = React.useRef(-1);
     React.useEffect(() => {
         if (!browserIsFirefox || window.devicePixelRatio === 1) return;
-        setScrolling(true);
+        // We don't want to go into scroll mode for a single repaint
+        if (scrollingStopRef.current !== -1) {
+            setScrolling(true);
+        }
         window.clearTimeout(scrollingStopRef.current);
         scrollingStopRef.current = window.setTimeout(() => {
-            console.log("Unset");
             setScrolling(false);
             scrollingStopRef.current = -1;
         }, 200);
@@ -490,7 +492,6 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, Props> = (p, forward
         selectedColumns,
         selectedCell,
         dragAndDropState,
-        hoveredCol,
         prelightCells,
         scrolling,
     ]);

--- a/core/src/data-grid/data-grid.tsx
+++ b/core/src/data-grid/data-grid.tsx
@@ -100,6 +100,7 @@ export interface DataGridProps {
     readonly experimental?: {
         readonly paddingRight?: number;
         readonly paddingBottom?: number;
+        readonly disableFirefoxRescaling?: boolean;
     };
 
     readonly headerIcons?: SpriteMap;
@@ -188,8 +189,9 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, Props> = (p, forward
     const spriteManager = React.useMemo(() => new SpriteManager(headerIcons), [headerIcons]);
 
     const scrollingStopRef = React.useRef(-1);
+    const disableFirefoxRescaling = p.experimental?.disableFirefoxRescaling === true;
     React.useEffect(() => {
-        if (!browserIsFirefox || window.devicePixelRatio === 1) return;
+        if (!browserIsFirefox || window.devicePixelRatio === 1 || disableFirefoxRescaling) return;
         // We don't want to go into scroll mode for a single repaint
         if (scrollingStopRef.current !== -1) {
             setScrolling(true);
@@ -199,7 +201,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, Props> = (p, forward
             setScrolling(false);
             scrollingStopRef.current = -1;
         }, 200);
-    }, [cellYOffset, cellXOffset, translateX, translateY]);
+    }, [cellYOffset, cellXOffset, translateX, translateY, disableFirefoxRescaling]);
 
     React.useEffect(() => {
         const fn = async () => {


### PR DESCRIPTION
- Start implementation of firefox fast scroll
- Dont disable blit for hovered cols as they damage correctly now
- add option to disalbe rescaling on firefox
