### PR TITLE
maintain-focus-when-cell-outside-viewport

### DIFF
--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -1133,6 +1133,15 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             const [fCol, fRow] = selection.current?.cell ?? [];
             const range = selection.current?.range;
 
+            let visibleCols = effectiveCols.map(c => c.sourceIndex);
+            let visibleRows = makeRange(cellYOffset, Math.min(rows, cellYOffset + accessibilityHeight));
+
+            // Maintain focus within grid if we own it but focused cell is outside visible viewport
+            // and not rendered.
+            if (fCol && fRow && !(visibleCols.includes(fCol) && (visibleRows.includes(fRow)))) { 
+                focusElement(null);
+            }
+
             return (
                 <table
                     key="access-tree"
@@ -1159,7 +1168,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                         </tr>
                     </thead>
                     <tbody role="rowgroup">
-                        {makeRange(cellYOffset, Math.min(rows, cellYOffset + accessibilityHeight)).map(row => (
+                        {visibleRows.map(row => (
                             <tr
                                 role="row"
                                 aria-selected={selection.rows.hasIndex(row)}


### PR DESCRIPTION
Ran into a bug when `gridSelection` cell is updated such that it resides outside of the viewport. Grid focus is incorrectly kept on the `td` of the previous `gridSelection`, and grid focus is lost on next arrowkey.

Here's basically the logical stack trace:
1. move `gridSelection` cell to cell outside viewport
2. accessibilityTree re-renders with new selection, but focus is kept on `td` of previous `gridSelection` cell and is not moved because none of the re-rendered `td` owns focus (again, cell it outside visible viewport and list of rendered cells)
3. press any arrowkey to move the `gridSelection` cell, handled internally by glide
4. accessibilityTree re-renders with new selection
5. previous `td` cell that had focus is unmounted due to new selection
6. `td` of the new `gridSelection` tries mounting but is undefined on first render; focus is given to canvas in `focusElement`
7. previous `td` cell is remounted, and due to how react works, focus is taken from canvas and given to previous `td` cell: https://github.com/facebook/react/blob/main/packages/react-dom/src/client/ReactInputSelection.js#L141
8. previous `td` cell is removed from document, and focus now belongs to `document.body`
9. any following arrowkeys dont work anymore since grid focus is lost

The problem essentially begins at step 2, where focus is kept on the previous `td` because none of the re-renders have focus `ref={focused ? focusElement : undefined}`. 

To fix this, when the current `gridSelection` cell is out of viewport / when none of rendered `td` have focus and the grid should retain focus, focus should be given to the canvas, such that when the new focused `td` is rendered, focus is transferred to it.