### PR TITLE
Fix issue with missing cjs dist in beta release action

### DIFF
--- a/.github/workflows/beta.js.yml
+++ b/.github/workflows/beta.js.yml
@@ -24,6 +24,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:
@@ -46,6 +47,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:
@@ -68,6 +70,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:


### PR DESCRIPTION
The issue with the missing cjs distribution (https://github.com/glideapps/glide-data-grid/issues/299) also exists in the beta release action.