### PR TITLE
Updating API.md with latest trailingRowOptions

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -848,9 +848,11 @@ The grid will not attempt to add additional rows if more data is pasted then can
 
 ```ts
 trailingRowOptions?: {
-    readonly tint?: boolean;
     readonly hint?: string;
-    readonly sticky?: boolean;
+    readonly addIcon?: string;
+    readonly targetColumn?: number | GridColumn;
+    readonly themeOverride?: Partial<Theme>;
+    readonly disabled?: boolean;
 }
 onRowAppended?: () => void;
 ```


### PR DESCRIPTION
The new options

https://github.com/glideapps/glide-data-grid/blob/91b2843ba5b248b7485293b8bc9f6fe53fb3a1fd/packages/core/src/data-grid/data-grid-types.ts#L182-L197

got updated in the GridColumn section

https://github.com/glideapps/glide-data-grid/blob/91b2843ba5b248b7485293b8bc9f6fe53fb3a1fd/packages/core/API.md?plain=1#L200-L220

but not in `trailingRowOptions`