### PR TITLE
Fix vertical alignment in cells

### DIFF
--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -81,7 +81,7 @@ const renderer: CustomCellRenderer<DropdownCell> = {
         const { ctx, theme, rect } = args;
         const { value } = cell.data;
         ctx.fillStyle = theme.textDark;
-        ctx.fillText(value, rect.x + theme.cellHorizontalPadding, rect.y + rect.height / 2);
+        ctx.fillText(value, rect.x + theme.cellHorizontalPadding, rect.y + Math.ceil(rect.height / 2));
 
         return true;
     },

--- a/packages/cells/src/cells/range-cell.tsx
+++ b/packages/cells/src/cells/range-cell.tsx
@@ -34,7 +34,7 @@ const renderer: CustomCellRenderer<RangeCell> = {
         const { min, max, value, label, measureLabel } = cell.data;
 
         const x = rect.x + theme.cellHorizontalPadding;
-        const yMid = rect.y + rect.height / 2;
+        const yMid = rect.y + Math.ceil(rect.height / 2);
 
         const rangeSize = max - min;
         const fillRatio = (value - min) / rangeSize;

--- a/packages/cells/src/cells/star-cell.tsx
+++ b/packages/cells/src/cells/star-cell.tsx
@@ -83,7 +83,7 @@ const renderer: CustomCellRenderer<StarCell> = {
         drawX += 8;
         ctx.beginPath();
         for (let i = 0; i < stars; i++) {
-            pathStar(ctx, [drawX, rect.y + rect.height / 2], 16);
+            pathStar(ctx, [drawX, rect.y + Math.ceil(rect.height / 2)], 16);
             drawX += 18;
         }
         ctx.fillStyle = theme.textDark;

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -91,14 +91,14 @@ const renderer: CustomCellRenderer<TagsCell> = {
 
         let x = drawArea.x;
         let row = 1;
-        let y = drawArea.y + (drawArea.height - rows * tagHeight - (rows - 1) * innerPad) / 2;
+        let y = drawArea.y + Math.ceil((drawArea.height - rows * tagHeight - (rows - 1) * innerPad) / 2);
         for (const tag of tags) {
             const color = possibleTags.find(t => t.tag === tag)?.color ?? theme.bgBubble;
 
             ctx.font = `12px ${theme.fontFamily}`;
             const metrics = measureTextCached(tag, ctx);
             const width = metrics.width + innerPad * 2;
-            const textY = tagHeight / 2;
+            const textY = Math.ceil(tagHeight / 2);
 
             if (x !== drawArea.x && x + width > drawArea.x + drawArea.width && row < rows) {
                 row++;
@@ -108,7 +108,7 @@ const renderer: CustomCellRenderer<TagsCell> = {
 
             ctx.fillStyle = color;
             ctx.beginPath();
-            roundedRect(ctx, x, y, width, tagHeight, tagHeight / 2);
+            roundedRect(ctx, x, y, width, tagHeight, Math.ceil(tagHeight / 2));
             ctx.fill();
 
             ctx.fillStyle = theme.textDark;

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -471,7 +471,7 @@ When provided the `provideEditor` callbacks job is to be a constructor for funct
 rowHeight: number | ((index: number) => number);
 ```
 
-`rowHeight` is the height of a row in the table. It defaults to `34`. By passing a function instead of a number you can give different heights to each row. The `index` is the zero-based absolute row index.
+`rowHeight` is the height of a row in the table. It defaults to `35`. By passing a function instead of a number you can give different heights to each row. The `index` is the zero-based absolute row index.
 
 ---
 
@@ -604,7 +604,7 @@ The height of the group headers in the data grid. If not provided this will defa
 headerHeight: number;
 ```
 
-`headerHeight` is the height of the table header. It defaults to `36`.
+`headerHeight` is the height of the table header. It defaults to `37`.
 
 ---
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -320,8 +320,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const {
         isDraggable = false,
         rowMarkers = "none",
-        rowHeight = 34,
-        headerHeight = 36,
+        rowHeight = 35,
+        headerHeight = 37,
         rowMarkerWidth: rowMarkerWidthRaw,
         imageEditorOverride,
         getRowThemeOverride,

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -328,13 +328,14 @@ export function drawTextCell(args: BaseDrawArgs, data: string, contentAlign?: Ba
             ctx.textAlign = contentAlign;
             changed = true;
         }
+        const yCentered = y + Math.ceil(h / 2);
 
         if (contentAlign === "right") {
-            ctx.fillText(data, x + w - (theme.cellHorizontalPadding + 0.5), y + h / 2);
+            ctx.fillText(data, x + w - (theme.cellHorizontalPadding + 0.5), yCentered);
         } else if (contentAlign === "center") {
-            ctx.fillText(data, x + w / 2, y + h / 2);
+            ctx.fillText(data, x + w / 2, yCentered);
         } else {
-            ctx.fillText(data, x + theme.cellHorizontalPadding + 0.5, y + h / 2);
+            ctx.fillText(data, x + theme.cellHorizontalPadding + 0.5, yCentered);
         }
 
         if (changed) {

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -328,6 +328,7 @@ export function drawTextCell(args: BaseDrawArgs, data: string, contentAlign?: Ba
             ctx.textAlign = contentAlign;
             changed = true;
         }
+
         const yCentered = y + Math.ceil(h / 2);
 
         if (contentAlign === "right") {
@@ -357,6 +358,8 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
 
     const alwaysShowIcon = data !== "";
 
+    const yCentered = y + Math.ceil(h / 2);
+
     if (icon !== undefined) {
         const padding = 8;
         const size = h - padding;
@@ -371,10 +374,10 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
 
         const padPlus = theme.cellHorizontalPadding + 4;
         if (lineSize > 0) {
-            ctx.moveTo(x + padPlus + xTranslate, y + h / 2);
-            ctx.lineTo(x + padPlus + xTranslate + lineSize, y + h / 2);
-            ctx.moveTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 - lineSize * 0.5);
-            ctx.lineTo(x + padPlus + xTranslate + lineSize * 0.5, y + h / 2 + lineSize * 0.5);
+            ctx.moveTo(x + padPlus + xTranslate, yCentered);
+            ctx.lineTo(x + padPlus + xTranslate + lineSize, yCentered);
+            ctx.moveTo(x + padPlus + xTranslate + lineSize * 0.5, yCentered - lineSize * 0.5);
+            ctx.lineTo(x + padPlus + xTranslate + lineSize * 0.5, yCentered + lineSize * 0.5);
             ctx.lineWidth = 2;
             ctx.strokeStyle = theme.bgIconHeader;
             ctx.lineCap = "round";
@@ -383,7 +386,7 @@ export function drawNewRowCell(args: BaseDrawArgs, data: string, icon?: string) 
     }
 
     ctx.fillStyle = theme.textMedium;
-    ctx.fillText(data, 24 + x + theme.cellHorizontalPadding + 0.5, y + h / 2);
+    ctx.fillText(data, 24 + x + theme.cellHorizontalPadding + 0.5, yCentered);
     ctx.beginPath();
 }
 
@@ -400,7 +403,7 @@ function drawCheckbox(
     hoverY: number = -20
 ) {
     const centerX = x + width / 2;
-    const centerY = y + height / 2;
+    const centerY = y + Math.ceil(height / 2);
 
     const hovered = Math.abs(hoverX - width / 2) < 10 && Math.abs(hoverY - height / 2) < 10;
 
@@ -496,7 +499,7 @@ export function drawMarkerRowCell(
             ctx.globalAlpha = 1 - hoverAmount;
         }
         ctx.fillStyle = theme.textLight;
-        ctx.fillText(text, start, y + height / 2);
+        ctx.fillText(text, start, y + Math.ceil(height / 2));
         if (hoverAmount !== 0) {
             ctx.globalAlpha = 1;
         }
@@ -516,7 +519,8 @@ export function drawProtectedCell(args: BaseDrawArgs) {
 
     const radius = 2.5;
     let xStart = x + theme.cellHorizontalPadding + radius;
-    const center = y + h / 2;
+
+    const center = y + Math.ceil(h / 2);
     const p = Math.cos(degreesToRadians(30)) * radius;
     const q = Math.sin(degreesToRadians(30)) * radius;
 
@@ -624,7 +628,7 @@ export function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
     renderBoxes.forEach((rectInfo, i) => {
         ctx.beginPath();
         ctx.fillStyle = theme.textBubble;
-        ctx.fillText(data[i], rectInfo.x + bubblePad, y + h / 2);
+        ctx.fillText(data[i], rectInfo.x + bubblePad, y + Math.ceil(h / 2));
     });
 }
 
@@ -707,6 +711,8 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
     const bubbleHeight = 24;
     const bubblePad = 8;
     const bubbleMargin = itemMargin;
+    const yCentered = y + Math.ceil(h / 2);
+
     let renderX = x + theme.cellHorizontalPadding;
 
     const tileMap = getAndCacheDrilldownBorder(theme.bgCell, theme.drilldownBorder);
@@ -738,9 +744,9 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
             const rw = Math.floor(rectInfo.width);
             ctx.imageSmoothingEnabled = false;
             const maxSideWidth = Math.min(17, rw / 2 + 5);
-            ctx.drawImage(el, 0, 0, sideWidth, height, rx - 5, y + h / 2 - 17, maxSideWidth, 34);
+            ctx.drawImage(el, 0, 0, sideWidth, height, rx - 5, yCentered - 17, maxSideWidth, 34);
             if (rectInfo.width > 24)
-                ctx.drawImage(el, sideWidth, 0, middleWidth, height, rx + 12, y + h / 2 - 17, rw - 24, 34);
+                ctx.drawImage(el, sideWidth, 0, middleWidth, height, rx + 12, yCentered - 17, rw - 24, 34);
             ctx.drawImage(
                 el,
                 width - sideWidth,
@@ -748,7 +754,7 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
                 sideWidth,
                 height,
                 rx + rw - (maxSideWidth - 5),
-                y + h / 2 - 17,
+                yCentered - 17,
                 maxSideWidth,
                 34
             );
@@ -781,10 +787,10 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
                     srcHeight = srcWidth;
                 }
                 ctx.beginPath();
-                roundedRect(ctx, drawX, y + h / 2 - imgSize / 2, imgSize, imgSize, 3);
+                roundedRect(ctx, drawX, yCentered - imgSize / 2, imgSize, imgSize, 3);
                 ctx.save();
                 ctx.clip();
-                ctx.drawImage(img, srcX, srcY, srcWidth, srcHeight, drawX, y + h / 2 - imgSize / 2, imgSize, imgSize);
+                ctx.drawImage(img, srcX, srcY, srcWidth, srcHeight, drawX, yCentered - imgSize / 2, imgSize, imgSize);
                 ctx.restore();
 
                 drawX += imgSize + 4;
@@ -793,7 +799,7 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
 
         ctx.beginPath();
         ctx.fillStyle = theme.textBubble;
-        ctx.fillText(d.text, drawX, y + h / 2);
+        ctx.fillText(d.text, drawX, yCentered);
     });
 }
 


### PR DESCRIPTION
The vertical alignment of content in all (text-based) cells is currently always off by one pixel. I assume the reason is that subpixel rendering seems to not work with `fillText`. If the cell height is an even number, it will always be off by one pixel. In case the cell height is uneven it is possible to center the content. Therefore, I updated the default heights to uneven numbers.  However, we also need to apply `Math.ceil` here to get the correct centered y position. 

This PR currently fixes all cells besides:
- header (tried it but the correct way to center here is just using `ctx.fillText(c.title, drawX, y + height / 2);` which seems a bit strange)
- group header
- user-profile-cell
- sparkling cell
- range cell