### PR TITLE
rowMarkerOffset for onCellActivated mouse clicks

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1211,7 +1211,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             }
                         }
                         if (col === selectedCol && col === prevCol && row === selectedRow && row === prevRow) {
-                            onCellActivated?.([col, row]);
+                            onCellActivated?.([col - rowMarkerOffset, row]);
                             reselect(a.bounds, false);
                             return true;
                         }


### PR DESCRIPTION
Keyboard activation already accounts for rowMarkerOffset; this fixes for mouse clicks