### PR TITLE
Allow onRowAppended to return a number for arbitrary row insertion

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -659,6 +659,78 @@ export const AddDataToTop: React.VFC = () => {
     },
 };
 
+interface AddDataToMiddleProps {
+    insertIndex: number;
+}
+export const AddDataToMiddle: React.FC<AddDataToMiddleProps> = p => {
+    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+
+    const [numRows, setNumRows] = React.useState(50);
+
+    const index = p.insertIndex;
+    const onRowAppended = React.useCallback(async () => {
+        // shift rows below index down
+        for (let y = numRows; y > index; y--) {
+          for (let x = 0; x < 6; x++) {
+            setCellValueRaw([x, y], getCellContent([x, y - 1]));
+          }
+        }
+        for (let c = 0; c < 6; c++) {
+            const cell = getCellContent([c, index]);
+            setCellValueRaw([c, index], clearCell(cell));
+        }
+        setNumRows(cv => cv + 1);
+        return index;
+    }, [getCellContent, numRows, setCellValueRaw, index]);
+
+    return (
+        <BeautifulWrapper
+            title="Add data to middle"
+            description={
+                <>
+                    <Description>
+                        You can return a different location to have the new row append take place.
+                    </Description>
+                    <MoreInfo>
+                        Note that <KeyName>insertIndex</KeyName> is zero-based while the number column on the left side of the grid is one-based, so inserting at index "4" creates a new row at "5"
+                    </MoreInfo>
+                </>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={cols}
+                rowMarkers={"both"}
+                onCellEdited={setCellValue}
+                trailingRowOptions={{
+                    hint: "New row...",
+                    sticky: true,
+                    tint: true,
+                }}
+                rows={numRows}
+                onRowAppended={onRowAppended}
+            />
+        </BeautifulWrapper>
+    );
+};
+(AddDataToMiddle as any).args = {
+    insertIndex: 10,
+};
+(AddDataToMiddle as any).argTypes = {
+    insertIndex: {
+        control: {
+            type: "range",
+            min: 1,
+            max: 48,
+        },
+    },
+};
+(AddDataToMiddle as any).parameters = {
+    options: {
+        showPanel: true,
+    },
+};
+
 export const SmallEditableGrid = () => {
     const { cols, getCellContent, setCellValue } = useMockDataGenerator(6, false);
 


### PR DESCRIPTION
Currently `onRowAppended` has the return type `"top" | "bottom" | undefined`. This works well if you want to prepend or append the value, but it does not allow you to insert values at an arbitrary index.

This adds `number` to the available return types (`"top" | "bottom" | number | undefined`) and uses that value for the `scrollTo` and `setGridSelection` calls instead of being limited to `row = bottom ? rows : 0`.

This also adds a "Add Data to Middle" story to the storybook to show and test its usage.

https://user-images.githubusercontent.com/94077014/149606249-13539b46-a1b4-4b86-afcd-db0ce82de95f.mp4