### PR TITLE
Add support for a editor-passed final value to onFinishedEditing

### DIFF
--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -71,13 +71,16 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
     let pad = true;
     let editor: React.ReactNode;
     if (CustomEditor !== undefined) {
+        const onCustomFinishedEditing = React.useCallback((newValue?: any | undefined) => {
+            onFinishEditing(newValue !== undefined ? newValue : tempValue, [0, 0])
+        }, [onFinishEditing, tempValue]);
         pad = CustomEditor.disablePadding !== true;
         editor = (
             <CustomEditor
                 isHighlighted={highlight}
                 onChange={setTempValue}
                 value={targetValue}
-                onFinishedEditing={onClickOutside}
+                onFinishedEditing={onCustomFinishedEditing}
             />
         );
     } else if (CellEditor !== undefined) {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -282,13 +282,13 @@ export type ProvideEditorCallback<T extends GridCell> = (
     cell: T
 ) =>
     | (React.FunctionComponent<{
-          readonly onChange: (newValue: T) => void;
-          readonly onFinishedEditing: () => void;
-          readonly isHighlighted: boolean;
-          readonly value: T;
-      }> & {
-          disablePadding?: boolean;
-      })
+        readonly onChange: (newValue: T) => void;
+        readonly onFinishedEditing: (newValue?: T) => void;
+        readonly isHighlighted: boolean;
+        readonly value: T;
+    }> & {
+        disablePadding?: boolean;
+    })
     | undefined;
 
 export interface CustomCell<T extends {} = {}> extends BaseGridCell {
@@ -385,7 +385,7 @@ function mergeRanges(input: CompactSelectionRanges) {
 let emptyCompactSelection: CompactSelection | undefined;
 
 export class CompactSelection {
-    private constructor(private readonly items: CompactSelectionRanges) {}
+    private constructor(private readonly items: CompactSelectionRanges) { }
 
     static empty = (): CompactSelection => {
         return emptyCompactSelection ?? (emptyCompactSelection = new CompactSelection([]));


### PR DESCRIPTION
This allows custom editors to pass the final value to be used, instead of relying upon the tempValue. If unspecified, the tempValue is used as before.

Fixes https://github.com/glideapps/glide-data-grid/issues/138