### PR TITLE
Update padding when paddingBottom and paddingRight values change

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -571,6 +571,63 @@ export const Overscroll: React.VFC<OverscrollProps> = p => {
     },
 };
 
+
+interface PaddingProps {
+    paddingRight: number;
+    paddingBottom: number;
+}
+
+export const Padding: React.VFC<PaddingProps> = p => {
+    const { paddingRight, paddingBottom } = p;
+    const { cols, getCellContent } = useMockDataGenerator(20);
+
+    return (
+        <BeautifulWrapper
+            title="Padding"
+            description={
+                <>
+                    <Description>
+                        You can add padding at the ends of the grid by setting the{" "}
+                        <PropName>paddingRight</PropName> and <PropName>paddingBottom</PropName> props
+                    </Description>
+                </>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={cols}
+                experimental={{ paddingRight, paddingBottom }}
+                rows={50}
+            />
+        </BeautifulWrapper>
+    );
+};
+(Padding as any).argTypes = {
+    paddingRight: {
+        control: {
+            type: "range",
+            min: 0,
+            max: 600,
+        },
+    },
+    paddingBottom: {
+        control: {
+            type: "range",
+            min: 0,
+            max: 600,
+        },
+    },
+};
+(Padding as any).args = {
+    paddingRight: 200,
+    paddingBottom: 200,
+};
+(Padding as any).parameters = {
+    options: {
+        showPanel: true,
+    },
+};
+
 function clearCell(cell: GridCell): GridCell {
     switch (cell.kind) {
         case GridCellKind.Boolean: {

--- a/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
+++ b/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
@@ -121,6 +121,11 @@ export const InfiniteScroller: React.FC<Props> = p => {
         });
     }, [paddingBottom, paddingRight, scrollHeight, update]);
 
+    // Ensure the grid is updated when paddingBottom and paddingRight change
+    React.useEffect(() => {
+        onScroll();
+    }, [onScroll, paddingBottom, paddingRight]);
+
     const lastProps = React.useRef<{ width?: number; height?: number }>();
 
     const nomEvent = React.useCallback((e: React.MouseEvent) => {


### PR DESCRIPTION
Currently the `paddingBottom` and `paddingRight` values don't update until you interact with the grid.

https://user-images.githubusercontent.com/94077014/153515433-a32f2355-91d7-4cb8-8d77-e960c129d831.mp4


This fixes that by calling `onScroll` whenever `paddingBottom` or `paddingRight` change

https://user-images.githubusercontent.com/94077014/153515458-9d13fa6a-9ad6-43a6-bf44-09f99db7cd66.mp4


I did notice that when this value is changing rapidly the width/height of the cells seems to briefly change. Not sure what is causing that

https://user-images.githubusercontent.com/94077014/153515561-204abf3b-cb2c-435f-b5ea-4ddb57c7d812.mp4