### PR TITLE
Hide vertical and horizontal border on edges of visible region

### DIFF
--- a/packages/core/src/data-grid/data-grid-render.tsx
+++ b/packages/core/src/data-grid/data-grid-render.tsx
@@ -384,7 +384,7 @@ function drawGridLines(
         if (c.width === 0) continue;
         x += c.width;
         const tx = c.sticky ? x : x + translateX;
-        if (tx >= minX && tx <= maxX && (index === effectiveCols.length - 1 || verticalBorder(index + 1))) {
+        if (tx >= minX && tx <= maxX - 1 && (index === effectiveCols.length - 1 || verticalBorder(index + 1))) {
             toDraw.push({
                 x1: tx,
                 y1: Math.max(groupHeaderHeight, minY),
@@ -410,7 +410,7 @@ function drawGridLines(
         while (y + translateY <= target) {
             const ty = isHeader ? y : y + translateY;
             // This shouldn't be needed it seems like... yet it is. We're not sure why.
-            if (ty >= minY && ty <= maxY && (!lastRowSticky || row !== rows - 1 || Math.abs(ty - stickyRowY) > 1)) {
+            if (ty >= minY && ty <= maxY - 1 && (!lastRowSticky || row !== rows - 1 || Math.abs(ty - stickyRowY) > 1)) {
                 const rowTheme = isHeader ? undefined : getRowThemeOverride?.(row);
                 toDraw.push({
                     x1: minX,


### PR DESCRIPTION
There is a minor visual issue when the table uses its ideal size and the container has a border:

If the container is set to the ideal size, there will be a double border on the right and bottom part:
![image](https://user-images.githubusercontent.com/2852129/169002289-0a4ba412-18f7-4ca0-8ce0-1f04b6de7a99.png)

If the container is set to cut of the cell border to just have a one line border, then the selection ring will also be cut off as well:
![image](https://user-images.githubusercontent.com/2852129/169002260-a708e190-3562-4787-a2a1-bac5d40e0970.png)

I experimented with various ways to fix this, but the best way seems to be to just hide the last vertical and horizontal border in case it's directly at the edge of the visible region/container. This prevents a double border while still showing the full cell selection ring.

I tested this change with the storybook and I wasn't able to detect any negative visual impact with any of the examples. 
