### PR TITLE
appendRow handle

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -277,6 +277,7 @@ export interface DataEditorProps extends Props {
 }
 
 export interface DataEditorRef {
+    appendRow: (col: number) => Promise<void>;
     updateCells: DataGridRef["damage"];
     getBounds: DataGridRef["getBounds"];
     focus: DataGridRef["focus"];
@@ -876,7 +877,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     getCellContentRef.current = getCellContent;
     rowsRef.current = rows;
     const appendRow = React.useCallback(
-        async (col: number) => {
+        async (col: number): Promise<void> => {
             const c = mangledCols[col];
             if (c?.trailingRowOptions?.disabled === true) {
                 return;
@@ -2536,6 +2537,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     React.useImperativeHandle(
         forwardedRef,
         () => ({
+            appendRow,
             updateCells: damageList => {
                 if (rowMarkerOffset !== 0) {
                     damageList = damageList.map(x => ({ cell: [x.cell[0] + rowMarkerOffset, x.cell[1]] }));

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2537,7 +2537,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     React.useImperativeHandle(
         forwardedRef,
         () => ({
-            appendRow,
+            appendRow: (col: number) => appendRow(col + rowMarkerOffset),
             updateCells: damageList => {
                 if (rowMarkerOffset !== 0) {
                     damageList = damageList.map(x => ({ cell: [x.cell[0] + rowMarkerOffset, x.cell[1]] }));

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -528,7 +528,7 @@ export const AppendRowHandle: React.VFC = () => {
     const ref = React.useRef<DataEditorRef>(null);
 
     const onClick = React.useCallback(() => {
-      ref.current?.appendRow(4)
+      ref.current?.appendRow(3)
     }, [ref]);
 
     const onRowAppended = React.useCallback(() => {

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -520,6 +520,62 @@ export const AddDataToMiddle: React.FC<AddDataToMiddleProps> = p => {
     },
 };
 
+export const AppendRowHandle: React.VFC = () => {
+    const { cols, getCellContent, setCellValueRaw, setCellValue } = useMockDataGenerator(60, false);
+
+    const [numRows, setNumRows] = React.useState(50);
+
+    const ref = React.useRef<DataEditorRef>(null);
+
+    const onClick = React.useCallback(() => {
+      ref.current?.appendRow(4)
+    }, [ref]);
+
+    const onRowAppended = React.useCallback(() => {
+        const newRow = numRows;
+        for (let c = 0; c < 6; c++) {
+            const cell = getCellContent([c, newRow]);
+            setCellValueRaw([c, newRow], clearCell(cell));
+        }
+        setNumRows(cv => cv + 1);
+    }, [getCellContent, numRows, setCellValueRaw]);
+
+    return (
+        <BeautifulWrapper
+            title="appendRow Ref"
+            description={
+                <>
+                    <Description>Adding data can also be triggered from outside of <PropName>DataEditor</PropName></Description>
+                    <MoreInfo>
+                        By calling <PropName>appendRow</PropName> on a <PropName>ref</PropName> to your grid, you can trigger
+                        the append elsewhere, like this <KeyName onClick={onClick}>Append</KeyName> button
+                    </MoreInfo>
+                </>
+            }>
+            <DataEditor
+                {...defaultProps}
+                ref={ref}
+                getCellContent={getCellContent}
+                columns={cols}
+                rowMarkers={"both"}
+                onCellEdited={setCellValue}
+                trailingRowOptions={{
+                    hint: "New row...",
+                    sticky: true,
+                    tint: true,
+                }}
+                rows={numRows}
+                onRowAppended={onRowAppended}
+            />
+        </BeautifulWrapper>
+    );
+};
+(AppendRowHandle as any).parameters = {
+    options: {
+        showPanel: false,
+    },
+};
+
 export const SmallEditableGrid = () => {
     const { cols, getCellContent, setCellValue } = useMockDataGenerator(6, false);
 


### PR DESCRIPTION
This adds `appendRow` to the `React.useImperativeHandle` so that it can be accessed via `ref.current.appendRow`

Also adds a story demonstrating its use

https://user-images.githubusercontent.com/94077014/174906326-e1be3bd7-98e4-445a-8593-d8d0af96c21e.mp4
