### PR TITLE
feat: allow custom cells to define their own measuring methods

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -21,10 +21,8 @@ function measureCell(
     theme: Theme,
     getCellRenderer: GetCellRendererCallback
 ): number {
-    if (cell.kind === GridCellKind.Custom) return defaultSize;
-
     const r = getCellRenderer(cell);
-    return r?.measure?.(ctx, cell, theme) ?? defaultSize;
+    return ('measure' in r && r?.measure?.(ctx, cell, theme)) ?? defaultSize;
 }
 
 export function measureColumn(


### PR DESCRIPTION
Current glide table does not allow for `measureCell` functions to run properly for custom cells (only default cells support this). This allows for custom cells to work as well.