### PR TITLE
5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-beta1",
+    "version": "5.2.0-beta2",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-beta3",
+    "version": "5.2.0",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-alpha3",
+    "version": "5.2.0-alpha4",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-alpha1",
+    "version": "5.2.0-alpha2",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-alpha2",
+    "version": "5.2.0-alpha3",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-alpha4",
+    "version": "5.2.0-beta1",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.1.4",
+    "version": "5.2.0-alpha1",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "5.2.0-beta2",
+    "version": "5.2.0-beta3",
     "scripts": {
         "start": "npm run storybook",
         "version": "./update-version.sh",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.1.4",
+    "version": "5.2.0-alpha1",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.1.4",
+        "@glideapps/glide-data-grid": "5.2.0-alpha1",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-alpha1",
+    "version": "5.2.0-alpha2",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha1",
+        "@glideapps/glide-data-grid": "5.2.0-alpha2",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-beta3",
+    "version": "5.2.0",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta3",
+        "@glideapps/glide-data-grid": "5.2.0",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-beta2",
+    "version": "5.2.0-beta3",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta2",
+        "@glideapps/glide-data-grid": "5.2.0-beta3",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-alpha3",
+    "version": "5.2.0-alpha4",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha3",
+        "@glideapps/glide-data-grid": "5.2.0-alpha4",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-alpha2",
+    "version": "5.2.0-alpha3",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha2",
+        "@glideapps/glide-data-grid": "5.2.0-alpha3",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-beta1",
+    "version": "5.2.0-beta2",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta1",
+        "@glideapps/glide-data-grid": "5.2.0-beta2",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-cells",
-    "version": "5.2.0-alpha4",
+    "version": "5.2.0-beta1",
     "description": "Extra cells for glide-data-grid",
     "sideEffects": [
         "**/*.css"
@@ -50,7 +50,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha4",
+        "@glideapps/glide-data-grid": "5.2.0-beta1",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
         "react-select": "^5.2.2"

--- a/packages/cells/src/cells/links-cell.tsx
+++ b/packages/cells/src/cells/links-cell.tsx
@@ -98,7 +98,7 @@ const renderer: CustomRenderer<LinksCell> = {
 
         for (const [index, l] of links.entries()) {
             const needsComma = index < links.length - 1;
-            const metrics = measureTextCached(l.title, ctx);
+            const metrics = measureTextCached(l.title, ctx, font);
             const commaMetrics = needsComma ? measureTextCached(l.title + ",", ctx, font) : metrics;
 
             const isHovered = rectHoverX > drawX && rectHoverX < drawX + metrics.width;

--- a/packages/cells/src/cells/spinner-cell.tsx
+++ b/packages/cells/src/cells/spinner-cell.tsx
@@ -16,16 +16,10 @@ const renderer: CustomRenderer<SpinnerCell> = {
 
         const x = rect.x + rect.width / 2;
         const y = rect.y + rect.height / 2;
-        ctx.arc(
-            x,
-            y,
-            Math.min(12, rect.height / 2 - 2),
-            Math.PI * 2 * progress,
-            Math.PI * 2 * progress + Math.PI * 1.5
-        );
+        ctx.arc(x, y, Math.min(12, rect.height / 6), Math.PI * 2 * progress, Math.PI * 2 * progress + Math.PI * 1.5);
 
         ctx.strokeStyle = theme.textMedium;
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 1.5;
         ctx.stroke();
 
         ctx.lineWidth = 1;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.1.4",
+    "version": "5.2.0-alpha1",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-alpha4",
+    "version": "5.2.0-beta1",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-beta2",
+    "version": "5.2.0-beta3",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-alpha2",
+    "version": "5.2.0-alpha3",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-beta3",
+    "version": "5.2.0",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-alpha3",
+    "version": "5.2.0-alpha4",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-beta1",
+    "version": "5.2.0-beta2",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid",
-    "version": "5.2.0-alpha1",
+    "version": "5.2.0-alpha2",
     "description": "React data grid for beautifully displaying and editing large amounts of data with amazing performance.",
     "sideEffects": [
         "**/*.css"

--- a/packages/core/src/common/styles.ts
+++ b/packages/core/src/common/styles.ts
@@ -68,6 +68,7 @@ export interface Theme {
     cellHorizontalPadding: number;
     cellVerticalPadding: number;
     headerFontStyle: string;
+    headerIconSize: number;
     baseFontStyle: string;
     fontFamily: string;
     editorFontSize: string;
@@ -108,6 +109,8 @@ const dataEditorBaseTheme: Theme = {
 
     cellHorizontalPadding: 8,
     cellVerticalPadding: 3,
+
+    headerIconSize: 18,
 
     headerFontStyle: "600 13px",
     baseFontStyle: "13px",

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1029,6 +1029,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const vScrollReady = (visibleRegion.height ?? 1) > 1;
     React.useLayoutEffect(() => {
         if (scrollOffsetY !== undefined && scrollRef.current !== null && vScrollReady) {
+            if (scrollRef.current.scrollTop === scrollOffsetY) return;
             scrollRef.current.scrollTop = scrollOffsetY;
             if (scrollRef.current.scrollTop !== scrollOffsetY) {
                 empty();
@@ -1040,6 +1041,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const hScrollReady = (visibleRegion.width ?? 1) > 1;
     React.useLayoutEffect(() => {
         if (scrollOffsetX !== undefined && scrollRef.current !== null && hScrollReady) {
+            if (scrollRef.current.scrollLeft === scrollOffsetX) return;
             scrollRef.current.scrollLeft = scrollOffsetX;
             if (scrollRef.current.scrollLeft !== scrollOffsetX) {
                 empty();

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -313,6 +313,11 @@ export interface DataEditorProps extends Props {
      */
     readonly rowMarkerStartIndex?: number;
 
+    /** Changes the theme of the row marker column
+     * @group Style
+     */
+    readonly rowMarkerTheme?: Partial<Theme>;
+
     /** Sets the width of the data grid.
      * @group Style
      */
@@ -711,6 +716,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         freezeColumns = 0,
         rowSelectionMode = "auto",
         rowMarkerStartIndex = 1,
+        rowMarkerTheme,
         onHeaderMenuClick,
         getGroupDetails,
         onSearchClose: onSearchCloseIn,
@@ -988,10 +994,11 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 icon: undefined,
                 hasMenu: false,
                 style: "normal" as const,
+                themeOverride: rowMarkerTheme,
             },
             ...columns,
         ];
-    }, [columns, rowMarkerWidth, rowMarkers, rowMarkerHeader]);
+    }, [columns, rowMarkerWidth, rowMarkers, rowMarkerHeader, rowMarkerTheme]);
 
     const [visibleRegionY, visibleRegionTy] = React.useMemo(() => {
         return [

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2255,7 +2255,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 args.location[0] === 0 &&
                 rowMarkerOffset === 1 &&
                 rowSelect === "multi" &&
-                mouseState.previousSelection
+                mouseState.previousSelection &&
+                !mouseState.previousSelection.rows.hasIndex(mouseDownData.current.location[1]) &&
+                gridSelection.rows.hasIndex(mouseDownData.current.location[1])
             ) {
                 const start = Math.min(mouseDownData.current.location[1], args.location[1]);
                 const end = Math.max(mouseDownData.current.location[1], args.location[1]) + 1;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2937,7 +2937,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     ...args,
                     preventDefault,
                 });
-                updateSelectedCell(clickLocation, args.location[1], false, false);
+                updateSelectedCell(args.location[0], args.location[1], false, false);
             }
         },
         [onCellContextMenu, onGroupHeaderContextMenu, onHeaderContextMenu, rowMarkerOffset, updateSelectedCell]

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3223,8 +3223,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 outRow !== expectedExternalGridSelection.current?.current?.cell[1])
         ) {
             scrollToRef.current(outCol, outRow);
-            hasJustScrolled.current = false; //only allow skipping a single scroll
         }
+        hasJustScrolled.current = false; //only allow skipping a single scroll
     }, [outCol, outRow]);
 
     const disabledRows = React.useMemo(() => {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3223,6 +3223,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 outRow !== expectedExternalGridSelection.current?.current?.cell[1])
         ) {
             scrollToRef.current(outCol, outRow);
+            hasJustScrolled.current = false; //only allow skipping a single scroll
         }
     }, [outCol, outRow]);
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2251,6 +2251,18 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         (args: GridMouseEventArgs) => {
             if (
                 mouseState !== undefined &&
+                mouseDownData.current?.location[0] === 0 &&
+                args.location[0] === 0 &&
+                rowMarkerOffset === 1 &&
+                rowSelect === "multi" &&
+                mouseState.previousSelection
+            ) {
+                const start = Math.min(mouseDownData.current.location[1], args.location[1]);
+                const end = Math.max(mouseDownData.current.location[1], args.location[1]) + 1;
+                setSelectedRows(CompactSelection.fromSingleSelection([start, end]), undefined, false);
+            }
+            if (
+                mouseState !== undefined &&
                 gridSelection.current !== undefined &&
                 !isActivelyDragging.current &&
                 (rangeSelect === "rect" || rangeSelect === "multi-rect")

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -1891,29 +1891,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     );
 
     const isPrevented = React.useRef(false);
-    const onContextMenu = React.useCallback(
-        (args: GridMouseEventArgs, preventDefault: () => void) => {
-            const clickLocation = args.location[0] - rowMarkerOffset;
-            if (args.kind === "header") {
-                onHeaderContextMenu?.(clickLocation, { ...args, preventDefault });
-            }
-
-            if (args.kind === groupHeaderKind) {
-                if (clickLocation < 0) {
-                    return;
-                }
-                onGroupHeaderContextMenu?.(clickLocation, { ...args, preventDefault });
-            }
-
-            if (args.kind === "cell") {
-                onCellContextMenu?.([clickLocation, args.location[1]], {
-                    ...args,
-                    preventDefault,
-                });
-            }
-        },
-        [onCellContextMenu, onGroupHeaderContextMenu, onHeaderContextMenu, rowMarkerOffset]
-    );
 
     const normalSizeColumn = React.useCallback(
         async (col: number): Promise<void> => {
@@ -2939,6 +2916,31 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rangeSelect,
             lastRowSticky,
         ]
+    );
+
+    const onContextMenu = React.useCallback(
+        (args: GridMouseEventArgs, preventDefault: () => void) => {
+            const clickLocation = args.location[0] - rowMarkerOffset;
+            if (args.kind === "header") {
+                onHeaderContextMenu?.(clickLocation, { ...args, preventDefault });
+            }
+
+            if (args.kind === groupHeaderKind) {
+                if (clickLocation < 0) {
+                    return;
+                }
+                onGroupHeaderContextMenu?.(clickLocation, { ...args, preventDefault });
+            }
+
+            if (args.kind === "cell") {
+                onCellContextMenu?.([clickLocation, args.location[1]], {
+                    ...args,
+                    preventDefault,
+                });
+                updateSelectedCell(clickLocation, args.location[1], false, false);
+            }
+        },
+        [onCellContextMenu, onGroupHeaderContextMenu, onHeaderContextMenu, rowMarkerOffset, updateSelectedCell]
     );
 
     const onPasteInternal = React.useCallback(

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2311,7 +2311,18 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
             onItemHovered?.({ ...args, location: [args.location[0] - rowMarkerOffset, args.location[1]] as any });
         },
-        [mouseState, gridSelection, rangeSelect, onItemHovered, rowMarkerOffset, lastRowSticky, rows, setCurrent]
+        [
+            mouseState,
+            rowMarkerOffset,
+            rowSelect,
+            gridSelection,
+            rangeSelect,
+            onItemHovered,
+            setSelectedRows,
+            lastRowSticky,
+            rows,
+            setCurrent,
+        ]
     );
 
     // 1 === move one

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -1073,7 +1073,7 @@ export const ScrollShadows: React.VFC = () => {
 
     return (
         <BeautifulWrapper
-            title="Automatic Row Markers"
+            title="Scroll Shadows"
             description={
                 <>
                     <Description>You can enable and disable the horizontal/vertical scroll shadows.</Description>

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -92,6 +92,12 @@ export const ResizableColumns: React.VFC = () => {
                 maxColumnAutoWidth={500}
                 maxColumnWidth={2000}
                 rows={50}
+                scaleToRem={true}
+                theme={{
+                    baseFontStyle: "0.8125rem",
+                    headerFontStyle: "600 0.8125rem",
+                    editorFontSize: "0.8125rem",
+                }}
                 onColumnResize={onColumnResize}
                 getCellsForSelection={getCellsForSelection}
             />

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -1694,6 +1694,7 @@ export const AllCellKinds: React.VFC = () => {
                 getCellContent={getCellContent}
                 columns={cols}
                 onCellEdited={setCellValue}
+                // rowHeight={55}
                 onColumnResize={onColumnResize}
                 highlightRegions={[
                     {

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -79,6 +79,7 @@ export function useColumnSizer(
     themeRef.current = theme;
 
     const [ctx] = React.useState(() => {
+        if (typeof window === undefined) return null;
         const offscreen = document.createElement("canvas");
         offscreen.style["display"] = "none";
         offscreen.style["opacity"] = "0";

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -80,6 +80,10 @@ export function useColumnSizer(
 
     const [ctx] = React.useState(() => {
         const offscreen = document.createElement("canvas");
+        offscreen.style["display"] = "none";
+        offscreen.style["opacity"] = "0";
+        offscreen.style["position"] = "fixed";
+        document.documentElement.append(offscreen);
         return offscreen.getContext("2d", { alpha: false });
     });
 

--- a/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/data-grid-dnd/data-grid-dnd.tsx
@@ -398,7 +398,7 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             onItemHovered={onItemHoveredImpl}
             onDragStart={onDragStartImpl}
             onMouseDown={onMouseDownImpl}
-            allowResize={onColumnResize !== undefined}
+            allowResize={canResize}
             onMouseUp={onMouseUpImpl}
             dragAndDropState={dragOffset}
             onMouseMoveRaw={onMouseMove}

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -934,7 +934,7 @@ export function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCe
 
     const font = `${theme.baseFontStyle} ${theme.fontFamily}`;
     const emHeight = getEmHeight(ctx, font);
-    const h = Math.min(rect.height, Math.ceil(emHeight * theme.lineHeight) * 2);
+    const h = Math.min(rect.height, Math.max(16, Math.ceil(emHeight * theme.lineHeight) * 2));
     const y = Math.floor(rect.y + (rect.height - h) / 2);
 
     const bubbleHeight = h - 10;

--- a/packages/core/src/data-grid/data-grid-lib.ts
+++ b/packages/core/src/data-grid/data-grid-lib.ts
@@ -892,8 +892,9 @@ function getAndCacheDrilldownBorder(
 
     drilldownCache[key] = canvas;
 
+    const trueRounding = Math.min(rounding, targetWidth / 2, targetHeight / 2);
     ctx.beginPath();
-    roundedRect(ctx, shadowBlur, shadowBlur, targetWidth, targetHeight, rounding);
+    roundedRect(ctx, shadowBlur, shadowBlur, targetWidth, targetHeight, trueRounding);
 
     ctx.shadowColor = "rgba(24, 25, 34, 0.4)";
     ctx.shadowBlur = 1;
@@ -911,7 +912,7 @@ function getAndCacheDrilldownBorder(
     ctx.shadowBlur = 0;
 
     ctx.beginPath();
-    roundedRect(ctx, shadowBlur + 0.5, shadowBlur + 0.5, targetWidth, targetHeight, rounding);
+    roundedRect(ctx, shadowBlur + 0.5, shadowBlur + 0.5, targetWidth, targetHeight, trueRounding);
 
     ctx.strokeStyle = border;
     ctx.lineWidth = 1;

--- a/packages/core/src/data-grid/data-grid-render.tsx
+++ b/packages/core/src/data-grid/data-grid-render.tsx
@@ -705,7 +705,7 @@ export function drawHeader(
         return;
     }
 
-    const xPad = 8;
+    const xPad = theme.cellHorizontalPadding;
     const fillStyle = selected ? theme.textHeaderSelected : theme.textHeader;
 
     const shouldDrawMenu = c.hasMenu === true && (isHovered || (touchMode && selected));
@@ -716,7 +716,8 @@ export function drawHeader(
         if (c.style === "highlight") {
             variant = selected ? "selected" : "special";
         }
-        spriteManager.drawSprite(c.icon, variant, ctx, drawX, y + (height - 20) / 2, 20, theme);
+        const headerSize = theme.headerIconSize;
+        spriteManager.drawSprite(c.icon, variant, ctx, drawX, y + (height - headerSize) / 2, headerSize, theme);
 
         if (c.overlayIcon !== undefined) {
             spriteManager.drawSprite(
@@ -730,7 +731,7 @@ export function drawHeader(
             );
         }
 
-        drawX += 26;
+        drawX += Math.ceil(headerSize * 1.3);
     }
 
     if (shouldDrawMenu && c.hasMenu === true && width > 35) {

--- a/packages/core/src/data-grid/data-grid-types.ts
+++ b/packages/core/src/data-grid/data-grid-types.ts
@@ -22,6 +22,19 @@ export interface GridSelection {
     readonly rows: CompactSelection;
 }
 
+export function gridSelectionHasItem(sel: GridSelection, item: Item): boolean {
+    const [col, row] = item;
+    if (sel.columns.hasIndex(col) || sel.rows.hasIndex(row)) return true;
+    if (sel.current !== undefined) {
+        if (sel.current.cell[0] === col && sel.current.cell[1] === row) return true;
+        const toCheck = [sel.current.range, ...sel.current.rangeStack];
+        for (const r of toCheck) {
+            if (col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height) return true;
+        }
+    }
+    return false;
+}
+
 /** @category Types */
 export type ImageEditorType = React.ComponentType<OverlayImageEditorProps>;
 

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -634,8 +634,25 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     hoverInfoRef.current = hoveredItemInfo;
 
     const [bufferA, bufferB] = React.useMemo(() => {
-        return [document.createElement("canvas"), document.createElement("canvas")];
+        const a = document.createElement("canvas");
+        const b = document.createElement("canvas");
+        a.style["display"] = "none";
+        a.style["opacity"] = "0";
+        a.style["position"] = "fixed";
+        b.style["display"] = "none";
+        b.style["opacity"] = "0";
+        b.style["position"] = "fixed";
+        return [a, b];
     }, []);
+
+    React.useLayoutEffect(() => {
+        document.documentElement.append(bufferA);
+        document.documentElement.append(bufferB);
+        return () => {
+            bufferA.remove();
+            bufferB.remove();
+        };
+    }, [bufferA, bufferB]);
 
     const lastArgsRef = React.useRef<DrawGridArg>();
     const draw = React.useCallback(() => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2193,6 +2193,40 @@ describe("data-editor", () => {
         });
     });
 
+    test("Drag click row marker", async () => {
+        const spy = jest.fn();
+        jest.useFakeTimers();
+        render(<EventedDataEditor {...basicProps} onGridSelectionChange={spy} rowMarkers="both" />, {
+            wrapper: Context,
+        });
+        prep();
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        fireEvent.mouseDown(canvas, {
+            clientX: 10, // Row marker
+            clientY: 36 + 32 * 2 + 16, // Row 2 (0 indexed)
+        });
+
+        spy.mockClear();
+
+        fireEvent.mouseMove(canvas, {
+            shiftKey: true,
+            clientX: 10, // Row marker
+            clientY: 36 + 32 * 5 + 16, // Row 2 (0 indexed)
+        });
+
+        fireEvent.mouseUp(canvas, {
+            shiftKey: true,
+            clientX: 10, // Row marker
+            clientY: 36 + 32 * 5 + 16, // Row 2 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith({
+            columns: CompactSelection.empty(),
+            rows: CompactSelection.fromSingleSelection([2, 6]),
+        });
+    });
+
     test("Shift click row marker - no multi-select", async () => {
         const spy = jest.fn();
         jest.useFakeTimers();

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -355,6 +355,148 @@ describe("data-editor", () => {
         );
     });
 
+    test("emits contextmenu for cell but does not change selection if already selected - rows", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                gridSelection={{
+                    columns: CompactSelection.empty(),
+                    rows: CompactSelection.fromSingleSelection(1),
+                }}
+                onCellContextMenu={spy}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).not.toHaveBeenCalled();
+    });
+
+    test("emits contextmenu for cell but does not change selection if already selected - cols", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                gridSelection={{
+                    columns: CompactSelection.fromSingleSelection(1),
+                    rows: CompactSelection.empty(),
+                }}
+                onCellContextMenu={spy}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).not.toHaveBeenCalled();
+    });
+
+    test("emits contextmenu for cell but does not change selection if already selected - current.cell", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                gridSelection={{
+                    columns: CompactSelection.empty(),
+                    rows: CompactSelection.empty(),
+                    current: {
+                        cell: [1, 1],
+                        range: { x: 1, y: 1, width: 1, height: 1 },
+                        rangeStack: [],
+                    },
+                }}
+                onCellContextMenu={spy}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).not.toHaveBeenCalled();
+    });
+
+    test("emits contextmenu for cell but does not change selection if already selected - current.range", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                gridSelection={{
+                    columns: CompactSelection.empty(),
+                    rows: CompactSelection.empty(),
+                    current: {
+                        cell: [0, 0],
+                        range: { x: 0, y: 0, width: 2, height: 2 },
+                        rangeStack: [],
+                    },
+                }}
+                onCellContextMenu={spy}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).not.toHaveBeenCalled();
+    });
+
     test("emits contextmenu for cell row markers", async () => {
         const spy = jest.fn();
         const spySelection = jest.fn();

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -348,7 +348,45 @@ describe("data-editor", () => {
         });
 
         expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
-        expect(spySelection).toHaveBeenCalledWith("false");
+        expect(spySelection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                current: expect.objectContaining({ cell: [1, 1] }),
+            })
+        );
+    });
+
+    test("emits contextmenu for cell row markers", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                rowMarkers={"both"}
+                onCellContextMenu={spy}
+                onGridSelectionChange={spySelection}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 320, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                current: expect.objectContaining({ cell: [1, 1] }),
+            })
+        );
     });
 
     test("Emits cell click", async () => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "../src";
 import type { SizedGridColumn } from "../src/data-grid/data-grid-types";
 import type { DataEditorRef } from "../src/data-editor/data-editor";
+import { assert } from "../src/common/support";
 
 jest.mock("../src/common/resize-detector", () => {
     return {
@@ -326,6 +327,28 @@ describe("data-editor", () => {
 
         const a11ycell = screen.getByTestId("glide-cell-0-5");
         fireEvent.click(a11ycell);
+    });
+
+    test("emits contextmenu for cell", async () => {
+        const spy = jest.fn();
+        const spySelection = jest.fn();
+
+        jest.useFakeTimers();
+        render(<DataEditor {...basicProps} onCellContextMenu={spy} onGridSelectionChange={spySelection} />, {
+            wrapper: Context,
+        });
+        const scroller = prep();
+
+        assert(scroller !== null);
+
+        screen.getByTestId("data-grid-canvas");
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 16, // Row 1 (0 indexed)
+        });
+
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+        expect(spySelection).toHaveBeenCalledWith("false");
     });
 
     test("Emits cell click", async () => {

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-beta3",
+    "version": "5.2.0",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta3"
+        "@glideapps/glide-data-grid": "5.2.0"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-alpha3",
+    "version": "5.2.0-alpha4",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha3"
+        "@glideapps/glide-data-grid": "5.2.0-alpha4"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-beta1",
+    "version": "5.2.0-beta2",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta1"
+        "@glideapps/glide-data-grid": "5.2.0-beta2"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.1.4",
+    "version": "5.2.0-alpha1",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.1.4"
+        "@glideapps/glide-data-grid": "5.2.0-alpha1"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-alpha1",
+    "version": "5.2.0-alpha2",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha1"
+        "@glideapps/glide-data-grid": "5.2.0-alpha2"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-alpha4",
+    "version": "5.2.0-beta1",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha4"
+        "@glideapps/glide-data-grid": "5.2.0-beta1"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-beta2",
+    "version": "5.2.0-beta3",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-beta2"
+        "@glideapps/glide-data-grid": "5.2.0-beta3"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@glideapps/glide-data-grid-source",
-    "version": "5.2.0-alpha2",
+    "version": "5.2.0-alpha3",
     "description": "Useful data source hooks for Glide Data Grid",
     "sideEffects": false,
     "type": "module",
@@ -44,7 +44,7 @@
         "canvas"
     ],
     "dependencies": {
-        "@glideapps/glide-data-grid": "5.2.0-alpha2"
+        "@glideapps/glide-data-grid": "5.2.0-alpha3"
     },
     "peerDependencies": {
         "lodash": "^4.17.19",


### PR DESCRIPTION
## New Features

- REM support available via `scaleToRem` prop. You may want to specify font sizes in rems if set to try.
- Theme can now set `headerIconSize` to control header icon sizes.
- `rowMarkerTheme` now available for overriding the theme of the row marker column

## Bug Fixes

- Spinners no longer obnoxiously large
- Fix case where horizontal resize cursor would not show
- Links cell now properly uses font cache
- Headers now respect horizontal padding of theme