### PR TITLE
Horizontally center bubble cell editor

### DIFF
--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
@@ -3,6 +3,7 @@ import { styled } from "@linaria/react";
 export const BubblesOverlayEditorStyle = styled.div`
     display: flex;
     flex-wrap: wrap;
+    margin: auto;
 
     .boe-bubble {
         display: flex;

--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
@@ -3,7 +3,8 @@ import { styled } from "@linaria/react";
 export const BubblesOverlayEditorStyle = styled.div`
     display: flex;
     flex-wrap: wrap;
-    margin: auto;
+    margin-top: auto;
+    margin-bottom: auto;
 
     .boe-bubble {
         display: flex;


### PR DESCRIPTION
Mini fix to center the bubbles in the bubble cell editor overlay.

Before:

<img width="229" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/5d6f7dbe-d5fe-4116-aa8c-e580bdd6df47">

After:

<img width="229" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/f817c517-edfb-46fc-b56b-d41680b9e443">
