### PR TITLE
Add CodeSandbox example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ function getData([col, row]: Item): GridCell {
 }
 ```
 
+You can edit [this example live](https://codesandbox.io/s/glide-data-grid-template-ydvnnk) on CodeSandbox
+
 ## Full API documentation
 
 The full [API documentation is on the main site](https://grid.glideapps.com/docs/index.html).

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ function getData([col, row]: Item): GridCell {
 }
 ```
 
-You can edit [this example live](https://codesandbox.io/s/glide-data-grid-template-ydvnnk) on CodeSandbox
+You can [edit this example live](https://codesandbox.io/s/glide-data-grid-template-ydvnnk) on CodeSandbox
 
 ## Full API documentation
 


### PR DESCRIPTION
I found myself using CodeSandbox to test features and share examples frequently enough that I made a template for it based on the quick start guide in the README.

This adds a link to that template below the quick start section so people can jump right in to a live demo and tweak/edit it as they like.

---

Feel free to tweak this template as you see fit, and/or create your own version of it so you can keep it up to date. A (free) account is required to make a template, but anyone can fork and modify it, even without an account.