### PR TITLE
Fix sparkline cell with two values

### DIFF
--- a/packages/cells/src/cells/sparkline-cell.tsx
+++ b/packages/cells/src/cells/sparkline-cell.tsx
@@ -68,7 +68,7 @@ const renderer: CustomRenderer<SparklineCell> = {
         } else {
             if (values.length === 1) {
                 values = [values[0], values[0]];
-                if (displayValues !== undefined) {
+                if (displayValues) {
                     displayValues = [displayValues[0], displayValues[0]];
                 }
             }

--- a/packages/cells/src/cells/sparkline-cell.tsx
+++ b/packages/cells/src/cells/sparkline-cell.tsx
@@ -66,7 +66,12 @@ const renderer: CustomRenderer<SparklineCell> = {
             ctx.fillStyle = cell.data.color ?? theme.accentColor;
             ctx.fill();
         } else {
-            if (values.length === 1) values = [values[0], values[0]];
+            if (values.length === 1) {
+                values = [values[0], values[0]];
+                if (displayValues !== undefined) {
+                    displayValues = [displayValues[0], displayValues[0]];
+                }
+            }
             // draw line
             ctx.beginPath();
 
@@ -79,11 +84,13 @@ const renderer: CustomRenderer<SparklineCell> = {
             });
             ctx.moveTo(points[0].x, points[0].y);
 
-            let i: number;
-            for (i = 1; i < points.length - 2; i++) {
-                const xControl = (points[i].x + points[i + 1].x) / 2;
-                const yControl = (points[i].y + points[i + 1].y) / 2;
-                ctx.quadraticCurveTo(points[i].x, points[i].y, xControl, yControl);
+            let i = 0;
+            if (points.length > 2) {
+                for (i = 1; i < points.length - 2; i++) {
+                    const xControl = (points[i].x + points[i + 1].x) / 2;
+                    const yControl = (points[i].y + points[i + 1].y) / 2;
+                    ctx.quadraticCurveTo(points[i].x, points[i].y, xControl, yControl);
+                }
             }
             ctx.quadraticCurveTo(points[i].x, points[i].y, points[i + 1].x, points[i + 1].y);
 


### PR DESCRIPTION
Sparkline cell with line or area chart currently throws an error if it is used with less than three values:

<img width="1014" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/4eb7e090-403c-4bae-8b71-ce7a4eb5c2cd">

It also fixes the display label if only one value is used. 
