### PR TITLE
Switch appendRow to use scrollTo

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -499,7 +499,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
 
                 const row = bottom ? rows : 0;
-                scrollRef.current?.scrollBy(0, (bottom ? 1 : -1) * scrollRef.current.scrollHeight + 1000);
+                scrollTo(col, row);
                 setGridSelection({
                     cell: [col, row],
                     range: {


### PR DESCRIPTION
Currently the scrolling logic for `onRowAppended` just scrolls by 1000 or -1000 depending on whether the insertion is happening at "top" or "bottom"

https://github.com/glideapps/glide-data-grid/blob/113ba8c71cc2f37d83e78ab2ec3f3122533f8e96/packages/core/src/data-editor/data-editor.tsx#L501-L502

This works fine for smaller tables, but for tables over 1000pt tall it, does not scroll far enough and can cause the editor to appear outside the grid or outside of the bounds of the window entirely.

https://user-images.githubusercontent.com/94077014/149605780-6662103a-d6e2-410e-9f33-fb89dded8f27.mp4

This uses the new-ish `scrollTo` function to ensure the proper cell is scrolled to regardless of distance.

https://user-images.githubusercontent.com/94077014/149605792-47b058b6-4545-4b7d-a43c-ce3a57a87287.mp4