### PR TITLE
get rid of magic number in accessibilityTree

### DIFF
--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -1118,7 +1118,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     const lastFocusedSubdomNode = React.useRef<Item>();
     const accessibilityTree = useDebouncedMemo(
         () => {
-            if (width < 50) return null;
+            if (width < accessibilityHeight) return null;
             let effectiveCols = getEffectiveColumns(mappedColumns, cellXOffset, width, dragAndDropState, translateX);
             const colOffset = firstColAccessible ? 0 : -1;
             if (!firstColAccessible && effectiveCols[0]?.sourceIndex === 0) {


### PR DESCRIPTION
Was looking through `data-grid` and noticed a magic constant that was introduced in this PR: https://github.com/glideapps/glide-data-grid/pull/121 and this commit: https://github.com/glideapps/glide-data-grid/commit/5ee2a7a0aaea31cd83fc5599f893612b38eda75d

Seems that we can replace it with `accessibilityHeight` but not exactly sure.