### PR TITLE
Shift data down for "Add Data to Top" story

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -614,10 +614,15 @@ export const AddDataToTop: React.VFC = () => {
     const [numRows, setNumRows] = React.useState(50);
 
     const onRowAppended = React.useCallback(async () => {
-        const newRow = numRows;
+        // shift all of the existing cells down
+        for (let y = numRows; y > 0; y--) {
+          for (let x = 0; x < 6; x++) {
+            setCellValueRaw([x, y], getCellContent([x, y - 1]));
+          }
+        }
         for (let c = 0; c < 6; c++) {
-            const cell = getCellContent([c, newRow]);
-            setCellValueRaw([c, newRow], clearCell(cell));
+            const cell = getCellContent([c, 0]);
+            setCellValueRaw([c, 0], clearCell(cell));
         }
         setNumRows(cv => cv + 1);
         return "top" as const;
@@ -631,9 +636,6 @@ export const AddDataToTop: React.VFC = () => {
                     <Description>
                         You can return a different location to have the new row append take place.
                     </Description>
-                    <MoreInfo>
-                        At this time this story still adds the data to the end because our fake data source is bad.
-                    </MoreInfo>
                 </>
             }>
             <DataEditor


### PR DESCRIPTION
The `Add Data to Top` storybook story is broken because the data source still adds the empty row to the bottom. This shifts all of the data down a row and then adds the empty row to the top.

Is there a better way of shifting/inserting rows instead of this?