### PR TITLE
Add marginBottom/marginRight and change paddingBottom/paddingRight behavior

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -942,7 +942,7 @@ interface AddColumnsProps {
     columnsCount: number;
 }
 
-export const AddColumns: React.VFC<AddColumnsProps> = p => {
+export const AddColumns: React.FC<AddColumnsProps> = p => {
     const { cols, getCellContent } = useMockDataGenerator(p.columnsCount);
 
     return (
@@ -1092,7 +1092,7 @@ interface ExperimentalMarginPaddingProps {
     paddingBottom: number;
     paddingRight: number;
 }
-export const ExperimentalMarginPadding: React.FC<ExperimentalMarginPaddingProps> = p => {
+export const ExperimentalMarginPadding: React.VFC<ExperimentalMarginPaddingProps> = p => {
     const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
 
     const [numRows, setNumRows] = React.useState(50);

--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -942,7 +942,7 @@ interface AddColumnsProps {
     columnsCount: number;
 }
 
-export const AddColumns: React.FC<AddColumnsProps> = p => {
+export const AddColumns: React.VFC<AddColumnsProps> = p => {
     const { cols, getCellContent } = useMockDataGenerator(p.columnsCount);
 
     return (
@@ -1084,6 +1084,96 @@ export const DrawCustomCells: React.VFC = () => {
 (DrawCustomCells as any).parameters = {
     options: {
         showPanel: false,
+    },
+};
+interface ExperimentalMarginPaddingProps {
+    marginBottom: number;
+    marginRight: number;
+    paddingBottom: number;
+    paddingRight: number;
+}
+export const ExperimentalMarginPadding: React.FC<ExperimentalMarginPaddingProps> = p => {
+    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+
+    const [numRows, setNumRows] = React.useState(50);
+
+    const onRowAppended = React.useCallback(() => {
+        const newRow = numRows;
+        for (let c = 0; c < 6; c++) {
+            const cell = getCellContent([c, newRow]);
+            setCellValueRaw([c, newRow], clearCell(cell));
+        }
+        setNumRows(cv => cv + 1);
+    }, [getCellContent, numRows, setCellValueRaw]);
+    
+    return (
+        <BeautifulWrapper
+            title="[Experimental] Margin and Padding"
+            description={
+                <>
+                    <Description>Margin and padding can be used to allow for extra scrolling</Description>
+                    <MoreInfo>
+                        Use <PropName>marginRight</PropName>, <PropName>marginBottom</PropName>, <PropName>paddingRight</PropName> and <PropName>paddingBottom</PropName> to control the drawing behavior
+                    </MoreInfo>
+                </>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={cols}
+                rowMarkers={"both"}
+                onCellEdited={setCellValue}
+                trailingRowOptions={{
+                    hint: "New row...",
+                    sticky: true,
+                    tint: true,
+                }}
+                experimental={p}
+                rows={numRows}
+                onRowAppended={onRowAppended}
+            />
+        </BeautifulWrapper>
+    );
+};
+(ExperimentalMarginPadding as any).args = {
+    marginBottom: 100,
+    marginRight: 100,
+    paddingBottom: 100,
+    paddingRight: 100,
+};
+(ExperimentalMarginPadding as any).argTypes = {
+    marginBottom: {
+        control: {
+            type: "number",
+            min: 0,
+            max: 300,
+        },
+    },
+    marginRight: {
+        control: {
+            type: "number",
+            min: 0,
+            max: 300,
+        },
+    },
+    paddingBottom: {
+        control: {
+            type: "number",
+            min: 0,
+            max: 300,
+        },
+    },
+    paddingRight: {
+        control: {
+            type: "number",
+            min: 0,
+            max: 300,
+        },
+    },
+};
+(ExperimentalMarginPadding as any).parameters = {
+    options: {
+        showPanel: true,
     },
 };
 

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -109,6 +109,8 @@ export interface DataGridProps {
     };
 
     readonly experimental?: {
+        readonly marginRight?: number;
+        readonly marginBottom?: number;
         readonly paddingRight?: number;
         readonly paddingBottom?: number;
         readonly disableFirefoxRescaling?: boolean;

--- a/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
+++ b/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
@@ -7,8 +7,8 @@ import { browserIsSafari } from "../common/browser-detect";
 interface Props {
     readonly className?: string;
     readonly draggable: boolean;
-    readonly paddingRight?: number;
-    readonly paddingBottom?: number;
+    readonly marginRight?: number;
+    readonly marginBottom?: number;
     readonly clientHeight: number;
     readonly scrollWidth: number;
     readonly scrollHeight: number;
@@ -69,8 +69,8 @@ export const InfiniteScroller: React.FC<Props> = p => {
         update,
         draggable,
         className,
-        paddingBottom = 0,
-        paddingRight = 0,
+        marginBottom = 0,
+        marginRight = 0,
         rightElement,
         rightElementSticky = false,
         scrollRef,
@@ -116,10 +116,14 @@ export const InfiniteScroller: React.FC<Props> = p => {
         update({
             x: el.scrollLeft,
             y: Math.min(maxFakeY, newY + offsetY.current),
-            width: el.clientWidth - paddingRight,
-            height: el.clientHeight - paddingBottom,
+            width: el.clientWidth - marginRight,
+            height: el.clientHeight - marginBottom,
         });
-    }, [paddingBottom, paddingRight, scrollHeight, update]);
+    }, [marginBottom, marginRight, scrollHeight, update]);
+
+    React.useEffect(() => {
+        onScroll();
+    }, [onScroll, marginBottom, marginRight]);
 
     const lastProps = React.useRef<{ width?: number; height?: number }>();
 
@@ -186,8 +190,8 @@ export const InfiniteScroller: React.FC<Props> = p => {
                                                     position: "sticky",
                                                     top: 0,
                                                     marginBottom: -40,
-                                                    marginRight: paddingRight,
-                                                    right: rightElementSticky ? paddingRight ?? 0 : undefined,
+                                                    marginRight: marginRight,
+                                                    right: rightElementSticky ? marginRight ?? 0 : undefined,
                                                     pointerEvents: "auto",
                                                 }}>
                                                 {rightElement}

--- a/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
+++ b/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
@@ -121,6 +121,7 @@ export const InfiniteScroller: React.FC<Props> = p => {
         });
     }, [marginBottom, marginRight, scrollHeight, update]);
 
+    // Ensure the grid is updated when marginBottom and marginRight change
     React.useEffect(() => {
         onScroll();
     }, [onScroll, marginBottom, marginRight]);

--- a/packages/core/src/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/scrolling-data-grid/scrolling-data-grid.tsx
@@ -51,7 +51,7 @@ const MinimapStyle = styled.div`
 
 const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
     const { columns, rows, rowHeight, headerHeight, groupHeaderHeight, enableGroups, freezeColumns, experimental } = p;
-    const { paddingRight, paddingBottom } = experimental ?? {};
+    const { marginRight, marginBottom, paddingRight, paddingBottom } = experimental ?? {};
     const {
         className,
         onVisibleRegionChanged,
@@ -274,12 +274,12 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
             minimap={minimap}
             className={className}
             draggable={dataGridProps.isDraggable === true}
-            scrollWidth={width + (paddingRight ?? 0)}
-            scrollHeight={height + (paddingBottom ?? 0)}
+            scrollWidth={width + (marginRight ?? 0) + (paddingRight ?? 0)}
+            scrollHeight={height + (marginBottom ?? 0) + (paddingBottom ?? 0)}
             clientHeight={clientHeight}
             rightElement={rightElement}
-            paddingBottom={paddingBottom}
-            paddingRight={paddingRight}
+            marginBottom={marginBottom}
+            marginRight={marginRight}
             rightElementSticky={rightElementSticky}
             update={onScrollUpdate}
             scrollToEnd={scrollToEnd}>


### PR DESCRIPTION
As described in #159, currently `paddingBottom` and `paddingRight` function more like a margin, where nothing is drawn in that area. This changes `paddingBottom` and `paddingRight` to still draw empty cells in those areas, and uses `marginBottom` and `marginRight` to achieve the prior behavior.

https://user-images.githubusercontent.com/94077014/152607986-ff462cef-592d-4677-b413-4fb3665cc6bd.mp4
