### PR TITLE
Auto column sizing, fixes #181

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -5,6 +5,7 @@ set -e
 for DIR in "core" "cells" "source"
 do
     pushd packages/$DIR
-    npm run lint && npm run build
+    npm run lint
+    npm run build
     popd
 done

--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -225,7 +225,6 @@ function createTextColumnInfo(index: number, group: boolean): GridColumnWithMock
     return {
         title: `Column ${index}`,
         group: group ? `Group ${Math.round(index / 3)}` : undefined,
-        width: 120,
         icon: GridColumnIcon.HeaderString,
         hasMenu: false,
         getContent: () => {
@@ -247,7 +246,6 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         {
             title: "First name",
             group: group ? "Name" : undefined,
-            width: 120,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
             getContent: () => {
@@ -264,7 +262,6 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         {
             title: "Last name",
             group: group ? "Name" : undefined,
-            width: 120,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
             getContent: () => {
@@ -280,7 +277,6 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Avatar",
-            width: 120,
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderImage,
             hasMenu: false,
@@ -298,7 +294,6 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Email",
-            width: 120,
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -315,7 +310,6 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Title",
-            width: 120,
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -332,14 +326,13 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "More Info",
-            width: 120,
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderUri,
             hasMenu: false,
             getContent: () => {
                 const url = faker.internet.url();
                 return {
-                    kind: GridCellKind.Markdown,
+                    kind: GridCellKind.Uri,
                     displayData: url,
                     data: url,
                     allowOverlay: true,
@@ -1219,7 +1212,7 @@ export const RearrangeColumns: React.VFC = () => {
     // you should track indexes properly
     const [sortableCols, setSortableCols] = React.useState(() => {
         num = 200;
-        return cols.map(c => ({ ...c, width: c.width + (rand() % 100) }));
+        return cols.map(c => ({ ...c, width: (c.width ?? 150) + (rand() % 100) }));
     });
 
     const onColMoved = React.useCallback((startIndex: number, endIndex: number): void => {
@@ -2389,7 +2382,7 @@ a new line char ""more quotes"" plus a tab  ."	https://google.com`}
 };
 
 export const FreezeColumns: React.VFC = () => {
-    const { cols, getCellContent } = useMockDataGenerator(100);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(100);
 
     return (
         <BeautifulWrapper
@@ -2405,6 +2398,7 @@ export const FreezeColumns: React.VFC = () => {
                 rowMarkers="both"
                 freezeColumns={1}
                 getCellContent={getCellContent}
+                getCellsForSelection={getCellsForSelection}
                 columns={cols}
                 verticalBorder={c => c > 0}
                 rows={1_000}

--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -984,7 +984,7 @@ export const ObserveVisibleRegion: React.VFC = () => {
 };
 
 export const OneHundredThousandCols: React.VFC = () => {
-    const { cols, getCellContent } = useMockDataGenerator(100000);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(100000);
 
     return (
         <BeautifulWrapper
@@ -995,7 +995,13 @@ export const OneHundredThousandCols: React.VFC = () => {
                     but that&apos;s not important.
                 </Description>
             }>
-            <DataEditor {...defaultProps} getCellContent={getCellContent} columns={cols} rows={1000} />
+            <DataEditor
+                {...defaultProps}
+                getCellsForSelection={getCellsForSelection}
+                getCellContent={getCellContent}
+                columns={cols}
+                rows={1000}
+            />
         </BeautifulWrapper>
     );
 };

--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -111,9 +111,9 @@ export default {
     ],
 };
 
-interface GridColumnWithMockingInfo extends GridColumn {
+type GridColumnWithMockingInfo = GridColumn & {
     getContent(): GridCell;
-}
+};
 
 function getGridColumn(columnWithMock: GridColumnWithMockingInfo): GridColumn {
     const { getContent, ...rest } = columnWithMock;
@@ -224,6 +224,7 @@ const BeautifulWrapper: React.FC<BeautifulProps> = p => {
 function createTextColumnInfo(index: number, group: boolean): GridColumnWithMockingInfo {
     return {
         title: `Column ${index}`,
+        id: `Column ${index}`,
         group: group ? `Group ${Math.round(index / 3)}` : undefined,
         icon: GridColumnIcon.HeaderString,
         hasMenu: false,
@@ -245,6 +246,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
     const defaultColumns: GridColumnWithMockingInfo[] = [
         {
             title: "First name",
+            id: "First name",
             group: group ? "Name" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -261,6 +263,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Last name",
+            id: "Last name",
             group: group ? "Name" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -277,6 +280,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Avatar",
+            id: "Avatar",
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderImage,
             hasMenu: false,
@@ -294,6 +298,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Email",
+            id: "Email",
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -310,6 +315,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "Title",
+            id: "Title",
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderString,
             hasMenu: false,
@@ -326,6 +332,7 @@ function getResizableColumns(amount: number, group: boolean): GridColumnWithMock
         },
         {
             title: "More Info",
+            id: "More Info",
             group: group ? "Info" : undefined,
             icon: GridColumnIcon.HeaderUri,
             hasMenu: false,
@@ -612,7 +619,10 @@ function clearCell(cell: GridCell): GridCell {
 }
 
 export const AddData: React.VFC = () => {
-    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+    const { cols, getCellContent, setCellValueRaw, setCellValue, getCellsForSelection } = useMockDataGenerator(
+        60,
+        false
+    );
 
     const [numRows, setNumRows] = React.useState(50);
 
@@ -640,6 +650,7 @@ export const AddData: React.VFC = () => {
                 {...defaultProps}
                 getCellContent={getCellContent}
                 columns={cols}
+                getCellsForSelection={getCellsForSelection}
                 rowMarkers={"both"}
                 onCellEdited={setCellValue}
                 trailingRowOptions={{
@@ -1061,7 +1072,7 @@ interface AddColumnsProps {
 }
 
 export const AddColumns: React.FC<AddColumnsProps> = p => {
-    const { cols, getCellContent } = useMockDataGenerator(p.columnsCount);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(p.columnsCount);
 
     return (
         <BeautifulWrapper
@@ -1072,7 +1083,13 @@ export const AddColumns: React.FC<AddColumnsProps> = p => {
                     <MoreInfo>Use the story&apos;s controls to change the number of columns</MoreInfo>
                 </>
             }>
-            <DataEditor {...defaultProps} getCellContent={getCellContent} columns={cols} rows={10_000} />
+            <DataEditor
+                {...defaultProps}
+                getCellsForSelection={getCellsForSelection}
+                getCellContent={getCellContent}
+                columns={cols}
+                rows={10_000}
+            />
         </BeautifulWrapper>
     );
 };
@@ -1206,14 +1223,11 @@ export const DrawCustomCells: React.VFC = () => {
 };
 
 export const RearrangeColumns: React.VFC = () => {
-    const { cols, getCellContent } = useMockDataGenerator(60);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(60);
 
     // This is a dirty hack because the mock generator doesn't really support changing this. In a real data source
     // you should track indexes properly
-    const [sortableCols, setSortableCols] = React.useState(() => {
-        num = 200;
-        return cols.map(c => ({ ...c, width: (c.width ?? 150) + (rand() % 100) }));
-    });
+    const [sortableCols, setSortableCols] = React.useState(cols);
 
     const onColMoved = React.useCallback((startIndex: number, endIndex: number): void => {
         setSortableCols(old => {
@@ -1246,6 +1260,7 @@ export const RearrangeColumns: React.VFC = () => {
                 freezeColumns={1}
                 rowMarkers="both"
                 getCellContent={getCellContentMangled}
+                getCellsForSelection={getCellsForSelection}
                 columns={sortableCols}
                 onColumnMoved={onColMoved}
                 rows={1_000}
@@ -1264,7 +1279,7 @@ interface RowAndHeaderSizesProps {
     headerHeight: number;
 }
 export const RowAndHeaderSizes: React.VFC<RowAndHeaderSizesProps> = p => {
-    const { cols, getCellContent } = useMockDataGenerator(6);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(6);
 
     const [selectedRows, setSelectedRows] = React.useState<CompactSelection>();
 
@@ -1286,6 +1301,7 @@ export const RowAndHeaderSizes: React.VFC<RowAndHeaderSizesProps> = p => {
                 headerHeight={p.headerHeight}
                 selectedRows={selectedRows}
                 onSelectedRowsChange={setSelectedRows}
+                getCellsForSelection={getCellsForSelection}
                 rowMarkers={"number"}
                 getCellContent={getCellContent}
                 columns={cols}
@@ -1332,7 +1348,7 @@ const KeyName = styled.kbd`
 `;
 
 export const MultiSelectColumns: React.VFC = () => {
-    const { cols, getCellContent } = useMockDataGenerator(100);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(100);
 
     const [sel, setSel] = React.useState(CompactSelection.empty());
 
@@ -1354,6 +1370,7 @@ export const MultiSelectColumns: React.VFC = () => {
             <DataEditor
                 {...defaultProps}
                 getCellContent={getCellContent}
+                getCellsForSelection={getCellsForSelection}
                 rowMarkers="both"
                 columns={cols}
                 rows={100_000}
@@ -1817,7 +1834,7 @@ export const ThemePerColumn: React.VFC = () => {
 };
 
 export const ThemePerRow: React.VFC = () => {
-    const { cols, getCellContent, onColumnResized, setCellValue } = useMockDataGenerator(5);
+    const { cols, getCellContent, onColumnResized, setCellValue, getCellsForSelection } = useMockDataGenerator(5);
 
     return (
         <BeautifulWrapper
@@ -1834,6 +1851,7 @@ export const ThemePerRow: React.VFC = () => {
                 {...defaultProps}
                 getCellContent={getCellContent}
                 columns={cols}
+                getCellsForSelection={getCellsForSelection}
                 getRowThemeOverride={i =>
                     i % 2 === 0
                         ? undefined
@@ -2133,7 +2151,7 @@ export const CustomHeaderIcons: React.VFC = () => {
 };
 
 export const RightElement: React.VFC = () => {
-    const { cols, getCellContent, setCellValue } = useMockDataGenerator(12, false);
+    const { cols, getCellContent, setCellValue, getCellsForSelection } = useMockDataGenerator(12, false);
 
     const [numRows, setNumRows] = React.useState(30);
 
@@ -2161,6 +2179,7 @@ export const RightElement: React.VFC = () => {
                 {...defaultProps}
                 getCellContent={getCellContent}
                 columns={cols}
+                getCellsForSelection={getCellsForSelection}
                 rowMarkers={"both"}
                 onCellEdited={setCellValue}
                 trailingRowOptions={{
@@ -2206,7 +2225,7 @@ function rand(): number {
 }
 
 export const RapidUpdates: React.VFC = () => {
-    const { cols, getCellContent, setCellValueRaw } = useMockDataGenerator(100);
+    const { cols, getCellContent, setCellValueRaw, getCellsForSelection } = useMockDataGenerator(100);
 
     const ref = React.useRef<DataEditorRef>(null);
 
@@ -2277,7 +2296,14 @@ export const RapidUpdates: React.VFC = () => {
                     </MoreInfo>
                 </>
             }>
-            <DataEditor {...defaultProps} ref={ref} getCellContent={getCellContent} columns={cols} rows={10_000} />
+            <DataEditor
+                {...defaultProps}
+                ref={ref}
+                getCellContent={getCellContent}
+                getCellsForSelection={getCellsForSelection}
+                columns={cols}
+                rows={10_000}
+            />
         </BeautifulWrapper>
     );
 };
@@ -2481,7 +2507,7 @@ export const ReorderRows: React.VFC = () => {
 };
 
 export const ColumnGroups: React.VFC = () => {
-    const { cols, getCellContent } = useMockDataGenerator(20, true, true);
+    const { cols, getCellContent, getCellsForSelection } = useMockDataGenerator(20, true, true);
 
     return (
         <BeautifulWrapper
@@ -2496,6 +2522,7 @@ export const ColumnGroups: React.VFC = () => {
                 getCellContent={getCellContent}
                 onGroupHeaderRenamed={(x, y) => window.alert(`Please rename group ${x} to ${y}`)}
                 columns={cols}
+                getCellsForSelection={getCellsForSelection}
                 rows={1000}
                 getGroupDetails={g => ({
                     name: g,

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -9,6 +9,7 @@ import {
     GridCellKind,
     GridSelection,
     HeaderSelectionTrigger,
+    isSizedGridColumn,
 } from "..";
 
 jest.mock("react-virtualized-auto-sizer", () => {
@@ -1194,7 +1195,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => (isSizedGridColumn(c) ? c.width : 150)).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);
@@ -1206,7 +1207,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => (isSizedGridColumn(c) ? c.width : 150)).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);
@@ -1236,7 +1237,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => (isSizedGridColumn(c) ? c.width : 150)).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 55);
@@ -1248,7 +1249,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => (isSizedGridColumn(c) ? c.width : 150)).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -1194,7 +1194,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);
@@ -1206,7 +1206,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);
@@ -1236,7 +1236,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 55);
@@ -1248,7 +1248,7 @@ describe("data-editor", () => {
 
         if (scroller !== null) {
             jest.spyOn(scroller, "scrollWidth", "get").mockImplementation(() =>
-                basicProps.columns.map(c => c.width).reduce((pv, cv) => pv + cv, 0)
+                basicProps.columns.map(c => c.width ?? 150).reduce((pv, cv) => pv + cv, 0)
             );
             jest.spyOn(scroller, "scrollHeight", "get").mockImplementation(() => 1000 * 32 + 36);
             jest.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);

--- a/packages/core/src/data-editor/use-cell-sizer.ts
+++ b/packages/core/src/data-editor/use-cell-sizer.ts
@@ -69,7 +69,7 @@ export function useCellSizer(
 
             return {
                 ...c,
-                width: biggest,
+                width: Math.min(500, biggest),
             };
         }) as SizedGridColumn[];
     }, [columns]);

--- a/packages/core/src/data-editor/use-cell-sizer.ts
+++ b/packages/core/src/data-editor/use-cell-sizer.ts
@@ -17,6 +17,12 @@ export function useCellSizer(
     getCellsForSelection: DataEditorProps["getCellsForSelection"],
     theme: Theme
 ): readonly SizedGridColumn[] {
+    const rowsRef = React.useRef(rows);
+    rowsRef.current = rows;
+    const getCellsForSelectionRef = React.useRef(getCellsForSelection);
+    getCellsForSelectionRef.current = getCellsForSelection;
+    const themeRef = React.useRef(theme);
+    themeRef.current = theme;
     return React.useMemo(() => {
         if (!columns.some(c => c.width === undefined)) {
             return columns as SizedGridColumn[];
@@ -37,13 +43,13 @@ export function useCellSizer(
             }) as SizedGridColumn[];
         }
 
-        ctx.font = `${theme.baseFontStyle} ${theme.fontFamily}`;
+        ctx.font = `${themeRef.current.baseFontStyle} ${themeRef.current.fontFamily}`;
 
-        const cells = getCellsForSelection?.({
+        const cells = getCellsForSelectionRef.current?.({
             x: 0,
             y: 0,
             width: columns.length,
-            height: Math.min(rows, 10),
+            height: Math.min(rowsRef.current, 10),
         });
 
         return columns.map((c, colIndex) => {
@@ -66,6 +72,5 @@ export function useCellSizer(
                 width: biggest,
             };
         }) as SizedGridColumn[];
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [columns]);
 }

--- a/packages/core/src/data-editor/use-cell-sizer.ts
+++ b/packages/core/src/data-editor/use-cell-sizer.ts
@@ -1,0 +1,71 @@
+import { GridCell, GridCellKind, GridColumn, SizedGridColumn } from "../data-grid/data-grid-types";
+import { DataEditorProps } from "./data-editor";
+import * as React from "react";
+import { CellRenderers } from "../data-grid/cells";
+import { Theme } from "../common/styles";
+
+function measureCell(ctx: CanvasRenderingContext2D, cell: GridCell): number {
+    if (cell.kind === GridCellKind.Custom) return 150;
+
+    const r = CellRenderers[cell.kind];
+    return r?.measure(ctx, cell) ?? 150;
+}
+
+export function useCellSizer(
+    columns: readonly GridColumn[],
+    rows: number,
+    getCellsForSelection: DataEditorProps["getCellsForSelection"],
+    theme: Theme
+): readonly SizedGridColumn[] {
+    return React.useMemo(() => {
+        if (!columns.some(c => c.width === undefined)) {
+            return columns as SizedGridColumn[];
+        }
+
+        const offscreen = document.createElement("canvas");
+        const ctx = offscreen.getContext("2d", {
+            alpha: false,
+        });
+        if (ctx === null) {
+            return columns.map(c => {
+                if (c.width !== undefined) return c;
+
+                return {
+                    ...c,
+                    width: 150,
+                };
+            }) as SizedGridColumn[];
+        }
+
+        ctx.font = `${theme.baseFontStyle} ${theme.fontFamily}`;
+
+        const cells = getCellsForSelection?.({
+            x: 0,
+            y: 0,
+            width: columns.length,
+            height: Math.min(rows, 10),
+        });
+
+        return columns.map((c, colIndex) => {
+            if (c.width !== undefined) return c;
+
+            if (cells === undefined) {
+                return {
+                    ...c,
+                    width: 150,
+                };
+            }
+
+            const sizes = cells.map(row => row[colIndex]).map(cell => measureCell(ctx, cell));
+            sizes.push(ctx.measureText(c.title).width + 16 + (c.icon === undefined ? 0 : 28));
+            const average = sizes.reduce((a, b) => a + b) / sizes.length;
+            const biggest = sizes.reduce((a, acc) => (a > average * 2 ? acc : Math.max(acc, a)));
+
+            return {
+                ...c,
+                width: biggest,
+            };
+        }) as SizedGridColumn[];
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [columns]);
+}

--- a/packages/core/src/data-editor/use-cell-sizer.ts
+++ b/packages/core/src/data-editor/use-cell-sizer.ts
@@ -1,8 +1,8 @@
-import { GridCell, GridCellKind, GridColumn, isSizedGridColumn, SizedGridColumn } from "../data-grid/data-grid-types";
-import { DataEditorProps } from "./data-editor";
 import * as React from "react";
-import { CellRenderers } from "../data-grid/cells";
 import { Theme } from "../common/styles";
+import { CellRenderers } from "../data-grid/cells";
+import { GridCell, GridCellKind, GridColumn, isSizedGridColumn, SizedGridColumn } from "../data-grid/data-grid-types";
+import type { DataEditorProps } from "./data-editor";
 
 const defaultSize = 150;
 

--- a/packages/core/src/data-grid/cells/boolean-cell.tsx
+++ b/packages/core/src/data-grid/cells/boolean-cell.tsx
@@ -8,6 +8,7 @@ export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
     needsHover: true,
     useLabel: false,
     needsHoverPosition: true,
+    measure: () => 50,
     render: a => drawBoolean(a, a.cell.data, a.cell.allowEdit),
     onDelete: c => ({
         ...c,

--- a/packages/core/src/data-grid/cells/bubble-cell.tsx
+++ b/packages/core/src/data-grid/cells/bubble-cell.tsx
@@ -11,6 +11,7 @@ export const bubbleCellRenderer: InternalCellRenderer<BubbleCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
+    measure: (ctx, cell) => cell.data.reduce((acc, data) => ctx.measureText(data).width + acc, 0) + 16,
     render: a => drawBubbles(a, a.cell.data),
     getEditor: () => p => {
         const { onKeyDown, value } = p;

--- a/packages/core/src/data-grid/cells/cell-types.ts
+++ b/packages/core/src/data-grid/cells/cell-types.ts
@@ -54,6 +54,7 @@ export interface InternalCellRenderer<T extends InnerGridCell> {
     readonly needsHover: boolean;
     readonly needsHoverPosition: boolean;
     readonly useLabel?: boolean;
+    readonly measure: (ctx: CanvasRenderingContext2D, cell: T) => number;
     readonly onClick?: (cell: T, posX: number, posY: number, bounds: Rectangle) => T | undefined;
     readonly onDelete?: (cell: T) => T | undefined;
     readonly getAccessibilityString: (cell: T) => string;

--- a/packages/core/src/data-grid/cells/drilldown-cell.tsx
+++ b/packages/core/src/data-grid/cells/drilldown-cell.tsx
@@ -11,6 +11,14 @@ export const drilldownCellRenderer: InternalCellRenderer<DrilldownCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
+    measure: (ctx, cell) => {
+        return (
+            cell.data.reduce(
+                (acc, data) => ctx.measureText(data.text).width + (data.img === undefined ? 0 : 20) + acc,
+                0
+            ) + 16
+        );
+    },
     render: a => drawDrilldownCell(a, a.cell.data),
     getEditor: () => p => {
         const { onKeyDown, value } = p;

--- a/packages/core/src/data-grid/cells/image-cell.tsx
+++ b/packages/core/src/data-grid/cells/image-cell.tsx
@@ -12,6 +12,7 @@ export const imageCellRenderer: InternalCellRenderer<ImageCell> = {
     useLabel: false,
     needsHoverPosition: false,
     render: a => drawImage(a, a.cell.displayData ?? a.cell.data),
+    measure: (_ctx, cell) => cell.data.length * 50,
     onDelete: c => ({
         ...c,
         data: [],

--- a/packages/core/src/data-grid/cells/loading-cell.tsx
+++ b/packages/core/src/data-grid/cells/loading-cell.tsx
@@ -7,5 +7,6 @@ export const loadingCellRenderer: InternalCellRenderer<LoadingCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
+    measure: () => 150,
     render: () => undefined,
 };

--- a/packages/core/src/data-grid/cells/markdown-cell.tsx
+++ b/packages/core/src/data-grid/cells/markdown-cell.tsx
@@ -11,6 +11,7 @@ export const markdownCellRenderer: InternalCellRenderer<MarkdownCell> = {
     needsHover: false,
     needsHoverPosition: false,
     renderPrep: prepTextCell,
+    measure: () => 200,
     render: a => drawTextCell(a, a.cell.data),
     onDelete: c => ({
         ...c,

--- a/packages/core/src/data-grid/cells/marker-cell.tsx
+++ b/packages/core/src/data-grid/cells/marker-cell.tsx
@@ -8,5 +8,6 @@ export const markerCellRenderer: InternalCellRenderer<MarkerCell> = {
     needsHover: true,
     needsHoverPosition: false,
     renderPrep: prepMarkerRowCell,
+    measure: () => 44,
     render: a => drawMarkerRowCell(a, a.cell.row, a.cell.checked, a.cell.markerKind),
 };

--- a/packages/core/src/data-grid/cells/new-row-cell.tsx
+++ b/packages/core/src/data-grid/cells/new-row-cell.tsx
@@ -7,5 +7,6 @@ export const newRowCellRenderer: InternalCellRenderer<NewRowCell> = {
     kind: InnerGridCellKind.NewRow,
     needsHover: true,
     needsHoverPosition: false,
+    measure: () => 200,
     render: a => drawNewRowCell(a, a.cell.hint, a.cell.icon),
 };

--- a/packages/core/src/data-grid/cells/number-cell.tsx
+++ b/packages/core/src/data-grid/cells/number-cell.tsx
@@ -13,6 +13,7 @@ export const numberCellRenderer: InternalCellRenderer<NumberCell> = {
     useLabel: true,
     renderPrep: prepTextCell,
     render: a => drawTextCell(a, a.cell.displayData),
+    measure: (ctx, cell) => ctx.measureText(cell.displayData).width + 16,
     onDelete: c => ({
         ...c,
         data: undefined,

--- a/packages/core/src/data-grid/cells/protected-cell.tsx
+++ b/packages/core/src/data-grid/cells/protected-cell.tsx
@@ -4,6 +4,7 @@ import { InternalCellRenderer } from "./cell-types";
 
 export const protectedCellRenderer: InternalCellRenderer<ProtectedCell> = {
     getAccessibilityString: () => "",
+    measure: () => 150,
     kind: GridCellKind.Protected,
     needsHover: false,
     needsHoverPosition: false,

--- a/packages/core/src/data-grid/cells/row-id-cell.tsx
+++ b/packages/core/src/data-grid/cells/row-id-cell.tsx
@@ -9,4 +9,5 @@ export const rowIDCellRenderer: InternalCellRenderer<RowIDCell> = {
     needsHoverPosition: false,
     renderPrep: a => prepTextCell(a, a.theme.textLight),
     render: a => drawTextCell(a, a.cell.data),
+    measure: (ctx, cell) => ctx.measureText(cell.data).width + 16,
 };

--- a/packages/core/src/data-grid/cells/text-cell.tsx
+++ b/packages/core/src/data-grid/cells/text-cell.tsx
@@ -13,6 +13,7 @@ export const textCellRenderer: InternalCellRenderer<TextCell> = {
     renderPrep: prepTextCell,
     useLabel: true,
     render: a => drawTextCell(a, a.cell.displayData),
+    measure: (ctx, cell) => ctx.measureText(cell.displayData).width + 16,
     onDelete: c => ({
         ...c,
         data: "",

--- a/packages/core/src/data-grid/cells/uri-cell.tsx
+++ b/packages/core/src/data-grid/cells/uri-cell.tsx
@@ -13,6 +13,7 @@ export const uriCellRenderer: InternalCellRenderer<UriCell> = {
     useLabel: true,
     renderPrep: prepTextCell,
     render: a => drawTextCell(a, a.cell.data),
+    measure: (ctx, cell) => ctx.measureText(cell.data).width + 16,
     onDelete: c => ({
         ...c,
         data: "",

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -1,15 +1,18 @@
 import { Theme } from "../common/styles";
-import { DrilldownCellData, GridColumn, Item, GridSelection, InnerGridCell } from "./data-grid-types";
+import { DrilldownCellData, Item, GridSelection, InnerGridCell, SizedGridColumn } from "./data-grid-types";
 import { degreesToRadians, direction } from "../common/utils";
 import React from "react";
 import { BaseDrawArgs } from "./cells/cell-types";
 
-export interface MappedGridColumn extends GridColumn {
+export interface MappedGridColumn extends SizedGridColumn {
     sourceIndex: number;
     sticky: boolean;
 }
 
-export function useMappedColumns(columns: readonly GridColumn[], freezeColumns: number): readonly MappedGridColumn[] {
+export function useMappedColumns(
+    columns: readonly SizedGridColumn[],
+    freezeColumns: number
+): readonly MappedGridColumn[] {
     return React.useMemo(
         () =>
             columns.map((c, i) => ({

--- a/packages/core/src/data-grid/data-grid-render.tsx
+++ b/packages/core/src/data-grid/data-grid-render.tsx
@@ -2,7 +2,6 @@ import ImageWindowLoader from "../common/image-window-loader";
 import type {
     GridSelection,
     DrawHeaderCallback,
-    GridColumn,
     InnerGridCell,
     Rectangle,
     CompactSelection,
@@ -11,6 +10,7 @@ import type {
     Item,
     CellList,
     GridMouseGroupHeaderEventArgs,
+    SizedGridColumn,
 } from "./data-grid-types";
 import { GridCellKind, isInnerOnlyCell } from "./data-grid-types";
 import { HoverValues } from "./animation-manager";
@@ -155,7 +155,7 @@ function blitLastFrame(
     rows: number,
     totalHeaderHeight: number,
     dpr: number,
-    columns: readonly GridColumn[],
+    columns: readonly SizedGridColumn[],
     effectiveCols: readonly MappedGridColumn[],
     getRowHeight: (r: number) => number
 ) {
@@ -1393,7 +1393,7 @@ export function drawGrid(
     cellYOffset: number,
     translateX: number,
     translateY: number,
-    columns: readonly GridColumn[],
+    columns: readonly SizedGridColumn[],
     mappedColumns: readonly MappedGridColumn[],
     enableGroups: boolean,
     freezeColumns: number,

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -147,8 +147,7 @@ export enum GridColumnIcon {
 
 export type Item = readonly [number, number];
 
-export interface GridColumn {
-    readonly width?: number;
+interface BaseGridColumn {
     readonly title: string;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
@@ -162,7 +161,22 @@ export interface GridColumn {
     };
 }
 
-export type SizedGridColumn = Omit<GridColumn, "width"> & { readonly width: number };
+export function isSizedGridColumn(c: GridColumn): c is SizedGridColumn {
+    return "width" in c;
+}
+
+export interface SizedGridColumn extends BaseGridColumn {
+    readonly width: number;
+    readonly id?: string;
+}
+
+interface AutoGridColumn extends BaseGridColumn {
+    readonly id: string;
+}
+
+export type GridColumn = SizedGridColumn | AutoGridColumn;
+
+// export type SizedGridColumn = Omit<GridColumn, "width"> & { readonly width: number };
 
 export type ReadWriteGridCell = TextCell | NumberCell | MarkdownCell | UriCell;
 

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -148,7 +148,7 @@ export enum GridColumnIcon {
 export type Item = readonly [number, number];
 
 export interface GridColumn {
-    readonly width: number;
+    readonly width?: number;
     readonly title: string;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
@@ -161,6 +161,8 @@ export interface GridColumn {
         readonly addIcon?: string;
     };
 }
+
+export type SizedGridColumn = Omit<GridColumn, "width"> & { readonly width: number };
 
 export type ReadWriteGridCell = TextCell | NumberCell | MarkdownCell | UriCell;
 

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -11,7 +11,6 @@ import {
     useMappedColumns,
 } from "./data-grid-lib";
 import {
-    GridColumn,
     GridCellKind,
     Rectangle,
     GridSelection,
@@ -25,6 +24,7 @@ import {
     CellList,
     Item,
     DrawHeaderCallback,
+    SizedGridColumn,
 } from "./data-grid-types";
 import { SpriteManager, SpriteMap } from "./data-grid-sprites";
 import { useDebouncedMemo, useEventListener } from "../common/utils";
@@ -61,7 +61,7 @@ export interface DataGridProps {
     readonly isResizing: boolean;
     readonly isDragging: boolean;
 
-    readonly columns: readonly GridColumn[];
+    readonly columns: readonly SizedGridColumn[];
     readonly rows: number;
 
     readonly headerHeight: number;

--- a/packages/source/src/use-data-source.test.tsx
+++ b/packages/source/src/use-data-source.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, test, expect } from "jest-without-globals";
 import { useDataSource } from "./index";
 import { Props } from "./types";
-import { GridCellKind, TextCell } from "@glideapps/glide-data-grid";
+import { GridCellKind, isSizedGridColumn, TextCell } from "@glideapps/glide-data-grid";
 
 const props: Props = {
     columns: [
@@ -75,7 +75,7 @@ const DataSourceMonkey = (p: Props) => {
             <ul data-testid="columns">
                 {columns.map(c => (
                     <li key={c.title}>
-                        Column {c.title} - {c.width}
+                        Column {c.title} - {isSizedGridColumn(c) ? c.width : "dynamic"}
                     </li>
                 ))}
             </ul>


### PR DESCRIPTION
fixes #181 

- [x] Test it works correctly when columns change.
- [x] Add unit tests because the type system isn't really checking the width is being correctly set OR find a way to make sure the type system does test that. (type system fixed)
- [x] Validate that GridColumns are not fed back out the API anywhere. They would need to be remapped to the source values passed by the user.
- [ ] ~~Make sure that if there is more space to give an a column wants it, we give it. Not sure if this is really possible yet because the auto-sizer would seemingly be kicking in after we size the columns... Tough one.~~
- [x] Make sure not to re-measure things which have been already measured if a column definition is changed (e.g. resizing)
- [x] Try to make it work well with 1,000 columns
- [x] Try to make it liveable with 10,000 columns
- [x] Try to make it not burn the computer to the ground with 100,000 columns
- [x] 1,000,000 columns better come with widths cuz that shit aint never gonne be liveable

One problem I have with this is it means every column must be iterated every time the columns change. This already happens in several other locations, but this iteration is not totally free either and too much of this will eventually limit the max number of columns we can support. The longer we go without that closing in on us the easier it will be to keep things fast as we add more features.