### PR TITLE
Allow using custom icons in trailing row

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -666,6 +666,52 @@ export const AddData: React.VFC = () => {
     },
 };
 
+export const TrailingRowOptions: React.VFC = () => {
+    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+
+    const [numRows, setNumRows] = React.useState(50);
+
+    const onRowAppended = React.useCallback(() => {
+        const newRow = numRows;
+        for (let c = 0; c < 6; c++) {
+            const cell = getCellContent([c, newRow]);
+            setCellValueRaw([c, newRow], clearCell(cell));
+        }
+        setNumRows(cv => cv + 1);
+    }, [getCellContent, numRows, setCellValueRaw]);
+
+    return (
+        <BeautifulWrapper
+            title="Trailing row options"
+            description={
+                <Description>
+                    You can customize the trailing row by using the <PropName>trailingRowOptions</PropName> prop
+                </Description>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={cols}
+                rowMarkers={"both"}
+                onCellEdited={setCellValue}
+                trailingRowOptions={{
+                    hint: "New row...",
+                    sticky: true,
+                    tint: true,
+                    addIcon: "headerRowID",
+                }}
+                rows={numRows}
+                onRowAppended={onRowAppended}
+            />
+        </BeautifulWrapper>
+    );
+};
+(TrailingRowOptions as any).parameters = {
+    options: {
+        showPanel: false,
+    },
+};
+
 export const AddDataToTop: React.VFC = () => {
     const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -106,6 +106,7 @@ export interface DataEditorProps extends Props {
         readonly tint?: boolean;
         readonly hint?: string;
         readonly sticky?: boolean;
+        readonly addIcon?: string;
     };
     readonly headerHeight?: number;
     readonly groupHeaderHeight?: number;
@@ -373,6 +374,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     hint: display,
                     isFirst,
                     allowOverlay: false,
+                    icon: trailingRowOptions?.addIcon,
                 };
             } else {
                 return getCellContent([col - rowMarkerOffset, row]);
@@ -386,6 +388,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rowMarkers,
             rowMarkerOffset,
             trailingRowOptions?.hint,
+            trailingRowOptions?.addIcon,
             getCellContent,
         ]
     );

--- a/packages/core/src/data-grid/cells/cell-types.ts
+++ b/packages/core/src/data-grid/cells/cell-types.ts
@@ -1,5 +1,6 @@
 import type { OverlayImageEditorProps, Theme } from "../..";
 import type ImageWindowLoader from "../../common/image-window-loader";
+import { SpriteManager } from "../data-grid-sprites";
 import type { InnerGridCell, Rectangle, Item } from "../data-grid-types";
 
 export type HoverInfo = readonly [Item, readonly [number, number]];
@@ -20,6 +21,7 @@ export interface BaseDrawArgs {
     hoverX: number | undefined;
     hoverY: number | undefined;
     imageLoader: ImageWindowLoader;
+    spriteManager: SpriteManager;
 }
 
 interface DrawArgs<T extends InnerGridCell> extends BaseDrawArgs {

--- a/packages/core/src/data-grid/cells/cell-types.ts
+++ b/packages/core/src/data-grid/cells/cell-types.ts
@@ -1,6 +1,6 @@
 import type { OverlayImageEditorProps, Theme } from "../..";
 import type ImageWindowLoader from "../../common/image-window-loader";
-import { SpriteManager } from "../data-grid-sprites";
+import type { SpriteManager } from "../data-grid-sprites";
 import type { InnerGridCell, Rectangle, Item } from "../data-grid-types";
 
 export type HoverInfo = readonly [Item, readonly [number, number]];

--- a/packages/core/src/data-grid/cells/new-row-cell.tsx
+++ b/packages/core/src/data-grid/cells/new-row-cell.tsx
@@ -7,5 +7,5 @@ export const newRowCellRenderer: InternalCellRenderer<NewRowCell> = {
     kind: InnerGridCellKind.NewRow,
     needsHover: true,
     needsHoverPosition: false,
-    render: a => drawNewRowCell(a, a.cell.hint, a.cell.isFirst),
+    render: a => drawNewRowCell(a, a.cell.hint, a.cell.isFirst, a.cell.icon),
 };

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -244,8 +244,8 @@ export function drawTextCell(args: BaseDrawArgs, data: string) {
     }
 }
 
