### PR TITLE
Automaic growing column sizing

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -93,6 +93,7 @@ type Props = Omit<
     | "onMouseUp"
     | "onMouseMove"
     | "freezeColumns"
+    | "clientSize"
     | "onSearchResultsChanged"
     | "onVisibleRegionChanged"
     | "rowHeight"
@@ -498,10 +499,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         return { ...getDataEditorTheme(), ...theme };
     }, [theme]);
 
+    const [clientSize, setClientSize] = React.useState<readonly [number, number]>([10, 10]);
+
     const columns = useColumnSizer(
         columnsIn,
         rows,
         getCellsForSeletionDirect,
+        clientSize[0] - (rowMarkerOffset === 0 ? 0 : rowMarkerWidth),
         minColumnWidth,
         maxColumnWidth,
         mergedTheme,
@@ -1442,7 +1446,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const currentCell = gridSelection?.current?.cell;
     const onVisibleRegionChangedImpl = React.useCallback(
-        (region: Rectangle, tx?: number, ty?: number) => {
+        (region: Rectangle, clientWidth: number, clientHeight: number, tx?: number, ty?: number) => {
             let selected = currentCell;
             if (selected !== undefined) {
                 selected = [selected[0] - rowMarkerOffset, selected[1]];
@@ -1466,6 +1470,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                               },
                 },
             };
+            setClientSize([clientWidth, clientHeight]);
             setVisibleRegion(newRegion);
             visibleRegionRef.current = newRegion;
             onVisibleRegionChanged?.(newRegion, newRegion.tx, newRegion.ty, newRegion.extras);
@@ -2752,6 +2757,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     onDrop={onDrop}
                     onSearchResultsChanged={onSearchResultsChanged}
                     onVisibleRegionChanged={onVisibleRegionChangedImpl}
+                    clientSize={clientSize}
                     rowHeight={rowHeight}
                     rows={mangledRows}
                     scrollRef={scrollRef}

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -2476,6 +2476,40 @@ export const ColumnGroups: React.VFC = () => {
     },
 };
 
+export const StretchColumnSize: React.VFC = () => {
+    const { cols, getCellContent, getCellsForSelection, onColumnResize } = useMockDataGenerator(5, true, true);
+
+    const columns = React.useMemo(() => {
+        return cols.map((x, i) => ({ ...x, grow: (5 + i) / 5 }));
+    }, [cols]);
+
+    return (
+        <BeautifulWrapper
+            title="Column Grow"
+            description={
+                <Description>
+                    Columns in the data grid may be set to grow to fill space by setting the <PropName>grow</PropName>{" "}
+                    prop.
+                </Description>
+            }>
+            <DataEditor
+                {...defaultProps}
+                getCellContent={getCellContent}
+                columns={columns}
+                getCellsForSelection={getCellsForSelection}
+                rows={1000}
+                onColumnResize={onColumnResize}
+                rowMarkers="both"
+            />
+        </BeautifulWrapper>
+    );
+};
+(StretchColumnSize as any).parameters = {
+    options: {
+        showPanel: false,
+    },
+};
+
 function useCollapsableColumnGroups(cols: readonly GridColumn[]) {
     const [collapsed, setCollapsed] = React.useState<readonly string[]>([]);
 

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -1815,7 +1815,7 @@ export const BuiltInSearch: React.VFC = () => {
     useEventListener(
         "keydown",
         React.useCallback(event => {
-            if ((event.ctrlKey || event.metaKey) && event.key === "f") {
+            if ((event.ctrlKey || event.metaKey) && event.code === "KeyF") {
                 setShowSearch(cv => !cv);
                 event.stopPropagation();
                 event.preventDefault();

--- a/packages/core/src/data-editor/use-column-sizer.test.tsx
+++ b/packages/core/src/data-editor/use-column-sizer.test.tsx
@@ -80,7 +80,7 @@ const abortController = new AbortController();
 describe("use-column-sizer", () => {
     it("Measures a simple cell", async () => {
         const { result } = renderHook(() =>
-            useColumnSizer(COLUMNS, 1000, getShortCellsForSelection, 20, 500, theme, abortController)
+            useColumnSizer(COLUMNS, 1000, getShortCellsForSelection, 400, 20, 500, theme, abortController)
         );
 
         const columnA = result.current.find(col => col.title === "A");
@@ -95,7 +95,9 @@ describe("use-column-sizer", () => {
     });
 
     it("Measures the last row", async () => {
-        renderHook(() => useColumnSizer(COLUMNS, 1000, getShortCellsForSelection, 20, 500, theme, abortController));
+        renderHook(() =>
+            useColumnSizer(COLUMNS, 1000, getShortCellsForSelection, 400, 20, 500, theme, abortController)
+        );
 
         expect(getShortCellsForSelection).toBeCalledTimes(2);
         expect(getShortCellsForSelection).toHaveBeenNthCalledWith(
@@ -122,7 +124,7 @@ describe("use-column-sizer", () => {
     it("Measures new columns when they arrive, doesn't re-measure existing ones", async () => {
         const { result, rerender } = renderHook(
             ({ getCellsForSelection, columns }) =>
-                useColumnSizer(columns, 1000, getCellsForSelection, 20, 500, theme, abortController),
+                useColumnSizer(columns, 1000, getCellsForSelection, 400, 20, 500, theme, abortController),
             {
                 initialProps: {
                     getCellsForSelection: getShortCellsForSelection,
@@ -164,7 +166,9 @@ describe("use-column-sizer", () => {
     });
 
     it("Returns the default sizes if getCellsForSelection is not provided", async () => {
-        const { result } = renderHook(() => useColumnSizer(COLUMNS, 1000, undefined, 20, 500, theme, abortController));
+        const { result } = renderHook(() =>
+            useColumnSizer(COLUMNS, 1000, undefined, 400, 20, 500, theme, abortController)
+        );
 
         const columnA = result.current.find(col => col.title === "A");
         const columnB = result.current.find(col => col.title === "B");
@@ -183,6 +187,7 @@ describe("use-column-sizer", () => {
                 A_BUNCH_OF_COLUMNS_THAT_ALREADY_HAVE_SIZES_WE_DONT_WANT_TO_MEASURE_THESE,
                 1000,
                 undefined,
+                400,
                 50,
                 500,
                 theme,

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -122,9 +122,9 @@ export function useColumnSizer(
     }, [abortController.signal, columns]);
 
     return React.useMemo(() => {
-        const getRaw = (): SizedGridColumn[] => {
+        const getRaw = () => {
             if (columns.every(isSizedGridColumn)) {
-                return [...columns];
+                return columns;
             }
 
             if (ctx === null) {
@@ -163,12 +163,12 @@ export function useColumnSizer(
             });
         };
 
-        const raw = getRaw();
+        let result = getRaw();
         let totalWidth = 0;
         let totalGrow = 0;
         const distribute: number[] = [];
-        for (let i = 0; i < raw.length; i++) {
-            const c = raw[i];
+        for (let i = 0; i < result.length; i++) {
+            const c = result[i];
             totalWidth += c.width;
             if (c.grow !== undefined && c.grow > 0) {
                 totalGrow += c.grow;
@@ -176,20 +176,22 @@ export function useColumnSizer(
             }
         }
         if (totalWidth < clientWidth && distribute.length > 0) {
+            const writeable = [...result];
             const extra = clientWidth - totalWidth;
             let remaining = extra;
             for (let di = 0; di < distribute.length; di++) {
                 const i = distribute[di];
-                const weighted = (raw[i].grow ?? 0) / totalGrow;
+                const weighted = (result[i].grow ?? 0) / totalGrow;
                 const toAdd =
                     di === distribute.length - 1 ? remaining : Math.min(remaining, Math.floor(extra * weighted));
-                raw[i] = {
-                    ...raw[i],
-                    width: raw[i].width + toAdd,
+                writeable[i] = {
+                    ...result[i],
+                    width: result[i].width + toAdd,
                 };
                 remaining -= toAdd;
             }
+            result = writeable;
         }
-        return raw;
+        return result;
     }, [columns, ctx, clientWidth, maxColumnWidth, minColumnWidth, selectedData]);
 }

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -7,6 +7,7 @@ import {
     GridCell,
     GridCellKind,
     GridColumn,
+    InnerGridColumn,
     isSizedGridColumn,
     resolveCellsThunk,
     SizedGridColumn,
@@ -58,7 +59,7 @@ export function useColumnSizer(
     maxColumnWidth: number,
     theme: Theme,
     abortController: AbortController
-): readonly SizedGridColumn[] {
+): readonly InnerGridColumn[] {
     const rowsRef = React.useRef(rows);
     const getCellsForSelectionRef = React.useRef(getCellsForSelection);
     const themeRef = React.useRef(theme);
@@ -163,7 +164,7 @@ export function useColumnSizer(
             });
         };
 
-        let result = getRaw();
+        let result: readonly InnerGridColumn[] = getRaw();
         let totalWidth = 0;
         let totalGrow = 0;
         const distribute: number[] = [];
@@ -186,6 +187,7 @@ export function useColumnSizer(
                     di === distribute.length - 1 ? remaining : Math.min(remaining, Math.floor(extra * weighted));
                 writeable[i] = {
                     ...result[i],
+                    growOffset: toAdd,
                     width: result[i].width + toAdd,
                 };
                 remaining -= toAdd;

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -262,7 +262,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
 
     const onSearchKeyDown = React.useCallback(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
-            if (((event.ctrlKey || event.metaKey) && event.key === "f") || event.key === "Escape") {
+            if (((event.ctrlKey || event.metaKey) && event.nativeEvent.code === "KeyF") || event.key === "Escape") {
                 onClose();
                 event.stopPropagation();
                 event.preventDefault();

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -395,6 +395,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                 onCanvasFocused={p.onCanvasFocused}
                 onCanvasBlur={p.onCanvasBlur}
                 isFocused={p.isFocused}
+                clientSize={p.clientSize}
                 headerHeight={p.headerHeight}
                 isFilling={p.isFilling}
                 fillHandle={p.fillHandle}

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -185,6 +185,7 @@ interface BaseGridColumn {
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;
     readonly hasMenu?: boolean;
+    readonly grow?: number;
     readonly style?: "normal" | "highlight";
     readonly themeOverride?: Partial<Theme>;
     readonly trailingRowOptions?: {
@@ -197,7 +198,7 @@ interface BaseGridColumn {
 }
 
 export function isSizedGridColumn(c: GridColumn): c is SizedGridColumn {
-    return "width" in c;
+    return "width" in c && typeof c.width === "number";
 }
 
 export interface SizedGridColumn extends BaseGridColumn {
@@ -205,7 +206,7 @@ export interface SizedGridColumn extends BaseGridColumn {
     readonly id?: string;
 }
 
-interface AutoGridColumn extends BaseGridColumn {
+export interface AutoGridColumn extends BaseGridColumn {
     readonly id: string;
 }
 

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -219,6 +219,8 @@ export type GetCellsThunk = () => Promise<CellArray>;
 
 export type GridColumn = SizedGridColumn | AutoGridColumn;
 
+export type InnerGridColumn = SizedGridColumn & { growOffset?: number };
+
 // export type SizedGridColumn = Omit<GridColumn, "width"> & { readonly width: number };
 
 export type ReadWriteGridCell = TextCell | NumberCell | MarkdownCell | UriCell | CustomCell | BooleanCell;

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -24,10 +24,10 @@ import {
     CellList,
     Item,
     DrawHeaderCallback,
-    SizedGridColumn,
     isReadWriteCell,
     isInnerOnlyCell,
     booleanCellIsEditable,
+    InnerGridColumn,
 } from "./data-grid-types";
 import { SpriteManager, SpriteMap } from "./data-grid-sprites";
 import { useDebouncedMemo, useEventListener } from "../common/utils";
@@ -69,7 +69,7 @@ export interface DataGridProps {
     readonly isFilling: boolean;
     readonly isFocused: boolean;
 
-    readonly columns: readonly SizedGridColumn[];
+    readonly columns: readonly InnerGridColumn[];
     readonly rows: number;
 
     readonly headerHeight: number;


### PR DESCRIPTION
While yes this works, this is pretty broken when used in conjunction with column resizing. There should be a way to fix this by storing on the column its original size prior to applying grow. Then using that number when sending out column resize events. I *think* this should result in the "jumps" going away but it still wont track the mouse perfectly even if it will be continuous.