### PR TITLE
Fix beep on Safari when copying cells using CMD+C

### DIFF
--- a/packages/core/src/data-editor/data-editor-fns.ts
+++ b/packages/core/src/data-editor/data-editor-fns.ts
@@ -207,8 +207,6 @@ export function copyToClipboard(
     columnIndexes: readonly number[],
     e?: ClipboardEvent
 ) {
-    e?.preventDefault();
-
     function escape(str: string): string {
         if (/[\n"\t]/.test(str)) {
             str = `"${str.replace(/"/g, '""')}"`;
@@ -307,4 +305,6 @@ export function copyToClipboard(
     } else {
         void window.navigator.clipboard?.writeText(str);
     }
+
+    e?.preventDefault();
 }

--- a/packages/core/src/data-editor/data-editor-fns.ts
+++ b/packages/core/src/data-editor/data-editor-fns.ts
@@ -207,6 +207,8 @@ export function copyToClipboard(
     columnIndexes: readonly number[],
     e?: ClipboardEvent
 ) {
+    e?.preventDefault();
+
     function escape(str: string): string {
         if (/[\n"\t]/.test(str)) {
             str = `"${str.replace(/"/g, '""')}"`;
@@ -298,7 +300,6 @@ export function copyToClipboard(
                 // This might fail if we had to await the thunk
                 e.clipboardData.setData("text/plain", str);
                 e.clipboardData.setData("text/html", `<table>${rootEl.outerHTML}</table>`);
-                e.preventDefault();
             } catch {
                 void window.navigator.clipboard?.writeText(str);
             }


### PR DESCRIPTION
In the current version, when you try to copy cells using CMD+C in Safari, you'd hear a beep indicating that the copy didn't work, even though data was successfully copied to the clipboard.

This PR fixes the issue by always calling `e.preventDefault()` in `copyToClipboard` when `e` is given.