### PR TITLE
Add paddingRight and paddingBottom to scrollWidth and scrollHeight

### DIFF
--- a/packages/core/src/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/scrolling-data-grid/scrolling-data-grid.tsx
@@ -274,8 +274,8 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             minimap={minimap}
             className={className}
             draggable={dataGridProps.isDraggable === true}
-            scrollWidth={width}
-            scrollHeight={height}
+            scrollWidth={width + (paddingRight ?? 0)}
+            scrollHeight={height + (paddingBottom ?? 0)}
             clientHeight={clientHeight}
             rightElement={rightElement}
             paddingBottom={paddingBottom}


### PR DESCRIPTION
When the experimental paddingRight and paddingBottom values are set, the rendered table gets properly clipped, but the scroll width and height are not adjusted to allow you to scroll to the last rows and columns.

https://user-images.githubusercontent.com/94077014/151888497-95393743-32d1-440a-b6b5-a26ca3406e28.mp4

This adds in the same padding so that it scrolls correctly.

https://user-images.githubusercontent.com/94077014/151888517-d6d03e0b-5bc5-470b-8152-5bac5fad1ade.mp4