### PR TITLE
Change column type from GridColumn to MappedGridColumn on DrawHeaderCallback

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -204,6 +204,7 @@ Grid columns are the basic horizontal building block of the data grid. At their 
 ```ts
 interface BaseGridColumn {
     readonly title: string;
+    readonly sourceIndex: number;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -204,7 +204,6 @@ Grid columns are the basic horizontal building block of the data grid. At their 
 ```ts
 interface BaseGridColumn {
     readonly title: string;
-    readonly sourceIndex: number;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;
@@ -605,7 +604,7 @@ You can specify `drawCell` to enable rendering your own cells. The Grid will cal
 ```ts
 drawHeader?: (args: {
     ctx: CanvasRenderingContext2D;
-    column: GridColumn;
+    column: MappedGridColumn;
     theme: Theme;
     rect: Rectangle;
     hoverAmount: number;

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -192,6 +192,7 @@ export const headerCellIndeterminateMarker = headerCellCheckboxPrefix + "indeter
 
 interface BaseGridColumn {
     readonly title: string;
+    readonly sourceIndex: number;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -5,6 +5,7 @@ import type React from "react";
 import type { CSSProperties } from "react";
 import type ImageWindowLoader from "../common/image-window-loader";
 import type { SpriteManager } from "./data-grid-sprites";
+import type { MappedGridColumn } from "./data-grid-lib";
 
 // Thoughts:
 // rows/columns are called out as selected, but when selected they must also be added
@@ -124,7 +125,7 @@ export type DrawCustomCellCallback = (args: {
 
 export type DrawHeaderCallback = (args: {
     ctx: CanvasRenderingContext2D;
-    column: GridColumn;
+    column: MappedGridColumn;
     theme: Theme;
     rect: Rectangle;
     hoverAmount: number;
@@ -192,7 +193,6 @@ export const headerCellIndeterminateMarker = headerCellCheckboxPrefix + "indeter
 
 interface BaseGridColumn {
     readonly title: string;
-    readonly sourceIndex: number;
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;


### PR DESCRIPTION
I noticed that `DrawCustomCellCallback` `GridColumn` was missing the `sourceIndex` prop. I think this is the correct fix.