### PR TITLE
Add support for returning bounds of entire scroll area

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -368,10 +368,10 @@ Causes the data grid to rerender these specific cells. Rerendering a single cell
 ## getBounds
 
 ```ts
-getBounds: (col: number, row?: number) => Rectangle | undefined;
+getBounds: (col?: number, row?: number) => Rectangle | undefined;
 ```
 
-`getBounds` returns the current bounding box of a cell. This does not need to be a currently rendered cell.
+`getBounds` returns the current bounding box of a cell. This does not need to be a currently rendered cell. If called with `col` and `row` as undefined, the bounds of the entire data grid scroll area are returned.
 
 ---
 

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -371,7 +371,7 @@ Causes the data grid to rerender these specific cells. Rerendering a single cell
 getBounds: (col?: number, row?: number) => Rectangle | undefined;
 ```
 
-`getBounds` returns the current bounding box of a cell. This does not need to be a currently rendered cell. If called with `col` and `row` as undefined, the bounds of the entire data grid scroll area are returned.
+`getBounds` returns the current bounding box of a cell. This does not need to be a currently rendered cell. If called with `col` and `row` as undefined, the bounding box of the entire data grid scroll area is returned.
 
 ---
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3443,11 +3443,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 if (col === undefined && row === undefined && scrollRef.current && canvasRef.current) {
                     // Return the bounds of the entire scroll area:
                     const rect = canvasRef.current.getBoundingClientRect()
+                    const scale = rect.width / scrollRef.current.clientWidth
                     return {   
-                         x: rect.x - scrollRef.current.scrollLeft,
-                         y: rect.y - scrollRef.current.scrollTop,
-                         width: scrollRef.current.scrollWidth,
-                         height: scrollRef.current.scrollHeight,
+                         x: rect.x - scrollRef.current.scrollLeft * scale,
+                         y: rect.y - scrollRef.current.scrollTop * scale,
+                         width: scrollRef.current.scrollWidth * scale,
+                         height: scrollRef.current.scrollHeight * scale,
                      };
                 }
                 return gridRef.current?.getBounds(col !== undefined ? col + rowMarkerOffset : undefined, row);

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3440,7 +3440,17 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 return gridRef.current?.damage(damageList);
             },
             getBounds: (col, row) => {
-                return gridRef.current?.getBounds(col + rowMarkerOffset, row);
+                if (col === undefined && row === undefined && scrollRef.current && canvasRef.current) {
+                    // Return the bounds of the entire scroll area:
+                    const rect = canvasRef.current.getBoundingClientRect()
+                    return {   
+                         x: rect.x - scrollRef.current.scrollLeft,
+                         y: rect.y - scrollRef.current.scrollTop,
+                         width: scrollRef.current.scrollWidth,
+                         height: scrollRef.current.scrollHeight,
+                     };
+                }
+                return gridRef.current?.getBounds(col !== undefined ? col + rowMarkerOffset : undefined, row);
             },
             focus: () => gridRef.current?.focus(),
             emit: async e => {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3441,7 +3441,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             },
             getBounds: (col, row) => {
 
-                if (canvasRef.current === null || scrollRef.current === null) {
+                if (canvasRef?.current === null || scrollRef?.current === null) {
                     return undefined
                 }
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3441,7 +3441,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             },
             getBounds: (col, row) => {
 
-                if (canvasRef.current == undefined || scrollRef.current == undefined) {
+                if (canvasRef.current === null || scrollRef.current === null) {
                     return undefined
                 }
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3440,7 +3440,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 return gridRef.current?.damage(damageList);
             },
             getBounds: (col, row) => {
-                if (col === undefined && row === undefined && scrollRef.current && canvasRef.current) {
+
+                if (canvasRef.current == undefined || scrollRef.current == undefined) {
+                    return undefined
+                }
+
+                if (col === undefined && row === undefined) {
                     // Return the bounds of the entire scroll area:
                     const rect = canvasRef.current.getBoundingClientRect()
                     const scale = rect.width / scrollRef.current.clientWidth
@@ -3451,7 +3456,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                          height: scrollRef.current.scrollHeight * scale,
                      };
                 }
-                return gridRef.current?.getBounds(col !== undefined ? col + rowMarkerOffset : undefined, row);
+                return gridRef.current?.getBounds( col ?? 0 + rowMarkerOffset, row);
             },
             focus: () => gridRef.current?.focus(),
             emit: async e => {

--- a/packages/core/src/data-grid/data-grid.tsx
+++ b/packages/core/src/data-grid/data-grid.tsx
@@ -283,7 +283,7 @@ type DamageUpdateList = readonly {
 
 export interface DataGridRef {
     focus: () => void;
-    getBounds: (col: number, row?: number) => Rectangle | undefined;
+    getBounds: (col?: number, row?: number) => Rectangle | undefined;
     damage: (cells: DamageUpdateList) => void;
 }
 
@@ -1499,12 +1499,12 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                     });
                 }
             },
-            getBounds: (col: number, row?: number) => {
+            getBounds: (col?: number, row?: number) => {
                 if (canvasRef === undefined || canvasRef.current === null) {
                     return undefined;
                 }
 
-                return getBoundsForItem(canvasRef.current, col, row ?? -1);
+                return getBoundsForItem(canvasRef.current, col ?? 0, row ?? -1);
             },
             damage,
         }),


### PR DESCRIPTION
This is a rough draft of how the entire scroll bounds could be returned via `getBounds` if `cell` and `row` are undefined (see https://github.com/glideapps/glide-data-grid/issues/784). I did some manual testing, and it seems to align well with what is returned by `getBounds` for specific items. The height differs by one pixel when compared with the last cell bounds. But that is probably the border that is also included in the scroll area.  

