### PR TITLE
only allowMixed row and col selections when isMultiKey true

### DIFF
--- a/packages/core/src/data-grid/use-selection-behavior.ts
+++ b/packages/core/src/data-grid/use-selection-behavior.ts
@@ -68,7 +68,6 @@ export function useSelectionBehavior(
     const setSelectedRows = React.useCallback(
         (newRows: CompactSelection | undefined, append: Slice | number | undefined, allowMixed: boolean): void => {
             newRows = newRows ?? gridSelection.rows;
-            allowMixed = allowMixed || gridSelection.current === undefined;
             if (append !== undefined) {
                 newRows = newRows.add(append);
             }
@@ -97,7 +96,6 @@ export function useSelectionBehavior(
     const setSelectedColumns = React.useCallback(
         (newCols: CompactSelection | undefined, append: number | Slice | undefined, allowMixed: boolean): void => {
             newCols = newCols ?? gridSelection.columns;
-            allowMixed = allowMixed || gridSelection.current === undefined;
             if (append !== undefined) {
                 newCols = newCols.add(append);
             }


### PR DESCRIPTION
Right now when selection behavior is set to "mixed"

```
rangeSelectionBlending={"mixed"}
columnSelectionBlending={"mixed"}
rowSelectionBlending={"mixed"}
```

clicking on a column header and then pressing on a row header _without_ ctrl/cmd key pressed will result in that row and column being selected.

Reason being if no cell / range selection is set, allowMixed is overrided and set equal to true

https://github.com/glideapps/glide-data-grid/blob/2ca4058673f3badfeae1e88c82b34d0a7a263788/packages/core/src/data-grid/use-selection-behavior.ts#L71

Expected behavior is clicking on column then row should select only the row and deselect the column _unless_ multiKey is pressed.

In general, expected behavior is that selections are exclusive when multiKey is not pressed and mixed when it is pressed.