### PR TITLE
Convert `&nbsp;` to regular spaces in `decodeHTML`

### DIFF
--- a/packages/core/src/data-editor/data-editor-fns.ts
+++ b/packages/core/src/data-editor/data-editor-fns.ts
@@ -173,6 +173,11 @@ export function unquote(str: string): string[][] {
     return result;
 }
 
+function normalizeHTMLString(input: string): string {
+    // Convert &nbsp; to regular spaces
+    return input.replace(/\u00A0/g, ' ');
+}
+
 export function decodeHTML(tableEl: HTMLTableElement): string[][] | undefined {
     const walkEl: Element[] = [tableEl];
     const result: string[][] = [];
@@ -192,7 +197,7 @@ export function decodeHTML(tableEl: HTMLTableElement): string[][] | undefined {
             current = [];
             walkEl.push(...[...el.children].reverse());
         } else if (el instanceof HTMLTableCellElement) {
-            current?.push(el.innerText ?? el.textContent ?? "");
+            current?.push(normalizeHTMLString(el.innerText ?? el.textContent ?? ""));
         }
     }
 

--- a/packages/core/test/data-editor-fns.test.ts
+++ b/packages/core/test/data-editor-fns.test.ts
@@ -25,6 +25,27 @@ describe("data-editor-fns", () => {
         ]);
     });
 
+    test("decode html converts &nbsp; characters to regular spaces", () => {
+        const root = document.createElement("table");
+        root.innerHTML = `
+            <tbody>
+                <tr>
+                    <td>hi&nbsp;mom!</td>
+                </tr>
+                <tr>
+                    <td>&nbsp; &nbsp;</td>
+                </tr>
+            </tbody>
+        `;
+
+        const decoded = decodeHTML(root);
+
+        expect(decoded).toEqual([
+            ["hi mom!"],
+            ["   "]
+        ]);
+    });
+
     test("format empty bubble cell", () => {
         expect(
             formatCell(


### PR DESCRIPTION
Fixes https://github.com/glideapps/glide/issues/23589

When pasting `text/html` content, we generate a DOM fragment and then `decodeHTML` walks that DOM, reading out the text values of cells. During this process, regular space characters are converted into non-breaking space Unicode characters, which can cause subtle and annoying issues if, for instance the pasted text is re-copied out of GDG.

This PR modifies `decodeHTML` to normalize the strings it reads from the DOM by replacing the non-breaking space characters with regular spaces.