### PR TITLE
Support indeterminate and empty states for boolean cell

### DIFF
--- a/.github/workflows/beta.js.yml
+++ b/.github/workflows/beta.js.yml
@@ -24,6 +24,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:
@@ -46,6 +47,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:
@@ -68,6 +70,7 @@ jobs:
               working-directory: .
             - run: npm run lint
             - run: npm run build-js
+            - run: npm run build-cjs
             - run: npm run build-types
             - uses: JS-DevTools/npm-publish@v1
               with:

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -1084,7 +1084,9 @@ describe("data-editor", () => {
         const canvas = screen.getByTestId("data-grid-canvas");
 
         // We need to be focused on the grid for booleans to toggle automatically
-        ref.current?.focus();
+        act(() => {
+            ref.current?.focus();
+        });
 
         // [7, 0] is a checked boolean
         const [checkedX, checkedY] = getCellCenterPositionForDefaultGrid([7, 0]);

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -1118,7 +1118,7 @@ describe("data-editor", () => {
         fireEvent.mouseDown(canvas, { clientX: emptyX, clientY: emptyY });
         fireEvent.mouseUp(canvas, { clientX: emptyX, clientY: emptyY });
 
-        expect(spy).not.toBeCalledWith([7, 3], expect.anything());
+        expect(spy).toBeCalledWith([7, 3], expect.objectContaining({ data: true }));
     });
 
     test("Arrow left", async () => {

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -12,6 +12,7 @@ import {
     Item,
 } from "..";
 import { DataEditorRef } from "./data-editor";
+import { SizedGridColumn } from "../data-grid/data-grid-types";
 
 jest.mock("react-virtualized-auto-sizer", () => {
     return {
@@ -20,6 +21,11 @@ jest.mock("react-virtualized-auto-sizer", () => {
         foo: "mocked foo",
     };
 });
+
+const BOOLEAN_DATA_LOOKUP: (boolean | null | undefined)[] = [true, false, undefined, null];
+function getMockBooleanData(row: number): boolean | null | undefined {
+    return BOOLEAN_DATA_LOOKUP[row % BOOLEAN_DATA_LOOKUP.length];
+}
 
 const makeCell = (cell: Item): GridCell => {
     const [col, row] = cell;
@@ -62,7 +68,7 @@ const makeCell = (cell: Item): GridCell => {
         return {
             kind: GridCellKind.Boolean,
             allowOverlay: false,
-            data: row % 2 === 0,
+            data: getMockBooleanData(row),
             allowEdit: true,
             showUnchecked: true,
         };
@@ -87,6 +93,7 @@ const makeCell = (cell: Item): GridCell => {
         displayData: `${col}, ${row}`,
     };
 };
+
 const basicProps: DataEditorProps = {
     columns: [
         {
@@ -153,6 +160,18 @@ const basicProps: DataEditorProps = {
     },
     rows: 1000,
 };
+
+function getCellCenterPositionForDefaultGrid(cell: Item): [number, number] {
+    const [col, row] = cell;
+
+    const xStart = basicProps.columns.slice(0, col).reduce((acc, curr) => acc + (curr as SizedGridColumn).width, 0);
+    const xOffset = (basicProps.columns[col] as SizedGridColumn).width / 2;
+
+    const yStart = (basicProps.headerHeight as number) + row * (basicProps.rowHeight as number);
+    const yOffset = (basicProps.rowHeight as number) / 2;
+
+    return [xStart + xOffset, yStart + yOffset];
+}
 
 beforeEach(() => {
     Element.prototype.scrollTo = jest.fn();
@@ -1051,6 +1070,53 @@ describe("data-editor", () => {
 
         expect(spy).toBeCalledWith([1, 1], expect.objectContaining({ data: "j" }));
         expect(overlay).not.toBeInTheDocument();
+    });
+
+    test("Directly toggle booleans", async () => {
+        const spy = jest.fn();
+        jest.useFakeTimers();
+        const ref = React.createRef<DataEditorRef>();
+        render(<DataEditor {...basicProps} onCellEdited={spy} ref={ref} />, {
+            wrapper: Context,
+        });
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        // We need to be focused on the grid for booleans to toggle automatically
+        ref.current?.focus(true);
+
+        // [7, 0] is a checked boolean
+        const [checkedX, checkedY] = getCellCenterPositionForDefaultGrid([7, 0]);
+
+        fireEvent.mouseDown(canvas, { clientX: checkedX, clientY: checkedY });
+        fireEvent.mouseUp(canvas, { clientX: checkedX, clientY: checkedY });
+
+        expect(spy).toBeCalledWith([7, 0], expect.objectContaining({ data: false }));
+
+        // [7, 1] is an unchecked boolean
+        const [uncheckedX, uncheckedY] = getCellCenterPositionForDefaultGrid([7, 1]);
+
+        fireEvent.mouseDown(canvas, { clientX: uncheckedX, clientY: uncheckedY });
+        fireEvent.mouseUp(canvas, { clientX: uncheckedX, clientY: uncheckedY });
+
+        expect(spy).toBeCalledWith([7, 1], expect.objectContaining({ data: true }));
+
+        // [7, 2] is an indeterminate boolean
+        const [indeterminateX, indeterminateY] = getCellCenterPositionForDefaultGrid([7, 2]);
+
+        fireEvent.mouseDown(canvas, { clientX: indeterminateX, clientY: indeterminateY });
+        fireEvent.mouseUp(canvas, { clientX: indeterminateX, clientY: indeterminateY });
+
+        expect(spy).toBeCalledWith([7, 2], expect.objectContaining({ data: true }));
+
+        // [7, 3] is an empty boolean
+        const [emptyX, emptyY] = getCellCenterPositionForDefaultGrid([7, 3]);
+
+        fireEvent.mouseDown(canvas, { clientX: emptyX, clientY: emptyY });
+        fireEvent.mouseUp(canvas, { clientX: emptyX, clientY: emptyY });
+
+        expect(spy).not.toBeCalledWith([7, 3], expect.anything());
     });
 
     test("Arrow left", async () => {
@@ -2746,28 +2812,6 @@ describe("data-editor", () => {
                 current: expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: cols, height: 1000 } }),
             })
         );
-
-        // spy.mockClear();
-        // fireEvent.keyDown(canvas, {
-        //     key: "ArrowUp",
-        //     ctrlKey: true,
-        //     shiftKey: true,
-        // });
-
-        // expect(spy).toBeCalledWith(
-        //     expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: cols, height: 1 } })
-        // );
-
-        // spy.mockClear();
-        // fireEvent.keyDown(canvas, {
-        //     key: "ArrowLeft",
-        //     ctrlKey: true,
-        //     shiftKey: true,
-        // });
-
-        // expect(spy).toBeCalledWith(
-        //     expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: 1, height: 1 } })
-        // );
     });
 
     test("Select range with mouse going out of bounds", async () => {

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -1084,7 +1084,7 @@ describe("data-editor", () => {
         const canvas = screen.getByTestId("data-grid-canvas");
 
         // We need to be focused on the grid for booleans to toggle automatically
-        ref.current?.focus(true);
+        ref.current?.focus();
 
         // [7, 0] is a checked boolean
         const [checkedX, checkedY] = getCellCenterPositionForDefaultGrid([7, 0]);

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -274,7 +274,7 @@ export interface DataEditorProps extends Props {
 export interface DataEditorRef {
     updateCells: DataGridRef["damage"];
     getBounds: DataGridRef["getBounds"];
-    focus: (immediate?: boolean) => void;
+    focus: DataGridRef["focus"];
     emit: (eventName: EmitEvents) => Promise<void>;
     scrollTo: (
         col: number,
@@ -2400,7 +2400,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 return gridRef.current?.damage(damageList);
             },
             getBounds: (...args) => gridRef.current?.getBounds(...args),
-            focus,
+            focus: () => gridRef.current?.focus(),
             emit: async e => {
                 switch (e) {
                     case "delete":
@@ -2449,7 +2449,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             },
             scrollTo,
         }),
-        [focus, onCopy, onKeyDown, onPasteInternal, rowMarkerOffset, scrollTo]
+        [onCopy, onKeyDown, onPasteInternal, rowMarkerOffset, scrollTo]
     );
 
     const [selCol, selRow] = currentCell ?? [];

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -49,6 +49,7 @@ import { SelectionBlending, useSelectionBehavior } from "../data-grid/use-select
 import { useCellsForSelection } from "./use-cells-for-selection";
 import { unquote, expandSelection, copyToClipboard } from "./data-editors-fns";
 import { DataEditorContainer } from "../data-editor-container/data-grid-container";
+import { toggleBoolean } from "../data-grid/cells/boolean-cell";
 
 let idCounter = 0;
 
@@ -273,6 +274,7 @@ export interface DataEditorProps extends Props {
 export interface DataEditorRef {
     updateCells: DataGridRef["damage"];
     getBounds: DataGridRef["getBounds"];
+    focus: (immediate?: boolean) => void;
     emit: (eventName: EmitEvents) => Promise<void>;
     scrollTo: (
         col: number,
@@ -728,7 +730,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             } else if (c.kind === GridCellKind.Boolean && fromKeyboard) {
                 mangledOnCellEdited(gridSelection.current.cell, {
                     ...c,
-                    data: !c.data,
+                    data: toggleBoolean(c.data),
                 });
                 gridRef.current?.damage([{ cell: gridSelection.current.cell }]);
             }
@@ -2398,6 +2400,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 return gridRef.current?.damage(damageList);
             },
             getBounds: (...args) => gridRef.current?.getBounds(...args),
+            focus,
             emit: async e => {
                 switch (e) {
                     case "delete":
@@ -2446,7 +2449,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             },
             scrollTo,
         }),
-        [onCopy, onKeyDown, onPasteInternal, rowMarkerOffset, scrollTo]
+        [focus, onCopy, onKeyDown, onPasteInternal, rowMarkerOffset, scrollTo]
     );
 
     const [selCol, selRow] = currentCell ?? [];

--- a/packages/core/src/data-editor/data-editors-fns.ts
+++ b/packages/core/src/data-editor/data-editors-fns.ts
@@ -1,6 +1,6 @@
 import { assertNever } from "../common/support";
 import { DataGridSearchProps } from "../data-grid-search/data-grid-search";
-import { GridCell, GridCellKind, GridSelection, Rectangle } from "../data-grid/data-grid-types";
+import { BooleanEmpty, BooleanIndeterminate, GridCell, GridCellKind, GridSelection, Rectangle } from "../data-grid/data-grid-types";
 
 export function expandSelection(
     newVal: GridSelection,
@@ -173,7 +173,7 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
         return str;
     }
 
-    const formatBoolean = (val: boolean | null | undefined): string => {
+    const formatBoolean = (val: boolean | BooleanEmpty | BooleanIndeterminate): string => {
         switch (val) {
             case true:
                 return "TRUE";
@@ -181,10 +181,10 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
             case false:
                 return "FALSE";
 
-            case undefined:
+            case BooleanIndeterminate:
                 return "INDETERMINATE";
 
-            case null:
+            case BooleanEmpty:
                 return "";
 
             default:

--- a/packages/core/src/data-editor/data-editors-fns.ts
+++ b/packages/core/src/data-editor/data-editors-fns.ts
@@ -185,7 +185,7 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
                 return "INDETERMINATE";
 
             case null:
-                return "EMPTY";
+                return "";
 
             default:
                 assertNever(val);

--- a/packages/core/src/data-editor/data-editors-fns.ts
+++ b/packages/core/src/data-editor/data-editors-fns.ts
@@ -173,6 +173,25 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
         return str;
     }
 
+    const formatBoolean = (val: boolean | null | undefined): string => {
+        switch (val) {
+            case true:
+                return "TRUE";
+
+            case false:
+                return "FALSE";
+
+            case undefined:
+                return "INDETERMINATE";
+
+            case null:
+                return "EMPTY";
+
+            default:
+                assertNever(val);
+        }
+    };
+
     const formatCell = (cell: GridCell, index: number): string => {
         const colIndex = columnIndexes[index];
         if (cell.span !== undefined && cell.span[0] !== colIndex) return "";
@@ -188,7 +207,7 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
             case GridCellKind.Bubble:
                 return cell.data.reduce((pv, cv) => `${escape(pv)},${escape(cv)}`);
             case GridCellKind.Boolean:
-                return cell.data ? "TRUE" : "FALSE";
+                return formatBoolean(cell.data);
             case GridCellKind.Loading:
                 return "#LOADING";
             case GridCellKind.Protected:

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -1187,7 +1187,8 @@ function getColumnsForCellTypes(): GridColumnWithMockingInfo[] {
             icon: GridColumnIcon.HeaderBoolean,
             hasMenu: false,
             getContent: () => {
-                const checked = Math.random() > 0.5;
+                const roll = Math.random();
+                const checked = roll < 0.1 ? undefined : roll < 0.2 ? null : roll < 0.6;
                 // TODO: Make editable. UX looks bad by default.
                 return {
                     kind: GridCellKind.Boolean,

--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -642,7 +642,7 @@ export function MarkdownEdits() {
 }
 
 export const CanEditBoolean = () => {
-    const [vals, setVals] = useState<[boolean, boolean]>([false, false]);
+    const [vals, setVals] = useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
     return (
         <DataEditor
             width="100%"

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -142,7 +142,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                                 testString = cell.data;
                                 break;
                             case GridCellKind.Boolean:
-                                testString = cell.data.toString();
+                                testString = typeof cell.data === "boolean" ? cell.data.toString() : undefined;
                                 break;
                             case GridCellKind.Image:
                             case GridCellKind.Bubble:

--- a/packages/core/src/data-grid/cells/boolean-cell.tsx
+++ b/packages/core/src/data-grid/cells/boolean-cell.tsx
@@ -8,7 +8,7 @@ import { InternalCellRenderer } from "./cell-types";
  * true + click -> unchecked
  * false + click -> checked
  * indeterminate + click -> checked
- * empty + click -> empty
+ * empty + click -> checked
  */
 export function toggleBoolean(data: boolean | null | undefined): boolean | null | undefined {
     return data !== true;

--- a/packages/core/src/data-grid/cells/boolean-cell.tsx
+++ b/packages/core/src/data-grid/cells/boolean-cell.tsx
@@ -1,6 +1,30 @@
+import { assertNever } from "../../common/support";
 import { drawBoolean } from "../data-grid-lib";
 import { GridCellKind, BooleanCell } from "../data-grid-types";
 import { InternalCellRenderer } from "./cell-types";
+
+/**
+ * Checkbox behavior:
+ *
+ * true + click -> unchecked
+ * false + click -> checked
+ * indeterminate + click -> checked
+ * empty + click -> empty
+ */
+export function toggleBoolean(data: boolean | null | undefined): boolean | null | undefined {
+    switch (data) {
+        case true:
+            return false;
+        case false:
+            return true;
+        case undefined:
+            return true;
+        case null:
+            return null;
+        default:
+            assertNever(data);
+    }
+}
 
 export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
     getAccessibilityString: c => c.data?.toString() ?? "false",
@@ -15,10 +39,15 @@ export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
         data: false,
     }),
     onClick: (cell, x, y, bounds) => {
-        if (cell.allowEdit && Math.abs(x - bounds.width / 2) <= 10 && Math.abs(y - bounds.height / 2) <= 10) {
+        if (
+            cell.allowEdit &&
+            cell.data !== null &&
+            Math.abs(x - bounds.width / 2) <= 10 &&
+            Math.abs(y - bounds.height / 2) <= 10
+        ) {
             return {
                 ...cell,
-                data: !cell.data,
+                data: toggleBoolean(cell.data),
             };
         }
         return undefined;

--- a/packages/core/src/data-grid/cells/boolean-cell.tsx
+++ b/packages/core/src/data-grid/cells/boolean-cell.tsx
@@ -1,4 +1,3 @@
-import { assertNever } from "../../common/support";
 import { drawBoolean } from "../data-grid-lib";
 import { GridCellKind, BooleanCell } from "../data-grid-types";
 import { InternalCellRenderer } from "./cell-types";
@@ -12,18 +11,7 @@ import { InternalCellRenderer } from "./cell-types";
  * empty + click -> empty
  */
 export function toggleBoolean(data: boolean | null | undefined): boolean | null | undefined {
-    switch (data) {
-        case true:
-            return false;
-        case false:
-            return true;
-        case undefined:
-            return true;
-        case null:
-            return null;
-        default:
-            assertNever(data);
-    }
+    return data !== true;
 }
 
 export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
@@ -39,12 +27,7 @@ export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
         data: false,
     }),
     onClick: (cell, x, y, bounds) => {
-        if (
-            cell.allowEdit &&
-            cell.data !== null &&
-            Math.abs(x - bounds.width / 2) <= 10 &&
-            Math.abs(y - bounds.height / 2) <= 10
-        ) {
+        if (cell.allowEdit && Math.abs(x - bounds.width / 2) <= 10 && Math.abs(y - bounds.height / 2) <= 10) {
             return {
                 ...cell,
                 data: toggleBoolean(cell.data),

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -364,7 +364,7 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
 function drawCheckbox(
     ctx: CanvasRenderingContext2D,
     theme: Theme,
-    checked: boolean | undefined,
+    checked: boolean | null | undefined,
     x: number,
     y: number,
     width: number,
@@ -399,6 +399,7 @@ function drawCheckbox(
             break;
         }
 
+        case null:
         case false: {
             ctx.beginPath();
             roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
@@ -538,15 +539,15 @@ function roundedRect(
 }
 
 export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined, canEdit: boolean) {
-    if (data === null) {
-        return;
-    }
-
     const { ctx, hoverAmount, theme, x, y, w, h, highlighted, hoverX, hoverY } = args;
 
     const hoverEffect = 0.35;
 
-    ctx.globalAlpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.6;
+    let alpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.4;
+    if (canEdit && data === null) {
+        alpha *= hoverAmount;
+    }
+    ctx.globalAlpha = alpha;
 
     drawCheckbox(ctx, theme, data, x, y, w, h, highlighted, hoverX, hoverY);
 

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -548,7 +548,7 @@ export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined
     const hoverEffect = 0.35;
 
     let alpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.4;
-    if (canEdit && data === null) {
+    if (data === null) {
         alpha *= hoverAmount;
     }
     ctx.globalAlpha = alpha;

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -3,6 +3,7 @@ import { DrilldownCellData, Item, GridSelection, InnerGridCell, SizedGridColumn,
 import { degreesToRadians, direction } from "../common/utils";
 import React from "react";
 import { BaseDrawArgs, PrepResult } from "./cells/cell-types";
+import { assertNever } from "../common/support";
 
 export interface MappedGridColumn extends SizedGridColumn {
     sourceIndex: number;
@@ -363,7 +364,7 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
 function drawCheckbox(
     ctx: CanvasRenderingContext2D,
     theme: Theme,
-    checked: boolean,
+    checked: boolean | undefined,
     x: number,
     y: number,
     width: number,
@@ -377,30 +378,56 @@ function drawCheckbox(
 
     const hovered = Math.abs(hoverX - width / 2) < 10 && Math.abs(hoverY - height / 2) < 10;
 
-    if (checked) {
-        ctx.beginPath();
-        roundedRect(ctx, centerX - 9, centerY - 9, 18, 18, 4);
+    switch (checked) {
+        case true: {
+            ctx.beginPath();
+            roundedRect(ctx, centerX - 9, centerY - 9, 18, 18, 4);
 
-        ctx.fillStyle = highlighted ? theme.accentColor : theme.textLight;
-        ctx.fill();
+            ctx.fillStyle = highlighted ? theme.accentColor : theme.textMedium;
+            ctx.fill();
 
-        ctx.beginPath();
-        ctx.moveTo(centerX - 8 + 3.65005, centerY - 8 + 7.84995);
-        ctx.lineTo(centerX - 8 + 6.37587, centerY - 8 + 10.7304);
-        ctx.lineTo(centerX - 8 + 11.9999, centerY - 8 + 4.74995);
+            ctx.beginPath();
+            ctx.moveTo(centerX - 8 + 3.65005, centerY - 8 + 7.84995);
+            ctx.lineTo(centerX - 8 + 6.37587, centerY - 8 + 10.7304);
+            ctx.lineTo(centerX - 8 + 11.9999, centerY - 8 + 4.74995);
 
-        ctx.strokeStyle = theme.accentFg;
-        ctx.lineJoin = "round";
-        ctx.lineCap = "round";
-        ctx.lineWidth = 1.9;
-        ctx.stroke();
-    } else {
-        ctx.beginPath();
-        roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
+            ctx.strokeStyle = theme.bgCell;
+            ctx.lineJoin = "round";
+            ctx.lineCap = "round";
+            ctx.lineWidth = 1.9;
+            ctx.stroke();
+            break;
+        }
 
-        ctx.lineWidth = 1;
-        ctx.strokeStyle = hovered ? theme.textMedium : theme.textLight;
-        ctx.stroke();
+        case false: {
+            ctx.beginPath();
+            roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
+
+            ctx.lineWidth = 1;
+            ctx.strokeStyle = hovered ? theme.textDark : theme.textMedium;
+            ctx.stroke();
+            break;
+        }
+
+        case undefined: {
+            ctx.beginPath();
+            roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
+
+            ctx.fillStyle = hovered ? theme.textMedium : theme.textLight;
+            ctx.fill();
+
+            ctx.beginPath();
+            ctx.moveTo(centerX - 4, centerY);
+            ctx.lineTo(centerX + 4, centerY);
+            ctx.strokeStyle = theme.bgCell;
+            ctx.lineCap = "round";
+            ctx.lineWidth = 1.9;
+            ctx.stroke();
+            break;
+        }
+
+        default:
+            assertNever(checked);
     }
 }
 
@@ -435,7 +462,7 @@ export function drawMarkerRowCell(
         ctx.globalAlpha = 1;
     }
     if (markerKind === "number" || (markerKind === "both" && !checked)) {
-        const text = (index).toString();
+        const text = index.toString();
 
         const start = x + width / 2;
         if (markerKind === "both" && hoverAmount !== 0) {
@@ -510,11 +537,16 @@ function roundedRect(
     ctx.arcTo(x, y, x + radius.tl, y, radius.tl);
 }
 
-export function drawBoolean(args: BaseDrawArgs, data: boolean, canEdit: boolean) {
+export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined, canEdit: boolean) {
+    if (data === null) {
+        return;
+    }
+
     const { ctx, hoverAmount, theme, x, y, w, h, highlighted, hoverX, hoverY } = args;
+
     const hoverEffect = 0.35;
 
-    ctx.globalAlpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.4;
+    ctx.globalAlpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.6;
 
     drawCheckbox(ctx, theme, data, x, y, w, h, highlighted, hoverX, hoverY);
 

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -539,6 +539,10 @@ function roundedRect(
 }
 
 export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined, canEdit: boolean) {
+    if (!canEdit && data === null) {
+        return;
+    }
+
     const { ctx, hoverAmount, theme, x, y, w, h, highlighted, hoverX, hoverY } = args;
 
     const hoverEffect = 0.35;

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -551,6 +551,9 @@ export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined
     if (data === null) {
         alpha *= hoverAmount;
     }
+    if (alpha === 0) {
+        return;
+    }
     ctx.globalAlpha = alpha;
 
     drawCheckbox(ctx, theme, data, x, y, w, h, highlighted, hoverX, hoverY);

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -1,5 +1,5 @@
 import { Theme } from "../common/styles";
-import { DrilldownCellData, Item, GridSelection, InnerGridCell, SizedGridColumn, Rectangle } from "./data-grid-types";
+import { DrilldownCellData, Item, GridSelection, InnerGridCell, SizedGridColumn, Rectangle, BooleanEmpty, BooleanIndeterminate } from "./data-grid-types";
 import { degreesToRadians, direction } from "../common/utils";
 import React from "react";
 import { BaseDrawArgs, PrepResult } from "./cells/cell-types";
@@ -364,7 +364,7 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
 function drawCheckbox(
     ctx: CanvasRenderingContext2D,
     theme: Theme,
-    checked: boolean | null | undefined,
+    checked: boolean | BooleanEmpty | BooleanIndeterminate,
     x: number,
     y: number,
     width: number,
@@ -399,7 +399,7 @@ function drawCheckbox(
             break;
         }
 
-        case null:
+        case BooleanEmpty:
         case false: {
             ctx.beginPath();
             roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
@@ -410,7 +410,7 @@ function drawCheckbox(
             break;
         }
 
-        case undefined: {
+        case BooleanIndeterminate: {
             ctx.beginPath();
             roundedRect(ctx, centerX - 8.5, centerY - 8.5, 17, 17, 4);
 
@@ -538,8 +538,8 @@ function roundedRect(
     ctx.arcTo(x, y, x + radius.tl, y, radius.tl);
 }
 
-export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined, canEdit: boolean) {
-    if (!canEdit && data === null) {
+export function drawBoolean(args: BaseDrawArgs, data: boolean | BooleanEmpty | BooleanIndeterminate, canEdit: boolean) {
+    if (!canEdit && data === BooleanEmpty) {
         return;
     }
 
@@ -548,7 +548,7 @@ export function drawBoolean(args: BaseDrawArgs, data: boolean | null | undefined
     const hoverEffect = 0.35;
 
     let alpha = canEdit ? 1 - hoverEffect + hoverEffect * hoverAmount : 0.4;
-    if (data === null) {
+    if (data === BooleanEmpty) {
         alpha *= hoverAmount;
     }
     if (alpha === 0) {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -35,6 +35,12 @@ export interface HeaderClickedEventArgs extends GridMouseHeaderEventArgs, Preven
 
 export interface GroupHeaderClickedEventArgs extends GridMouseGroupHeaderEventArgs, PreventableEvent {}
 
+export const BooleanEmpty = null;
+export const BooleanIndeterminate = undefined;
+
+export type BooleanEmpty = null;
+export type BooleanIndeterminate = undefined;
+
 interface PositionableMouseEventArgs {
     readonly localEventX: number;
     readonly localEventY: number;
@@ -387,11 +393,7 @@ export interface DrilldownCell extends BaseGridCell {
 
 export interface BooleanCell extends BaseGridCell {
     readonly kind: GridCellKind.Boolean;
-    // true -> checked
-    // false -> unchecked
-    // undefined -> indeterminate
-    // null -> empty
-    readonly data: boolean | null | undefined;
+    readonly data: boolean | BooleanEmpty | BooleanIndeterminate;
     readonly showUnchecked: boolean;
     readonly allowEdit: boolean;
     readonly allowOverlay: false;

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -387,7 +387,11 @@ export interface DrilldownCell extends BaseGridCell {
 
 export interface BooleanCell extends BaseGridCell {
     readonly kind: GridCellKind.Boolean;
-    readonly data: boolean;
+    // true -> checked
+    // false -> unchecked
+    // undefined -> indeterminate
+    // null -> empty
+    readonly data: boolean | null | undefined;
     readonly showUnchecked: boolean;
     readonly allowEdit: boolean;
     readonly allowOverlay: false;


### PR DESCRIPTION
Should close #309 

New styles look like:

<img width="136" alt="image" src="https://user-images.githubusercontent.com/18490534/166056786-fc45a2f6-4bd7-4ec5-8b37-7662ceec1cbf.png">

Bonus:
I added a `focus` imperative handle for the DataEditor that just forwards to DataGrid
