### PR TITLE
Add support for custom target column when adding rows

### DIFF
--- a/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/data-editor-beautiful.stories.tsx
@@ -678,6 +678,12 @@ const trailingRowOptionsColumnIndexesIcon: Record<number, string> = {
     5: GridColumnIcon.HeaderNumber,
 };
 
+const trailingRowOptionsColumnIndexesTarget: Record<number, number> = {
+    2: 0,
+    3: 0,
+    5: 0,
+};
+
 export const TrailingRowOptions: React.VFC = () => {
     const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
 
@@ -698,6 +704,7 @@ export const TrailingRowOptions: React.VFC = () => {
             trailingRowOptions: {
                 hint: trailingRowOptionsColumnIndexesHint[idx],
                 addIcon: trailingRowOptionsColumnIndexesIcon[idx],
+                targetColumn: trailingRowOptionsColumnIndexesTarget[idx],
             },
         }));
     }, [cols]);

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -26,6 +26,7 @@ import {
     GridMouseCellEventArgs,
     GridMouseHeaderEventArgs,
     GridMouseGroupHeaderEventArgs,
+    GridColumn,
 } from "../data-grid/data-grid-types";
 import DataGridSearch, { DataGridSearchProps } from "../data-grid-search/data-grid-search";
 import { browserIsOSX } from "../common/browser-detect";
@@ -123,7 +124,7 @@ export interface DataEditorProps extends Props {
         readonly hint?: string;
         readonly sticky?: boolean;
         readonly addIcon?: string;
-        readonly targetColumn?: number;
+        readonly targetColumn?: number | GridColumn;
     };
     readonly headerHeight?: number;
     readonly groupHeaderHeight?: number;
@@ -756,6 +757,29 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         [onRowAppended, rowMarkerOffset, rows, scrollTo, setGridSelection]
     );
 
+    const getCustomNewRowTargetColumn = React.useCallback(
+        (col: number): number | undefined => {
+            const customTargetColumn =
+                columns[col]?.trailingRowOptions?.targetColumn ?? trailingRowOptions?.targetColumn;
+
+            if (typeof customTargetColumn === "number") {
+                const customTargetOffset = hasRowMarkers ? 1 : 0;
+                return customTargetColumn + customTargetOffset;
+            }
+
+            if (typeof customTargetColumn === "object") {
+                const maybeIndex = columns.indexOf(customTargetColumn);
+                if (maybeIndex >= 0) {
+                    const customTargetOffset = hasRowMarkers ? 1 : 0;
+                    return maybeIndex + customTargetOffset;
+                }
+            }
+
+            return undefined;
+        },
+        [columns, hasRowMarkers, trailingRowOptions?.targetColumn]
+    );
+
     const lastSelectedRowRef = React.useRef<number>();
     const lastSelectedColRef = React.useRef<number>();
 
