### PR TITLE
allow custom editors to cancel editing

### DIFF
--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -60,7 +60,6 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
 
     const onCustomFinishedEditing = React.useCallback(
         (newValue: GridCell | undefined) => {
-            newValue = newValue ?? tempValue;
             onFinishEditing(newValue, customMotion.current ?? [0, 0]);
             finished.current = true;
         },


### PR DESCRIPTION
Trying to implement on a custom editor, pressing "Escape" should close overlay editor and not modify the underlying cell value.

Issue is when you have an initialValue and forceEditMode=true, `onFinishEditing(undefined)` submits the temporary / initial value.

https://github.com/glideapps/glide-data-grid/blob/2ca4058673f3badfeae1e88c82b34d0a7a263788/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx#L61-L68

The default editor implements the behavior by submitting `undefined`:

https://github.com/glideapps/glide-data-grid/blob/2ca4058673f3badfeae1e88c82b34d0a7a263788/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx#L70-L97

A substitute to `onFinishEditing(undefined)` would be `onFinishEditing(currentCell)` but right now, only `content: GridCell` and `initialValue: string | undefined` are passed to the custom editor, and when `initialValue` is defined, the value of content is overwritten with initialValue:

https://github.com/glideapps/glide-data-grid/blob/2ca4058673f3badfeae1e88c82b34d0a7a263788/packages/core/src/data-editor/data-editor.tsx#L698-L703

Maybe cell content shouldn't be overwritten when `initialValue !== undefined` is true, since both `content` and `initialValue` are passed as props, so we can leave it up to consumer to decide whether to merge them later or not.