### PR TITLE
Fix text edit in firefox

### DIFF
--- a/core/src/data-grid-overlay-editor/data-grid-overlay-editor-style.tsx
+++ b/core/src/data-grid-overlay-editor/data-grid-overlay-editor-style.tsx
@@ -53,6 +53,8 @@ export const DataGridOverlayEditorStyle = styled.div<Props>`
         overflow-y: auto;
         overflow-x: hidden;
         border-radius: 2px;
+        overflow: hidden;
+
         input {
             width: 100%;
 

--- a/core/src/growing-entry/growing-entry-style.tsx
+++ b/core/src/growing-entry/growing-entry-style.tsx
@@ -16,11 +16,13 @@ export const InputBox = styled.textarea`
     right: 0;
     top: 0;
     bottom: 0;
+    width: 100%;
+    height: 100%;
 
     border-radius: 0px;
 
     resize: none;
-    white-space: normal;
+    white-space: pre-wrap;
     min-width: 100%;
     overflow: hidden;
     border: 0;


### PR DESCRIPTION
Text input in firefox was broken in a few ways:
- We had a scrollbar that shouldn't be there
- The textarea didn't wrap lines
- The textarea didn't grow correctly with its value