### PR TITLE
Fix support for `displayData` in uri cell

### DIFF
--- a/packages/core/src/data-grid/cells/uri-cell.tsx
+++ b/packages/core/src/data-grid/cells/uri-cell.tsx
@@ -13,7 +13,7 @@ export const uriCellRenderer: InternalCellRenderer<UriCell> = {
     useLabel: true,
     drawPrep: prepTextCell,
     draw: a => drawTextCell(a, a.cell.displayData ?? a.cell.data, a.cell.contentAlign),
-    measure: (ctx, cell, theme) => ctx.measureText(a.cell.displayData ?? cell.data).width + theme.cellHorizontalPadding * 2,
+    measure: (ctx, cell, theme) => ctx.measureText(cell.displayData ?? cell.data).width + theme.cellHorizontalPadding * 2,
     onDelete: c => ({
         ...c,
         data: "",

--- a/packages/core/src/data-grid/cells/uri-cell.tsx
+++ b/packages/core/src/data-grid/cells/uri-cell.tsx
@@ -12,8 +12,8 @@ export const uriCellRenderer: InternalCellRenderer<UriCell> = {
     needsHoverPosition: false,
     useLabel: true,
     drawPrep: prepTextCell,
-    draw: a => drawTextCell(a, a.cell.data, a.cell.contentAlign),
-    measure: (ctx, cell, theme) => ctx.measureText(cell.data).width + theme.cellHorizontalPadding * 2,
+    draw: a => drawTextCell(a, a.cell.displayData ?? a.cell.data, a.cell.contentAlign),
+    measure: (ctx, cell, theme) => ctx.measureText(a.cell.displayData ?? cell.data).width + theme.cellHorizontalPadding * 2,
     onDelete: c => ({
         ...c,
         data: "",


### PR DESCRIPTION
The URI cell allows configuring display data, but the behavior differs from other cell types. The display data is only applied to the overlay editor, but not drawn to the canvas. This PR fixes this by preferring `displayData` in case it is configured.