### PR TITLE
Remove showUnchecked property from boolean cell

### DIFF
--- a/packages/core/src/data-editor/data-editor-input.test.tsx
+++ b/packages/core/src/data-editor/data-editor-input.test.tsx
@@ -56,7 +56,6 @@ const makeCell = (cell: Item): GridCell => {
             allowOverlay: false,
             data: row % 2 === 0,
             allowEdit: true,
-            showUnchecked: true,
         };
     } else if (col === 8) {
         return {

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -64,7 +64,6 @@ const makeCell = (cell: Item): GridCell => {
             allowOverlay: false,
             data: row % 2 === 0,
             allowEdit: true,
-            showUnchecked: true,
         };
     } else if (col === 8) {
         return {

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -1193,7 +1193,6 @@ function getColumnsForCellTypes(): GridColumnWithMockingInfo[] {
                     kind: GridCellKind.Boolean,
                     data: checked,
                     allowOverlay: false,
-                    showUnchecked: true,
                     allowEdit: true,
                 };
             },

--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -109,7 +109,6 @@ And supports newline chars and automatic wrapping text that just needs to be lon
         return {
             kind: GridCellKind.Boolean,
             data: row % 3 === 0 || row % 5 === 0,
-            showUnchecked: true,
             allowEdit: false,
             allowOverlay: false,
         };
@@ -663,7 +662,6 @@ export const CanEditBoolean = () => {
                     allowEdit: col === 0,
                     allowOverlay: false,
                     data: vals[col],
-                    showUnchecked: true,
                 };
             }}
             onCellEdited={([col], newVal) => {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -388,7 +388,6 @@ export interface DrilldownCell extends BaseGridCell {
 export interface BooleanCell extends BaseGridCell {
     readonly kind: GridCellKind.Boolean;
     readonly data: boolean;
-    readonly showUnchecked: boolean;
     readonly allowEdit: boolean;
     readonly allowOverlay: false;
 }


### PR DESCRIPTION
Should close #308 

Not sure why that property is there, but it's not used anywhere.

Also, is this a breaking change? TS users will get errors (albeit trivially solved) but there are no behavior changes 🤔 