### PR TITLE
Fix outlier removal in column sizer

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -137,7 +137,7 @@ export function useColumnSizer(
                 // Filter out outliers
                 sizes = sizes.filter(a => a < average * 2);
             }
-            const biggest = sizes.reduce((a, acc) => Math.max(acc, a));
+            const biggest = Math.max(...sizes);
             
             const final = Math.max(minColumnWidth, Math.min(maxColumnWidth, Math.ceil(biggest)));
             memoMap.current[c.id] = final;

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -133,8 +133,12 @@ export function useColumnSizer(
             }
             sizes.push(ctx.measureText(c.title).width + 16 + (c.icon === undefined ? 0 : 28));
             const average = sizes.reduce((a, b) => a + b) / sizes.length;
-            const biggest = sizes.reduce((a, acc) => (a > average * 2 ? acc : Math.max(acc, a)));
-
+            if (sizes.length > 5) {
+                // Filter out outliers
+                sizes = sizes.filter(a => a < average * 2);
+            }
+            const biggest = sizes.reduce((a, acc) => Math.max(acc, a));
+            
             const final = Math.max(minColumnWidth, Math.min(maxColumnWidth, Math.ceil(biggest)));
             memoMap.current[c.id] = final;
 


### PR DESCRIPTION
The outlier removal in the column sizer does not work correctly. For example:

```javascript
var sizes = [16, 150, 10, 8]
const average = sizes.reduce((a, b) => a + b) / sizes.length;
const biggest = sizes.reduce((a, acc) => (a > average * 2 ? acc : Math.max(acc, a)));

# average: 46
# biggest: 10
```

The reduce function does not select the maximum of all sizes without the outliers. To fix it, I propose to use a `filter` for the outliers before applying `reduce` to determine the biggest size. I think the outlier removal is not super useful for tables that only contain very few items. Therefore, I added a check to only apply it if there are at least 5 sizes available.

Closes #312