### PR TITLE
Pass fixedShadowX and fixedShadowY down to child components

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -280,6 +280,9 @@ export interface DataEditorProps extends Props {
 
     readonly onPaste?: ((target: Item, values: readonly (readonly string[])[]) => boolean) | boolean;
 
+    readonly fixedShadowX?: DataGridSearchProps["fixedShadowX"];
+    readonly fixedShadowY?: DataGridSearchProps["fixedShadowY"];
+
     readonly theme?: Partial<Theme>;
 }
 
@@ -397,6 +400,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         onColumnResize: onColumnResizeIn,
         onColumnResizeEnd: onColumnResizeEndIn,
         onColumnResizeStart: onColumnResizeStartIn,
+        fixedShadowX,
+        fixedShadowY,
         ...rest
     } = p;
 
@@ -2917,6 +2922,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     translateX={visibleRegion.tx}
                     translateY={visibleRegion.ty}
                     verticalBorder={mangledVerticalBorder}
+                    fixedShadowX={fixedShadowX}
+                    fixedShadowY={fixedShadowY}
                     gridRef={gridRef}
                 />
                 {renameGroupNode}

--- a/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
@@ -53,6 +53,8 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
         onRowMoved,
         lockColumns,
         getCellContent,
+        fixedShadowX,
+        fixedShadowY
     } = p;
 
     const canResize = (onColumnResize ?? onColumnResizeEnd ?? onColumnResizeStart) !== undefined;
@@ -353,6 +355,8 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             onMouseUp={onMouseUpImpl}
             dragAndDropState={dragOffset}
             onMouseMoveRaw={onMouseMove}
+            fixedShadowX={fixedShadowX}
+            fixedShadowY={fixedShadowY}
             ref={gridRef}
         />
     );

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -453,6 +453,8 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                 translateX={p.translateX}
                 translateY={p.translateY}
                 onKeyDown={p.onKeyDown}
+                fixedShadowX={p.fixedShadowX}
+                fixedShadowY={p.fixedShadowY}
                 // handled props
                 prelightCells={searchResults}
             />


### PR DESCRIPTION
Thee props aren't being passed down into child components so setting them to false right now when rendering DataGrid doesn't do anything.