### PR TITLE
Add appendRowRef to allow appending to be triggered elsewhere

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -659,6 +659,63 @@ export const AddDataToTop: React.VFC = () => {
     },
 };
 
+export const AppendRowRef: React.VFC = () => {
+    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+
+    const [numRows, setNumRows] = React.useState(50);
+
+    const appendRowRef = React.useRef<any>(null);
+
+    const onClick = React.useCallback(() => {
+      const appendRow = appendRowRef.current;
+      appendRow(4)
+    }, [appendRowRef]);
+
+    const onRowAppended = React.useCallback(() => {
+        const newRow = numRows;
+        for (let c = 0; c < 6; c++) {
+            const cell = getCellContent([c, newRow]);
+            setCellValueRaw([c, newRow], clearCell(cell));
+        }
+        setNumRows(cv => cv + 1);
+    }, [getCellContent, numRows, setCellValueRaw]);
+
+    return (
+        <BeautifulWrapper
+            title="appendRowRef"
+            description={
+                <>
+                    <Description>Adding data can also be triggered from outside of <PropName>DataEditor</PropName></Description>
+                    <MoreInfo>
+                        By passing in an <PropName>appendRowRef</PropName> you can trigger the append elsewhere,
+                        like this <KeyName onClick={onClick}>Append</KeyName> button
+                    </MoreInfo>
+                </>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={cols}
+                rowMarkers={"both"}
+                onCellEdited={setCellValue}
+                trailingRowOptions={{
+                    hint: "New row...",
+                    sticky: true,
+                    tint: true,
+                }}
+                rows={numRows}
+                appendRowRef={appendRowRef}
+                onRowAppended={onRowAppended}
+            />
+        </BeautifulWrapper>
+    );
+};
+(AppendRowRef as any).parameters = {
+    options: {
+        showPanel: false,
+    },
+};
+
 export const SmallEditableGrid = () => {
     const { cols, getCellContent, setCellValue } = useMockDataGenerator(6, false);
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -97,6 +97,7 @@ export interface DataEditorProps extends Props {
     readonly onGroupHeaderClicked?: (colIndex: number, event: GroupHeaderClickedEventArgs) => void;
     readonly onGroupHeaderRenamed?: (groupName: string, newVal: string) => void;
     readonly onCellClicked?: (cell: readonly [number, number], event: CellClickedEventArgs) => void;
+    readonly appendRowRef?: React.MutableRefObject<(col: number) => Promise<void> | null>; // {current?: (col: number) => void}; ???
 
     readonly trailingRowOptions?: {
         readonly tint?: boolean;
@@ -201,6 +202,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         onGroupHeaderRenamed,
         onCellEdited,
         enableDownfill = false,
+        appendRowRef,
         onRowAppended,
         onColumnMoved,
         drawCell,
@@ -522,6 +524,11 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         },
         [onRowAppended, rowMarkerOffset, rows, setGridSelection]
     );
+    React.useEffect(() => {
+      if (appendRowRef) {
+        appendRowRef.current = appendRow
+      }
+    }, [appendRow, appendRowRef])
 
     const lastSelectedRowRef = React.useRef<number>();
     const lastSelectedColRef = React.useRef<number>();

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -97,7 +97,7 @@ export interface DataEditorProps extends Props {
     readonly onGroupHeaderClicked?: (colIndex: number, event: GroupHeaderClickedEventArgs) => void;
     readonly onGroupHeaderRenamed?: (groupName: string, newVal: string) => void;
     readonly onCellClicked?: (cell: readonly [number, number], event: CellClickedEventArgs) => void;
-    readonly appendRowRef?: React.MutableRefObject<(col: number) => Promise<void> | null>; // {current?: (col: number) => void}; ???
+    readonly appendRowRef?: React.MutableRefObject<(col: number) => Promise<void> | null>;
 
     readonly trailingRowOptions?: {
         readonly tint?: boolean;


### PR DESCRIPTION
I'd like to be able to trigger the append action from outside of the provided row, but there doesn't currently seem to be an exposed way to do this.

I'm not sure if this is the right way to go about it (I'm hoping there's a cleaner method) but I added an `appendRowRef` prop that gets `appendRow` assigned to it, and I am able to call it from elsewhere.

https://user-images.githubusercontent.com/94077014/151271212-a6450588-4fbb-438b-8485-9bb0c33b9065.mp4
