### PR TITLE
Ability to override the cursor on a per-cell basis

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -279,6 +279,7 @@ interface BaseGridCell {
     readonly themeOverride?: Partial<Theme>;
     readonly span?: Item;
     readonly contentAlign?: "left" | "right" | "center";
+    readonly cursor?: CSSProperties["cursor"];
 }
 ```
 

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -310,6 +310,7 @@ export interface BaseGridCell {
     readonly themeOverride?: Partial<Theme>;
     readonly span?: Item;
     readonly contentAlign?: "left" | "right" | "center";
+    readonly cursor?: CSSProperties["cursor"];
 }
 
 export interface LoadingCell extends BaseGridCell {

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -607,12 +607,14 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     const groupHeaderHovered = hCol !== undefined && hRow === -2;
     let clickableInnerCellHovered = false;
     let editableBoolHovered = false;
+    let cursorOverride: React.CSSProperties["cursor"] | undefined = undefined;
     if (hCol !== undefined && hRow !== undefined && hRow > -1) {
         const cell = getCellContent([hCol, hRow]);
         clickableInnerCellHovered =
             cell.kind === InnerGridCellKind.NewRow ||
             (cell.kind === InnerGridCellKind.Marker && cell.markerKind !== "number");
         editableBoolHovered = cell.kind === GridCellKind.Boolean && booleanCellIsEditable(cell);
+        cursorOverride = cell.cursor;
     }
     const canDrag = hoveredOnEdge ?? false;
     const cursor = isDragging
@@ -621,6 +623,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         ? "col-resize"
         : overFill || isFilling
         ? "crosshair"
+        : cursorOverride !== undefined
+        ? cursorOverride
         : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
         ? "pointer"
         : "default";


### PR DESCRIPTION
This PR allows developers to override the cursor that is shown when hovering over a given cell. We use this to display a `pointer` cursor on cells that contain a clickable link, for example.

This is my first contribution, so please feel free to let me know if I forgot anything in this PR.