### PR TITLE
Add rounding radius property to theme

### DIFF
--- a/packages/cells/src/cells/article-cell-editor.tsx
+++ b/packages/cells/src/cells/article-cell-editor.tsx
@@ -14,10 +14,10 @@ const Wrapper = styled.div`
             border: none;
             padding: 8px 16px;
             font-size: 14px;
-            border-radius: 9px;
             font-weight: 500;
             font-family: var(--gdg-font-family);
             cursor: pointer;
+            border-radius: var(--gdg-rounding-radius, 9px);
         }
     }
     .gdg-save-button {

--- a/packages/cells/src/cells/button-cell.tsx
+++ b/packages/cells/src/cells/button-cell.tsx
@@ -111,7 +111,7 @@ const renderer: CustomRenderer<ButtonCell> = {
 
         if (backgroundColor !== undefined) {
             ctx.beginPath();
-            roundedRect(ctx, x, y, width, height, borderRadius ?? 0);
+            roundedRect(ctx, x, y, width, height, borderRadius ?? theme.roundingRadius ?? 0);
             ctx.fillStyle = unpackColor(backgroundColor, theme, hoverAmount);
             ctx.fill();
         }

--- a/packages/cells/src/cells/button-cell.tsx
+++ b/packages/cells/src/cells/button-cell.tsx
@@ -118,7 +118,7 @@ const renderer: CustomRenderer<ButtonCell> = {
 
         if (borderColor !== undefined) {
             ctx.beginPath();
-            roundedRect(ctx, x + 0.5, y + 0.5, width - 1, height - 1, borderRadius ?? 0);
+            roundedRect(ctx, x + 0.5, y + 0.5, width - 1, height - 1, borderRadius ?? theme.roundingRadius ?? 0);
             ctx.strokeStyle = unpackColor(borderColor, theme, hoverAmount);
             ctx.lineWidth = 1;
             ctx.stroke();

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -115,7 +115,7 @@ const renderer: CustomRenderer<TagsCell> = {
 
             ctx.fillStyle = color;
             ctx.beginPath();
-            roundedRect(ctx, x, y, width, tagHeight, tagHeight / 2);
+            roundedRect(ctx, x, y, width, tagHeight, theme.roundingRadius ?? tagHeight / 2);
             ctx.fill();
 
             ctx.fillStyle = theme.textDark;

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -51,7 +51,7 @@ const EditorWrap = styled.div<{ tagHeight: number; innerPad: number }>`
             margin-right: 6px;
             margin-bottom: 6px;
 
-            border-radius: ${p => p.tagHeight / 2}px;
+            border-radius: var(--gdg-rounding-radius, ${p => p.tagHeight / 2}px);
             min-height: ${p => p.tagHeight}px;
             padding: 2px ${p => p.innerPad}px;
             display: flex;
