### PR TITLE
fix function keys opening overlay

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2006,7 +2006,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     !event.metaKey &&
                     !event.ctrlKey &&
                     gridSelection.current !== undefined &&
-                    String.fromCharCode(event.keyCode).match(/(\w|\s)/g) &&
+                    event.key.match(/^(\w|\s)$/g) &&
                     event.bounds !== undefined &&
                     isReadWriteCell(getCellContent([col - rowMarkerOffset, Math.max(0, row - 1)]))
                 ) {
@@ -2016,11 +2016,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     ) {
                         return;
                     }
-                    let key = String.fromCharCode(event.keyCode);
-                    if (!event.shiftKey) {
-                        key = key.toLowerCase();
-                    }
-                    reselect(event.bounds, true, key);
+                    reselect(event.bounds, true, event.key);
                     event.cancel();
                 }
 


### PR DESCRIPTION
Fixes #296 

- instead of using `String.fromCharCode(event.keyCode)`, we use `event.key`.
- keyCode itself as a prop is deprecated https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
- to match against only alphanumeric and whitespace characters with `event.key` we also add start of line and end of line regex characters; otherwise 'f1' would match as it contains alphanumeric characters (but is not a single character itself)
- `event.key` also gives us capitalization of the character, so `event.shiftKey` is not necessary