### PR TITLE
Fix keyboard shortcut not focusing search input (#443)

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -71,6 +71,7 @@ type Props = Omit<
     DataGridSearchProps,
     | "accessibilityHeight"
     | "canvasRef"
+    | "searchInputRef"
     | "cellXOffset"
     | "cellYOffset"
     | "className"
@@ -320,6 +321,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         highlight: boolean;
         forceEditMode: boolean;
     }>();
+    const searchInputRef = React.useRef<HTMLInputElement | null>(null);
     const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
     const [mouseState, setMouseState] = React.useState<MouseState>();
     const scrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -2044,6 +2046,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     return;
                 } else if (isHotkey("primary+f", event) && keybindings.search) {
                     event.cancel();
+                    searchInputRef?.current?.focus({ preventScroll: true });
                     setShowSearchInner(true);
                 }
 
@@ -2861,6 +2864,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 inHeight={height ?? idealHeight}>
                 <DataGridSearch
                     {...rest}
+                    searchInputRef={searchInputRef}
                     enableGroups={enableGroups}
                     onCanvasFocused={onCanvasFocused}
                     onCanvasBlur={onFocusOut}

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -49,6 +49,7 @@ export interface DataGridSearchProps extends Omit<ScrollingDataGridProps, "preli
     readonly onSearchResultsChanged?: (results: readonly Item[], navIndex: number) => void;
     readonly showSearch?: boolean;
     readonly onSearchClose?: () => void;
+    readonly searchInputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 const targetSearchTimeMS = 10;
@@ -60,6 +61,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
         showSearch = false,
         onSearchClose,
         canvasRef,
+        searchInputRef,
         cellYOffset,
         rows,
         columns,
@@ -78,7 +80,6 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
     searchStatusRef.current = searchStatus;
 
     const abortControllerRef = React.useRef(new AbortController());
-    const inputRef = React.useRef<HTMLInputElement | null>(null);
     const searchHandle = React.useRef<number>();
     const [searchResults, setSearchResults] = React.useState<readonly Item[]>([]);
 
@@ -227,11 +228,11 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
     );
 
     React.useEffect(() => {
-        if (showSearch && inputRef.current !== null) {
+        if (showSearch && searchInputRef.current !== null) {
             setSearchString("");
-            inputRef.current.focus({ preventScroll: true });
+            searchInputRef.current.focus({ preventScroll: true });
         }
-    }, [showSearch]);
+    }, [showSearch, searchInputRef]);
 
     const onNext = React.useCallback(
         (ev?: React.MouseEvent) => {
@@ -319,7 +320,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                         id={searchID}
                         aria-hidden={!showSearch}
                         data-testid="search-input"
-                        ref={inputRef}
+                        ref={searchInputRef}
                         onChange={onSearchChange}
                         value={searchString}
                         tabIndex={showSearch ? undefined : -1}
@@ -378,6 +379,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
         searchString,
         showSearch,
         searchID,
+        searchInputRef,
     ]);
 
     return (


### PR DESCRIPTION
If search field loses focus, pressing the keyboard shortcut
again should refocus it.

Not addressing customization in: #443