-export function drawNewRowCell(args: BaseDrawArgs, data: string, isFirst: boolean) {
-    const { ctx, x, y, w, h, hoverAmount, theme } = args;
+export function drawNewRowCell(args: BaseDrawArgs, data: string, isFirst: boolean, icon?: string) {
+    const { ctx, x, y, w, h, hoverAmount, theme, spriteManager } = args;
     ctx.beginPath();
     ctx.globalAlpha = hoverAmount;
     ctx.rect(x, y, w, h);
@@ -254,20 +254,29 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, isFirst: boolea
     ctx.globalAlpha = 1;
     ctx.beginPath();
 
-    const finalLineSize = 12;
-    const lineSize = isFirst ? finalLineSize : hoverAmount * finalLineSize;
-    const xTranslate = isFirst ? 0 : (1 - hoverAmount) * finalLineSize * 0.5;
+    if (icon !== undefined) {
+        const padding = 8;
+        const size = h - padding;
+        const px = x + padding / 2;
+        const py = y + padding / 2;
 
-    const padPlus = theme.cellHorizontalPadding + 4;
-    if (lineSize > 0) {
-        ctx.moveTo(x + padPlus + xTranslate, y + h / 2);
-        ctx.lineTo(x + padPlus + xTranslate + lineSize, y + h / 2);
-        ctx.moveTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 - lineSize * 0.5);
-        ctx.lineTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 + lineSize * 0.5);
-        ctx.lineWidth = 2;
-        ctx.strokeStyle = theme.bgIconHeader;
-        ctx.lineCap = "round";
-        ctx.stroke();
+        spriteManager.drawSprite(icon, "normal", ctx, px, py, size, theme, isFirst ? 1 : hoverAmount);
+    } else {
+        const finalLineSize = 12;
+        const lineSize = isFirst ? finalLineSize : hoverAmount * finalLineSize;
+        const xTranslate = isFirst ? 0 : (1 - hoverAmount) * finalLineSize * 0.5;
+
+        const padPlus = theme.cellHorizontalPadding + 4;
+        if (lineSize > 0) {
+            ctx.moveTo(x + padPlus + xTranslate, y + h / 2);
+            ctx.lineTo(x + padPlus + xTranslate + lineSize, y + h / 2);
+            ctx.moveTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 - lineSize * 0.5);
+            ctx.lineTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 + lineSize * 0.5);
+            ctx.lineWidth = 2;
+            ctx.strokeStyle = theme.bgIconHeader;
+            ctx.lineCap = "round";
+            ctx.stroke();
+        }
     }
 
     ctx.fillStyle = theme.textMedium;

