### PR TITLE
fix: pass openOverlay in appendRow

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -397,7 +397,7 @@ Requests the data grid to scroll to a particular location. If only one direction
 ## appendRow
 
 ```ts
-appendRow: (col: number) => Promise<void>;
+appendRow: (col: number, openOverlay: boolean = true) => Promise<void>;
 ```
 
 Appends a row to the data grid.

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -629,7 +629,7 @@ export interface DataEditorRef {
      * @param col The column index to focus in the new row.
      * @returns A promise which waits for the append to complete.
      */
-    appendRow: (col: number, openOverlay: boolean) => Promise<void>;
+    appendRow: (col: number, openOverlay?: boolean) => Promise<void>;
     /**
      * Triggers cells to redraw.
      */
@@ -3374,7 +3374,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     React.useImperativeHandle(
         forwardedRef,
         () => ({
-            appendRow: (col: number) => appendRow(col + rowMarkerOffset),
+            appendRow: (col: number, openOverlay?: boolean) => appendRow(col + rowMarkerOffset, openOverlay),
             updateCells: damageList => {
                 if (rowMarkerOffset !== 0) {
                     damageList = damageList.map(x => ({ cell: [x.cell[0] + rowMarkerOffset, x.cell[1]] }));


### PR DESCRIPTION
#408 

`openOverlay` was added to `appendRow` to prevent opening editor when a row is appended. However, this internal change did not affect its external ref. This PR fixes that.