### PR TITLE
Fix scroll issue with overlay editor

### DIFF
--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor-style.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor-style.tsx
@@ -54,7 +54,6 @@ export const DataGridOverlayEditorStyle = styled.div<Props>`
         overflow-y: auto;
         overflow-x: hidden;
         border-radius: 2px;
-        overflow: hidden;
         flex-grow: 1;
 
         ${GrowingEntryStyle} {


### PR DESCRIPTION
At the moment, the overlay editor is not scrollable in case the content is too large. The reason is that the `overflow-y: auto` of the `clip-region` which should enable scrolling is overwritten by a redundant `overflow: hidden` property.