### PR TITLE
Fix resize cursor not displaying on hover

### DIFF
--- a/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
@@ -283,7 +283,7 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             isDragging={dragColActive}
             onItemHovered={onItemHoveredImpl}
             onMouseDown={onMouseDownImpl}
-            allowResize={onColumnResized !== undefined}
+            allowResize={onColumnResized !== undefined || onColumnResize !== undefined}
             onMouseUp={onMouseUpImpl}
             dragAndDropState={dragOffset}
             onMouseMoveRaw={onMouseMove}


### PR DESCRIPTION
This PR fixes the issue with `onColumnResize` not displaying the resize cursor on hovering the column edge. Closes #289.