@@ -809,12 +833,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         lastSelectedRowRef.current = row;
                     }
                 } else if (col >= rowMarkerOffset && showTrailingBlankRow && row === rows) {
-                    const customTargetColumn =
-                        columns[col]?.trailingRowOptions?.targetColumn ?? trailingRowOptions?.targetColumn;
-                    const customTargetOffset = hasRowMarkers ? 1 : 0;
-                    const correctedCustomTargetColumn =
-                        customTargetColumn !== undefined ? customTargetColumn + customTargetOffset : undefined;
-                    void appendRow(correctedCustomTargetColumn ?? col);
+                    const customTargetColumn = getCustomNewRowTargetColumn(col);
+                    void appendRow(customTargetColumn ?? col);
                 } else {
                     if (gridSelection?.cell[0] !== col || gridSelection.cell[1] !== row) {
                         const isLastStickyRow = lastRowSticky && row === rows;
@@ -957,8 +977,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             selectedRows,
             rowSelectionMode,
             setSelectedRows,
-            columns,
-            trailingRowOptions?.targetColumn,
+            getCustomNewRowTargetColumn,
             appendRow,
             lastRowSticky,
             selectedColumns,
@@ -1514,12 +1533,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         row++;
                     } else if (row === rows && showTrailingBlankRow) {
                         window.setTimeout(() => {
-                            const customTargetColumn =
-                                columns[col]?.trailingRowOptions?.targetColumn ?? trailingRowOptions?.targetColumn;
-                            const customTargetOffset = hasRowMarkers ? 1 : 0;
-                            const correctedCustomTargetColumn =
-                                customTargetColumn !== undefined ? customTargetColumn + customTargetOffset : undefined;
-                            void appendRow(correctedCustomTargetColumn ?? col);
+                            const customTargetColumn = getCustomNewRowTargetColumn(col);
+                            void appendRow(customTargetColumn ?? col);
                         }, 0);
                     } else {
                         reselect(event.bounds);
@@ -1640,9 +1655,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             mangledOnCellEdited,
             rows,
             showTrailingBlankRow,
-            columns,
-            trailingRowOptions?.targetColumn,
-            hasRowMarkers,
+            getCustomNewRowTargetColumn,
             appendRow,
             reselect,
             getMangedCellContent,

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -123,6 +123,7 @@ export interface DataEditorProps extends Props {
         readonly hint?: string;
         readonly sticky?: boolean;
         readonly addIcon?: string;
+        readonly targetColumn?: number;
     };
     readonly headerHeight?: number;
     readonly groupHeaderHeight?: number;
@@ -808,7 +809,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         lastSelectedRowRef.current = row;
                     }
                 } else if (col >= rowMarkerOffset && showTrailingBlankRow && row === rows) {
-                    void appendRow(col);
+                    const customTargetColumn =
+                        columns[col]?.trailingRowOptions?.targetColumn ?? trailingRowOptions?.targetColumn;
+                    const customTargetOffset = hasRowMarkers ? 1 : 0;
+                    const correctedCustomTargetColumn =
+                        customTargetColumn !== undefined ? customTargetColumn + customTargetOffset : undefined;
+                    void appendRow(correctedCustomTargetColumn ?? col);
                 } else {
                     if (gridSelection?.cell[0] !== col || gridSelection.cell[1] !== row) {
                         const isLastStickyRow = lastRowSticky && row === rows;
@@ -951,6 +957,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             selectedRows,
             rowSelectionMode,
             setSelectedRows,
+            columns,
+            trailingRowOptions?.targetColumn,
             appendRow,
             lastRowSticky,
             selectedColumns,
@@ -1506,7 +1514,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         row++;
                     } else if (row === rows && showTrailingBlankRow) {
                         window.setTimeout(() => {
-                            void appendRow(col);
+                            const customTargetColumn =
+                                columns[col]?.trailingRowOptions?.targetColumn ?? trailingRowOptions?.targetColumn;
+                            const customTargetOffset = hasRowMarkers ? 1 : 0;
+                            const correctedCustomTargetColumn =
+                                customTargetColumn !== undefined ? customTargetColumn + customTargetOffset : undefined;
+                            void appendRow(correctedCustomTargetColumn ?? col);
                         }, 0);
                     } else {
                         reselect(event.bounds);
@@ -1627,6 +1640,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             mangledOnCellEdited,
             rows,
             showTrailingBlankRow,
+            columns,
+            trailingRowOptions?.targetColumn,
+            hasRowMarkers,
             appendRow,
             reselect,
             getMangedCellContent,

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -159,6 +159,7 @@ export interface GridColumn {
     readonly trailingRowOptions?: {
         readonly hint?: string;
         readonly addIcon?: string;
+        readonly targetColumn?: number;
     };
 }
 

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -159,7 +159,7 @@ export interface GridColumn {
     readonly trailingRowOptions?: {
         readonly hint?: string;
         readonly addIcon?: string;
-        readonly targetColumn?: number;
+        readonly targetColumn?: number | GridColumn;
     };
 }
 


### PR DESCRIPTION
Should close #180 

Supporting a GridColumn has a few drawbacks:
- The user has to think in references
- Self-referencing in the column-based `trailingRowOptions` is hard
- Doesn't really add functionality

But anyways, I don't think they hurt enough to remove it.