@@ -130,7 +130,7 @@ const renderer: CustomRenderer<TagsCell> = {
     provideEditor: () => {
         // eslint-disable-next-line react/display-name
         return p => {
-            const { onChange, value } = p;
+            const { onChange, value, theme } = p;
             const { readonly = false } = value;
             const { possibleTags, tags } = value.data;
             return (

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -130,7 +130,7 @@ const renderer: CustomRenderer<TagsCell> = {
     provideEditor: () => {
         // eslint-disable-next-line react/display-name
         return p => {
-            const { onChange, value, theme } = p;
+            const { onChange, value } = p;
             const { readonly = false } = value;
             const { possibleTags, tags } = value.data;
             return (

--- a/packages/core/src/cells/bubble-cell.tsx
+++ b/packages/core/src/cells/bubble-cell.tsx
@@ -52,7 +52,7 @@ function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
             y + (h - bubbleHeight) / 2,
             rectInfo.width + bubblePad * 2,
             bubbleHeight,
-            bubbleHeight / 2
+            theme.roundingRadius ?? bubbleHeight / 2
         );
     }
     ctx.fillStyle = highlighted ? theme.bgBubbleSelected : theme.bgBubble;

--- a/packages/core/src/cells/drilldown-cell.tsx
+++ b/packages/core/src/cells/drilldown-cell.tsx
@@ -41,7 +41,8 @@ const drilldownCache: {
 function getAndCacheDrilldownBorder(
     bgCell: string,
     border: string,
-    height: number
+    height: number,
+    rounding: number
 ): {
     el: HTMLCanvasElement;
     height: number;
@@ -55,7 +56,6 @@ function getAndCacheDrilldownBorder(
     const shadowBlur = 5;
     const targetHeight = height - shadowBlur * 2;
     const middleWidth = 4;
-    const rounding = 6;
 
     const innerHeight = height * dpr;
     const sideWidth = rounding + shadowBlur;
@@ -137,8 +137,9 @@ function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCellData[
     const bubblePad = 8;
     const bubbleMargin = itemMargin;
     let renderX = x + theme.cellHorizontalPadding;
+    const rounding = theme.roundingRadius ?? 6;
 
-    const tileMap = getAndCacheDrilldownBorder(theme.bgCell, theme.drilldownBorder, h);
+    const tileMap = getAndCacheDrilldownBorder(theme.bgCell, theme.drilldownBorder, h, rounding);
 
     const renderBoxes: { x: number; width: number }[] = [];
     for (const el of data) {
@@ -224,7 +225,7 @@ function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCellData[
                     srcHeight = srcWidth;
                 }
                 ctx.beginPath();
-                roundedRect(ctx, drawX, y + h / 2 - imgSize / 2, imgSize, imgSize, 3);
+                roundedRect(ctx, drawX, y + h / 2 - imgSize / 2, imgSize, imgSize, theme.roundingRadius ?? 3);
                 ctx.save();
                 ctx.clip();
                 ctx.drawImage(img, srcX, srcY, srcWidth, srcHeight, drawX, y + h / 2 - imgSize / 2, imgSize, imgSize);

--- a/packages/core/src/cells/drilldown-cell.tsx
+++ b/packages/core/src/cells/drilldown-cell.tsx
@@ -87,9 +87,8 @@ function getAndCacheDrilldownBorder(
 
     drilldownCache[key] = canvas;
 
-    const trueRounding = Math.min(rounding, targetWidth / 2, targetHeight / 2);
     ctx.beginPath();
-    roundedRect(ctx, shadowBlur, shadowBlur, targetWidth, targetHeight, trueRounding);
+    roundedRect(ctx, shadowBlur, shadowBlur, targetWidth, targetHeight, rounding);
 
     ctx.shadowColor = "rgba(24, 25, 34, 0.4)";
     ctx.shadowBlur = 1;
@@ -107,7 +106,7 @@ function getAndCacheDrilldownBorder(
     ctx.shadowBlur = 0;
 
     ctx.beginPath();
-    roundedRect(ctx, shadowBlur + 0.5, shadowBlur + 0.5, targetWidth, targetHeight, trueRounding);
+    roundedRect(ctx, shadowBlur + 0.5, shadowBlur + 0.5, targetWidth, targetHeight, rounding);
 
     ctx.strokeStyle = border;
     ctx.lineWidth = 1;

--- a/packages/core/src/cells/image-cell.tsx
+++ b/packages/core/src/cells/image-cell.tsx
@@ -11,7 +11,13 @@ export const imageCellRenderer: InternalCellRenderer<ImageCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
-    draw: a => drawImage(a, a.cell.displayData ?? a.cell.data, a.cell.rounding, a.cell.contentAlign),
+    draw: a =>
+        drawImage(
+            a,
+            a.cell.displayData ?? a.cell.data,
+            a.cell.rounding ?? a.theme.roundingRadius ?? 4,
+            a.cell.contentAlign
+        ),
     measure: (_ctx, cell) => cell.data.length * 50,
     onDelete: c => ({
         ...c,
@@ -63,7 +69,7 @@ const itemMargin = 4;
 export function drawImage(
     args: BaseDrawArgs,
     data: readonly string[],
-    rounding: number = 4,
+    rounding: number,
     contentAlign?: BaseGridCell["contentAlign"]
 ) {
     const { rect, col, row, theme, ctx, imageLoader } = args;

--- a/packages/core/src/cells/loading-cell.tsx
+++ b/packages/core/src/cells/loading-cell.tsx
@@ -37,7 +37,14 @@ export const loadingCellRenderer: InternalCellRenderer<LoadingCell> = {
         const hpad = theme.cellHorizontalPadding;
         const rectHeight = cell.skeletonHeight ?? Math.min(18, rect.height - 2 * theme.cellVerticalPadding);
 
-        roundedRect(ctx, rect.x + hpad, rect.y + (rect.height - rectHeight) / 2, width, rectHeight, 3);
+        roundedRect(
+            ctx,
+            rect.x + hpad,
+            rect.y + (rect.height - rectHeight) / 2,
+            width,
+            rectHeight,
+            theme.roundingRadius ?? 3
+        );
         ctx.fillStyle = withAlpha(theme.textDark, 0.1);
         ctx.fill();
     },

--- a/packages/core/src/common/styles.ts
+++ b/packages/core/src/common/styles.ts
@@ -75,6 +75,7 @@ export interface Theme {
     fontFamily: string;
     editorFontSize: string;
     lineHeight: number;
+    roundingRadius?: number;
 }
 
 const dataEditorBaseTheme: Theme = {

--- a/packages/core/src/common/styles.ts
+++ b/packages/core/src/common/styles.ts
@@ -36,6 +36,7 @@ export function makeCSSStyle(theme: Theme): Record<string, string> {
         "--gdg-marker-font-style": theme.markerFontStyle,
         "--gdg-font-family": theme.fontFamily,
         "--gdg-editor-font-size": theme.editorFontSize,
+        ...(theme.roundingRadius === undefined ? {} : { "--gdg-rounding-radius": `${theme.roundingRadius}px` }),
     };
 }
 

--- a/packages/core/src/docs/examples/theme-support.stories.tsx
+++ b/packages/core/src/docs/examples/theme-support.stories.tsx
@@ -93,6 +93,7 @@ const hotdogStand = {
     baseFontStyle: "13px",
     fontFamily:
         "Inter, Roboto, -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Ubuntu, noto, arial, sans-serif",
+    roundingRadius: 6,
 };
 
 export const ThemeSupport: React.VFC = () => {

--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -181,6 +181,7 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                 imageEditorOverride={imageEditorOverride}
                 markdownDivCreateNode={markdownDivCreateNode}
                 isValid={isValid}
+                theme={theme}
             />
         );
     }

--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
@@ -1,5 +1,7 @@
 import { styled } from "@linaria/react";
 
+const BUBBLE_HEIGHT = 20;
+
 export const BubblesOverlayEditorStyle = styled.div`
     display: flex;
     flex-wrap: wrap;
@@ -11,11 +13,10 @@ export const BubblesOverlayEditorStyle = styled.div`
         justify-content: center;
         align-items: center;
 
-        border-radius: 100px;
+        border-radius: var(--gdg-rounding-radius, ${BUBBLE_HEIGHT / 2}px);
 
         padding: 0 8px;
-        height: 20px;
-
+        height: ${BUBBLE_HEIGHT}px;
         background-color: var(--gdg-bg-bubble);
         color: var(--gdg-text-dark);
         margin: 2px;

--- a/packages/core/src/internal/data-grid-overlay-editor/private/drilldown-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/drilldown-overlay-editor.tsx
@@ -11,8 +11,6 @@ const DrilldownOverlayEditorStyle = styled.div`
         justify-content: center;
         align-items: center;
 
-        border-radius: 100px;
-
         padding: 0 8px;
         height: 24px;
 
@@ -20,7 +18,7 @@ const DrilldownOverlayEditorStyle = styled.div`
         color: var(--gdg-text-dark);
         margin: 2px;
 
-        border-radius: 6px;
+        border-radius: var(--gdg-rounding-radius, 6px);
 
         box-shadow:
             0 0 1px rgba(62, 65, 86, 0.4),

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -372,6 +372,7 @@ export type ProvideEditorComponent<T extends InnerGridCell> = React.FunctionComp
     readonly target: Rectangle;
     readonly forceEditMode: boolean;
     readonly isValid?: boolean;
+    readonly theme: Theme;
 }>;
 
 type ObjectEditorCallbackResult<T extends InnerGridCell> = {

--- a/packages/core/src/internal/data-grid/draw-checkbox.ts
+++ b/packages/core/src/internal/data-grid/draw-checkbox.ts
@@ -19,7 +19,7 @@ export function drawCheckbox(
     alignment: BaseGridCell["contentAlign"] = "center"
 ) {
     const centerY = Math.floor(y + height / 2);
-    const rectBordRadius = 4;
+    const rectBordRadius = theme.roundingRadius ?? 4;
     const checkBoxWidth = getSquareWidth(maxSize, height, theme.cellVerticalPadding);
     const checkBoxHalfWidth = checkBoxWidth / 2;
     const posX = getSquareXPosFromAlign(alignment, x, width, theme.cellHorizontalPadding, checkBoxWidth);


### PR DESCRIPTION
Introduces an optional `roundingRadius` theming option which is used as a default/fallback for rounded rects in GDG:

This is applied in: 

- Skeleton of loading cell
- Checkbox
- Image cell
- Button cell
- Tags cell
- Bubble cell
- Drilldown cell

Example with `roundingRadius==6`

<img width="764" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/ba5be0d1-02dc-4a19-b7f2-b0ca88a2c74a">


Closes https://github.com/glideapps/glide-data-grid/issues/845