### PR TITLE
Expandable tree example

### DIFF
--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -21,6 +21,8 @@ import type { DatePickerCell } from "./cells/date-picker-cell";
 import type { LinksCell } from "./cells/links-cell";
 import type { ButtonCell } from "./cells/button-cell";
 
+import { createSampleTree, useCollapsingTreeRows } from "@glideapps/glide-data-grid-source"
+
 const SimpleWrapper = styled.div`
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
@@ -494,64 +496,9 @@ export const CustomCellEditing: React.VFC = () => {
 };
 
 export const CustomTreeCell: React.VFC = () => {
-    const names = ["Alfa", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
+    const [root, setRoot] = React.useState(() => createSampleTree());
 
-    const createNode = (name: string, description?: string, children: TreeNode[] = []): TreeNode => ({
-        name,
-        description: description || `Item ${name}`,
-        children
-    });
-
-    const createTree = (): TreeNode => {
-        const root = createNode("Root", "Root Item");
-
-        names.forEach(nameX => {
-            const nodeX = createNode(nameX);
-            root.children.push(nodeX);
-            names.forEach(nameY => {
-                const nameXY = `${nameX} ${nameY}`;
-                const nodeY = createNode(nameXY);
-                nodeY.collapsed = true;
-                nodeX.children.push(nodeY);
-                names.forEach(nameZ => {
-                    const nameXYZ = `${nameX} ${nameY} ${nameZ}`;
-                    const nodeZ = createNode(nameXYZ);
-                    nodeY.children.push(nodeZ);
-                });
-            });
-        });
-
-        return root;
-    };
-
-    const [root, setRoot] = React.useState(createTree());
-
-    const flatten = (tree: TreeNode): TreeNode[] => {
-        const _visit = (node: TreeNode, depth: number = 0) => {
-            node.depth = depth;
-            flattened.push(node);
-            node.children.forEach(child => (!node.collapsed) && _visit(child, depth + 1));
-        };
-
-        const flattened: TreeNode[] = [];
-
-        _visit(tree);
-
-        return flattened;
-    };
-
-    const [rows, setRows] = React.useState<TreeNode[]>([]);
-
-    React.useEffect(
-        () => {
-            const flattened = flatten(root);
-            setRows(flattened);
-            setNumRows(flattened.length);
-        },
-        [root]
-    );
-
-    const [numRows, setNumRows] = React.useState(rows.length);
+    const rows = useCollapsingTreeRows(root);
 
     const columns = React.useMemo<GridColumn[]>(() => [
         {
@@ -662,7 +609,7 @@ export const CustomTreeCell: React.VFC = () => {
                 }}
                 columns={columns}
                 rowMarkers={"none"}
-                rows={numRows}
+                rows={rows.length}
             />
         </BeautifulWrapper>
     );

--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -511,7 +511,6 @@ export const CustomTreeCell: React.VFC = () => {
         { title: "Depth", width: 55 },
         { title: "Children", width: 70 },
         { title: "Collapsed", width: 80 },
-        { title: "Description", width: 200 }
     ], []);
 
     const getCellContent = React.useCallback(
@@ -519,7 +518,7 @@ export const CustomTreeCell: React.VFC = () => {
             const node = rows[row];
             const field = columns[col].title;
 
-            const { name, depth, children: { length }, collapsed, description } = node;
+            const { name, depth, children: { length }, collapsed } = node;
 
 
             const collapsedString = node.children.length > 0 ? (collapsed ? "YES" : "NO") : "N/A";
@@ -557,14 +556,6 @@ export const CustomTreeCell: React.VFC = () => {
                         kind: GridCellKind.Text,
                         displayData: collapsedString,
                         data: collapsedString,
-                        allowOverlay: false,
-                    };
-
-                case "Description":
-                    return {
-                        kind: GridCellKind.Text,
-                        displayData: description,
-                        data: description,
                         allowOverlay: false,
                     };
 

--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -599,13 +599,10 @@ export const CustomTreeCell: React.VFC = () => {
                 {...defaultProps}
                 {...cellProps}
                 getCellContent={getCellContent}
-                onCellClicked={(item, event) => {
-                    const cell = getCellContent(item);
-                    /*
-                    onCellClicked(cell, event, () => {
-                        setRoot({...root});
-                    })
-                    */
+                onCellEdited={(_, item) => {
+                    if (item.kind !== GridCellKind.Custom) return
+                    if (item.data.kind !== 'tree-cell') return
+                    setRoot({...root})
                 }}
                 columns={columns}
                 rowMarkers={"none"}

--- a/packages/cells/src/cells/tree-cell.tsx
+++ b/packages/cells/src/cells/tree-cell.tsx
@@ -62,21 +62,20 @@ const renderer: CustomRenderer<TreeCell> = {
 
       return true;
   },
-  /*
-  onCellClicked: (cell, event, callback) => {
-      const { item } = cell.data;
-      const { depth } = item;
-      const { localEventX } = event;
+  onClick: ({ cell, posX, preventDefault }) => {
+      const { node } = cell.data;
+      const { depth } = node;
 
       const depthOffset = (depth || 0) * 20;
 
-      if (localEventX < depthOffset || localEventX > depthOffset + 22) return;
+      if (posX < depthOffset || posX > depthOffset + 22) return;
 
-      event.preventDefault();
-      item.collapsed = !item.collapsed;
-      callback(item);
+      preventDefault();
+
+      node.collapsed = !node.collapsed
+
+      return cell
   },
-  */
   provideEditor: undefined,
 };
 

--- a/packages/cells/src/cells/tree-cell.tsx
+++ b/packages/cells/src/cells/tree-cell.tsx
@@ -1,0 +1,83 @@
+import { CustomCell, CustomRenderer, GridCellKind, Rectangle, drawTextCell } from "@glideapps/glide-data-grid";
+
+export type TreeNode = {
+  name: string;
+  description: string;
+  depth?: number;
+  collapsed?: boolean;
+  children: TreeNode[];
+};
+
+interface TreeCellProps {
+  readonly kind: "tree-cell";
+  readonly node: TreeNode;
+};
+
+export type TreeCell = CustomCell<TreeCellProps>;
+
+const renderer: CustomRenderer<TreeCell> = {
+  kind: GridCellKind.Custom,
+  isMatch: (cell: CustomCell): cell is TreeCell => (cell.data as any).kind === "tree-cell",
+  draw: (args, cell) => {
+      const { ctx, rect, theme } = args;
+      const { x, y, width, height } = rect;
+      const { data } = cell;
+      const { node } = data;
+      const { children, collapsed, depth, name } = node;
+
+      const depthOffset = (depth || 0) * 20;
+
+      ctx.save();
+
+      if (children?.length) {
+          ctx.fillStyle = "none";
+          ctx.lineCap = "round";
+          ctx.lineJoin = "round";
+          ctx.lineWidth = 1.5;
+          ctx.strokeStyle = theme.textDark;
+          ctx.beginPath();
+          if (collapsed) {
+              ctx.moveTo(x + depthOffset + 8, y + height / 2 - 4);
+              ctx.lineTo(x + depthOffset + 8, y + height / 2 + 4);
+              ctx.lineTo(x + depthOffset + 14, y + height / 2);
+          } else {
+              ctx.moveTo(x + depthOffset + 15, y + height / 2 - 3);
+              ctx.lineTo(x + depthOffset + 7, y + height / 2 - 3);
+              ctx.lineTo(x + depthOffset + 11, y + height / 2 + 3);
+          }
+          ctx.closePath();
+          ctx.stroke();
+      }
+
+      ctx.restore();
+
+      const indent = depthOffset + 20;
+      const indentRect: Rectangle = {
+        ...rect,
+        x: rect.x + indent,
+        width: width - indent,
+      };
+
+      drawTextCell({...args, rect: indentRect }, name, cell.contentAlign);
+
+      return true;
+  },
+  /*
+  onCellClicked: (cell, event, callback) => {
+      const { item } = cell.data;
+      const { depth } = item;
+      const { localEventX } = event;
+
+      const depthOffset = (depth || 0) * 20;
+
+      if (localEventX < depthOffset || localEventX > depthOffset + 22) return;
+
+      event.preventDefault();
+      item.collapsed = !item.collapsed;
+      callback(item);
+  },
+  */
+  provideEditor: undefined,
+};
+
+export default renderer;

--- a/packages/cells/src/cells/tree-cell.tsx
+++ b/packages/cells/src/cells/tree-cell.tsx
@@ -11,7 +11,7 @@ export type TreeNode = {
 interface TreeCellProps {
   readonly kind: "tree-cell";
   readonly node: TreeNode;
-};
+}
 
 export type TreeCell = CustomCell<TreeCellProps>;
 

--- a/packages/cells/src/cells/tree-cell.tsx
+++ b/packages/cells/src/cells/tree-cell.tsx
@@ -2,7 +2,6 @@ import { CustomCell, CustomRenderer, GridCellKind, Rectangle, drawTextCell } fro
 
 export type TreeNode = {
   name: string;
-  description: string;
   depth?: number;
   collapsed?: boolean;
   children: TreeNode[];

--- a/packages/cells/src/index.ts
+++ b/packages/cells/src/index.ts
@@ -2,6 +2,7 @@ import { useCustomCells } from "@glideapps/glide-data-grid";
 import StarCellRenderer, { StarCell } from "./cells/star-cell";
 import SparklineCellRenderer, { SparklineCell } from "./cells/sparkline-cell";
 import TagsCellRenderer, { TagsCell } from "./cells/tags-cell";
+import TreeCellRenderer, { TreeCell } from "./cells/tree-cell";
 import UserProfileCellRenderer, { UserProfileCell } from "./cells/user-profile-cell";
 import DropdownCellRenderer, { DropdownCell } from "./cells/dropdown-cell";
 import ArticleCellRenderer from "./cells/article-cell";
@@ -16,6 +17,7 @@ const cells = [
     StarCellRenderer,
     SparklineCellRenderer,
     TagsCellRenderer,
+    TreeCellRenderer,
     UserProfileCellRenderer,
     DropdownCellRenderer,
     ArticleCellRenderer,
@@ -34,6 +36,7 @@ export {
     StarCellRenderer as StarCell,
     SparklineCellRenderer as SparklineCell,
     TagsCellRenderer as TagsCell,
+    TreeCellRenderer as TreeCell,
     UserProfileCellRenderer as UserProfileCell,
     DropdownCellRenderer as DropdownCell,
     ArticleCellRenderer as ArticleCell,
@@ -49,6 +52,7 @@ export type {
     StarCell as StarCellType,
     SparklineCell as SparklineCellType,
     TagsCell as TagsCellType,
+    TreeCell as TreeCellType,
     UserProfileCell as UserProfileCellType,
     DropdownCell as DropdownCellType,
     ArticleCell as ArticleCellType,

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -3,3 +3,4 @@ export { useMoveableColumns } from "./use-movable-columns";
 export { useColumnSort } from "./use-column-sort";
 export { useAsyncDataSource } from "./use-async-data-source";
 export { useUndoRedo } from "./use-undo-redo";
+export { createSampleTree, useCollapsingTreeRows } from "./use-collapsing-tree-rows";

--- a/packages/source/src/use-collapsing-tree-rows.ts
+++ b/packages/source/src/use-collapsing-tree-rows.ts
@@ -1,0 +1,50 @@
+import type { TreeNode } from "@glideapps/glide-data-grid-cells/src/cells/tree-cell";
+import React from "react";
+
+const names = ["Alfa", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
+
+const createNode = (name: string, description?: string, children: TreeNode[] = []): TreeNode => ({
+    name,
+    description: description ?? `Item ${name}`,
+    children
+});
+
+const flattenTree = (tree: TreeNode): TreeNode[] => {
+    const _visit = (node: TreeNode, depth: number = 0) => {
+        node.depth = depth;
+        flattened.push(node);
+        node.children.forEach(child => { if (!(node.collapsed === true)) _visit(child, depth + 1) });
+    };
+
+    const flattened: TreeNode[] = [];
+
+    _visit(tree);
+
+    return flattened;
+}
+
+export function createSampleTree(): TreeNode {
+    const root = createNode("Root", "Root Item");
+
+    names.forEach(nameX => {
+        const nodeX = createNode(nameX);
+        root.children.push(nodeX);
+        names.forEach(nameY => {
+            const nameXY = `${nameX} ${nameY}`;
+            const nodeY = createNode(nameXY);
+            nodeY.collapsed = true;
+            nodeX.children.push(nodeY);
+            names.forEach(nameZ => {
+                const nameXYZ = `${nameX} ${nameY} ${nameZ}`;
+                const nodeZ = createNode(nameXYZ);
+                nodeY.children.push(nodeZ);
+            });
+        });
+    });
+
+    return root;
+}
+
+export function useCollapsingTreeRows(tree: TreeNode): TreeNode[] {
+    return React.useMemo(() => flattenTree(tree), [tree]);
+}

--- a/packages/source/src/use-collapsing-tree-rows.ts
+++ b/packages/source/src/use-collapsing-tree-rows.ts
@@ -3,9 +3,8 @@ import React from "react";
 
 const names = ["Alfa", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"];
 
-const createNode = (name: string, description?: string, children: TreeNode[] = []): TreeNode => ({
+const createNode = (name: string, children: TreeNode[] = []): TreeNode => ({
     name,
-    description: description ?? `Item ${name}`,
     children
 });
 
@@ -24,7 +23,7 @@ const flattenTree = (tree: TreeNode): TreeNode[] => {
 }
 
 export function createSampleTree(): TreeNode {
-    const root = createNode("Root", "Root Item");
+    const root = createNode("Root");
 
     names.forEach(nameX => {
         const nodeX = createNode(nameX);

--- a/packages/source/src/use-collapsing-tree-rows.ts
+++ b/packages/source/src/use-collapsing-tree-rows.ts
@@ -12,7 +12,8 @@ const flattenTree = (tree: TreeNode): TreeNode[] => {
     const _visit = (node: TreeNode, depth: number = 0) => {
         node.depth = depth;
         flattened.push(node);
-        node.children.forEach(child => { if (!(node.collapsed === true)) _visit(child, depth + 1) });
+        if (node.collapsed === true) return;
+        node.children.forEach(child => { _visit(child, depth + 1) });
     };
 
     const flattened: TreeNode[] = [];


### PR DESCRIPTION
This adds a storybook example of an expandable nested tree by implementing a custom cell renderer, shifting text based on depth, and filtering out the children of collapsed items.

https://user-images.githubusercontent.com/94077014/171967390-19d2047f-70e7-4dff-b818-4a73d146324d.mp4