### PR TITLE
Use `accentLight` color for resize indicator

### DIFF
--- a/packages/core/src/internal/data-grid/data-grid-render.tsx
+++ b/packages/core/src/internal/data-grid/data-grid-render.tsx
@@ -1828,7 +1828,7 @@ function drawColumnResizeOutline(
     ctx.lineTo(yOffset, height);
 
     ctx.lineWidth = 2;
-    ctx.strokeStyle = theme.accentColor;
+    ctx.strokeStyle = theme.accentLight;
 
     ctx.stroke();
 

--- a/packages/core/src/internal/data-grid/data-grid-render.tsx
+++ b/packages/core/src/internal/data-grid/data-grid-render.tsx
@@ -1828,7 +1828,7 @@ function drawColumnResizeOutline(
     ctx.lineTo(yOffset, height);
 
     ctx.lineWidth = 2;
-    ctx.strokeStyle = theme.accentLight;
+    ctx.strokeStyle = blend(theme.accentLight, theme.bgCell);
 
     ctx.stroke();
 


### PR DESCRIPTION
Uses `accentLight` color for resize indicator instead of `accentColor`:

https://github.com/glideapps/glide-data-grid/assets/2852129/f9c759ec-7d7c-404c-8704-a0aaae0e3887