--- a/packages/core/src/data-grid/data-grid-render.tsx
+++ b/packages/core/src/data-grid/data-grid-render.tsx
@@ -78,6 +78,7 @@ export function drawCell(
     theme: Theme,
     drawCustomCell: DrawCustomCellCallback | undefined,
     imageLoader: ImageWindowLoader,
+    spriteManager: SpriteManager,
     hoverAmount: number,
     hoverInfo: HoverInfo | undefined,
     frameTime: number,
@@ -91,7 +92,23 @@ export function drawCell(
         hoverY = hoverInfo[1][1];
     }
     let result: {} | undefined = undefined;
-    const args = { ctx, theme, col, row, cell, x, y, w, h, highlighted, hoverAmount, hoverX, hoverY, imageLoader };
+    const args = {
+        ctx,
+        theme,
+        col,
+        row,
+        cell,
+        x,
+        y,
+        w,
+        h,
+        highlighted,
+        hoverAmount,
+        hoverX,
+        hoverY,
+        imageLoader,
+        spriteManager,
+    };
     const needsAnim = drawWithLastUpdate(args, cell.lastUpdated, frameTime, forcePrep => {
         const drawn = isInnerOnlyCell(cell)
             ? false
@@ -832,6 +849,7 @@ function drawCells(
     prelightCells: CellList | undefined,
     drawCustomCell: DrawCustomCellCallback | undefined,
     imageLoader: ImageWindowLoader,
+    spriteManager: SpriteManager,
     hoverValues: HoverValues,
     hoverInfo: HoverInfo | undefined,
     outerTheme: Theme,
@@ -1008,6 +1026,7 @@ function drawCells(
                             theme,
                             drawCustomCell,
                             imageLoader,
+                            spriteManager,
                             hoverValue?.hoverAmount ?? 0,
                             hoverInfo,
                             frameTime,
@@ -1398,6 +1417,7 @@ export function drawGrid(
                 prelightCells,
                 drawCustomCell,
                 imageLoader,
+                spriteManager,
                 hoverValues,
                 hoverInfo,
                 theme,
@@ -1520,6 +1540,7 @@ export function drawGrid(
         prelightCells,
         drawCustomCell,
         imageLoader,
+        spriteManager,
         hoverValues,
         hoverInfo,
         theme,

--- a/packages/core/src/data-grid/data-grid-sprites.ts
+++ b/packages/core/src/data-grid/data-grid-sprites.ts
@@ -53,7 +53,8 @@ export class SpriteManager {
         x: number,
         y: number,
         size: number,
-        theme: Theme
+        theme: Theme,
+        alpha?: number
     ) {
         if (this.spriteCanvas === undefined) throw new Error();
 
@@ -66,7 +67,9 @@ export class SpriteManager {
         const xOffset = spriteIndex * renderSize;
         const yOffset = Math.max(0, variantIndex * renderSize);
 
+        ctx.globalAlpha = alpha ?? 1;
         ctx.drawImage(this.spriteCanvas, xOffset, yOffset, renderSize, renderSize, x, y, size, size);
+        ctx.globalAlpha = 1;
     }
 
     public async buildSpriteMap(theme: Theme, cols: readonly GridColumn[]): Promise<boolean> {

--- a/packages/core/src/data-grid/data-grid-sprites.ts
+++ b/packages/core/src/data-grid/data-grid-sprites.ts
@@ -54,7 +54,7 @@ export class SpriteManager {
         y: number,
         size: number,
         theme: Theme,
-        alpha?: number
+        alpha: number = 1
     ) {
         if (this.spriteCanvas === undefined) throw new Error();
 
@@ -67,9 +67,13 @@ export class SpriteManager {
         const xOffset = spriteIndex * renderSize;
         const yOffset = Math.max(0, variantIndex * renderSize);
 
-        ctx.globalAlpha = alpha ?? 1;
+        if (alpha < 1) {
+            ctx.globalAlpha = alpha;
+        }
         ctx.drawImage(this.spriteCanvas, xOffset, yOffset, renderSize, renderSize, x, y, size, size);
-        ctx.globalAlpha = 1;
+        if (alpha < 1) {
+            ctx.globalAlpha = 1;
+        }
     }
 
     public async buildSpriteMap(theme: Theme, cols: readonly GridColumn[]): Promise<boolean> {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -344,6 +344,7 @@ export interface NewRowCell extends BaseGridCell {
     readonly hint: string;
     readonly isFirst: boolean;
     readonly allowOverlay: false;
+    readonly icon?: string;
 }
 
 export interface MarkerCell extends BaseGridCell {

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -988,6 +988,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                 theme,
                                 drawCustomCell,
                                 imageLoader,
+                                spriteManager,
                                 1,
                                 undefined,
                                 0
@@ -1023,6 +1024,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             getCellContent,
             drawCustomCell,
             imageLoader,
+            spriteManager,
         ]
     );
     useEventListener("dragstart", onDragStartImpl, eventTargetRef?.current ?? null, false, false);


### PR DESCRIPTION
`trailingRowOptions` now takes an optional `addIcon`, which should be the name of a sprite in the spriteMap