### PR TITLE
Add multi-select cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "root",
-    "version": "5.99.9-charlie9",
+    "version": "6.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "root",
-            "version": "5.99.9-charlie9",
+            "version": "6.0.0",
             "license": "MIT",
             "workspaces": [
                 "./packages/core",
@@ -7820,6 +7820,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/chroma-js": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.3.tgz",
+            "integrity": "sha512-1ly5ly/7S/YF8aD7MxUQnFOZxdegimuOunJl0xDsLlguu5JrwuSTVGVH3UpIUlh6YauI0RMNT4cqjBonhgbdIQ==",
+            "dev": true
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -9929,6 +9935,11 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/chroma-js": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -20663,17 +20674,19 @@
         },
         "packages/cells": {
             "name": "@glideapps/glide-data-grid-cells",
-            "version": "5.99.9-charlie9",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "5.99.9-charlie9",
+                "@glideapps/glide-data-grid": "6.0.0",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
+                "chroma-js": "^2.4.2",
                 "react-select": "^5.2.2"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
+                "@types/chroma-js": "^2.4.3",
                 "@types/prosemirror-commands": "^1.0.4",
                 "@types/react": "16.14.21",
                 "eslint": "^8.19.0",
@@ -20687,7 +20700,7 @@
         },
         "packages/core": {
             "name": "@glideapps/glide-data-grid",
-            "version": "5.99.9-charlie9",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
                 "@linaria/react": "^4.5.3",
@@ -20759,10 +20772,10 @@
         },
         "packages/source": {
             "name": "@glideapps/glide-data-grid-source",
-            "version": "5.99.9-charlie9",
+            "version": "6.0.0",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "5.99.9-charlie9"
+                "@glideapps/glide-data-grid": "6.0.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
@@ -22711,12 +22724,14 @@
             "version": "file:packages/cells",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "5.99.9-charlie9",
+                "@glideapps/glide-data-grid": "6.0.0",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
+                "@types/chroma-js": "^2.4.3",
                 "@types/prosemirror-commands": "^1.0.4",
                 "@types/react": "16.14.21",
+                "chroma-js": "^2.4.2",
                 "eslint": "^8.19.0",
                 "eslint-plugin-import": "^2.22.0",
                 "eslint-plugin-react": "^7.21.5",
@@ -22731,7 +22746,7 @@
             "version": "file:packages/source",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "5.99.9-charlie9",
+                "@glideapps/glide-data-grid": "6.0.0",
                 "eslint": "^8.19.0",
                 "eslint-plugin-import": "^2.22.0",
                 "eslint-plugin-react": "^7.21.5",
@@ -25907,6 +25922,12 @@
                 "@types/node": "*"
             }
         },
+        "@types/chroma-js": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.3.tgz",
+            "integrity": "sha512-1ly5ly/7S/YF8aD7MxUQnFOZxdegimuOunJl0xDsLlguu5JrwuSTVGVH3UpIUlh6YauI0RMNT4cqjBonhgbdIQ==",
+            "dev": true
+        },
         "@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -27511,6 +27532,11 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
             "dev": true
+        },
+        "chroma-js": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
         },
         "chrome-trace-event": {
             "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7820,12 +7820,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/chroma-js": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.3.tgz",
-            "integrity": "sha512-1ly5ly/7S/YF8aD7MxUQnFOZxdegimuOunJl0xDsLlguu5JrwuSTVGVH3UpIUlh6YauI0RMNT4cqjBonhgbdIQ==",
-            "dev": true
-        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -9935,11 +9929,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/chroma-js": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
-            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
@@ -20681,12 +20670,10 @@
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
-                "chroma-js": "^2.4.2",
                 "react-select": "^5.2.2"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
-                "@types/chroma-js": "^2.4.3",
                 "@types/prosemirror-commands": "^1.0.4",
                 "@types/react": "16.14.21",
                 "eslint": "^8.19.0",
@@ -22728,10 +22715,8 @@
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
-                "@types/chroma-js": "^2.4.3",
                 "@types/prosemirror-commands": "^1.0.4",
                 "@types/react": "16.14.21",
-                "chroma-js": "^2.4.2",
                 "eslint": "^8.19.0",
                 "eslint-plugin-import": "^2.22.0",
                 "eslint-plugin-react": "^7.21.5",
@@ -25922,12 +25907,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/chroma-js": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.4.3.tgz",
-            "integrity": "sha512-1ly5ly/7S/YF8aD7MxUQnFOZxdegimuOunJl0xDsLlguu5JrwuSTVGVH3UpIUlh6YauI0RMNT4cqjBonhgbdIQ==",
-            "dev": true
-        },
         "@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -27532,11 +27511,6 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
             "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
             "dev": true
-        },
-        "chroma-js": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
-            "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
         },
         "chrome-trace-event": {
             "version": "1.0.3",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -54,10 +54,12 @@
         "@linaria/react": "^4.5.3",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
+        "chroma-js": "^2.4.2",
         "react-select": "^5.2.2"
     },
     "devDependencies": {
         "@babel/cli": "^7.16.0",
+        "@types/chroma-js": "^2.4.3",
         "@types/prosemirror-commands": "^1.0.4",
         "@types/react": "16.14.21",
         "eslint": "^8.19.0",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -54,12 +54,10 @@
         "@linaria/react": "^4.5.3",
         "@toast-ui/editor": "3.1.10",
         "@toast-ui/react-editor": "3.1.10",
-        "chroma-js": "^2.4.2",
         "react-select": "^5.2.2"
     },
     "devDependencies": {
         "@babel/cli": "^7.16.0",
-        "@types/chroma-js": "^2.4.3",
         "@types/prosemirror-commands": "^1.0.4",
         "@types/react": "16.14.21",
         "eslint": "^8.19.0",

--- a/packages/cells/src/cells/multi-select-cell.tsx
+++ b/packages/cells/src/cells/multi-select-cell.tsx
@@ -432,7 +432,7 @@ const renderer: CustomRenderer<MultiSelectCell> = {
             roundedRect(ctx, x, y, width, BUBBLE_HEIGHT, theme.roundingRadius ?? BUBBLE_HEIGHT / 2);
             ctx.fill();
 
-            // If a color is set for this option, we use it to determine the text color.
+            // If a color is set for this option, we use either black or white as the text color depending on the background.
             // Otherwise, use the configured textBubble color.
             ctx.fillStyle = matchedOption?.color ? (color.luminance() > 0.5 ? "#000000" : "#ffffff") : theme.textBubble;
             ctx.fillText(displayText, x + BUBBLE_PADDING, y + textY + getMiddleCenterBias(ctx, theme));

--- a/packages/cells/src/cells/multi-select-cell.tsx
+++ b/packages/cells/src/cells/multi-select-cell.tsx
@@ -11,7 +11,6 @@ import {
     GridCellKind,
     roundedRect,
     getLuminance,
-    toHex,
 } from "@glideapps/glide-data-grid";
 
 import { styled } from "@linaria/react";
@@ -229,7 +228,7 @@ const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
         multiValue: (styles, { data }) => {
             return {
                 ...styles,
-                backgroundColor: data.color ? toHex(data.color) : theme.bgBubble,
+                backgroundColor: data.color ?? theme.bgBubble,
                 borderRadius: `${theme.roundingRadius ?? BUBBLE_HEIGHT / 2}px`,
             };
         },
@@ -410,11 +409,7 @@ const renderer: CustomRenderer<MultiSelectCell> = {
                 : drawArea.y + (drawArea.height - rows * BUBBLE_HEIGHT - (rows - 1) * BUBBLE_PADDING) / 2;
         for (const value of values) {
             const matchedOption = options.find(t => t.value === value);
-            const colorHex = matchedOption?.color
-                ? toHex(matchedOption?.color)
-                : highlighted
-                ? theme.bgBubbleSelected
-                : theme.bgBubble;
+            const color = matchedOption?.color ?? (highlighted ? theme.bgBubbleSelected : theme.bgBubble);
             const displayText = matchedOption?.label ?? value;
             const metrics = measureTextCached(displayText, ctx);
             const width = metrics.width + BUBBLE_PADDING * 2;
@@ -426,7 +421,7 @@ const renderer: CustomRenderer<MultiSelectCell> = {
                 x = drawArea.x;
             }
 
-            ctx.fillStyle = colorHex;
+            ctx.fillStyle = color;
             ctx.beginPath();
             roundedRect(ctx, x, y, width, BUBBLE_HEIGHT, theme.roundingRadius ?? BUBBLE_HEIGHT / 2);
             ctx.fill();
@@ -434,7 +429,7 @@ const renderer: CustomRenderer<MultiSelectCell> = {
             // If a color is set for this option, we use either black or white as the text color depending on the background.
             // Otherwise, use the configured textBubble color.
             ctx.fillStyle = matchedOption?.color
-                ? getLuminance(colorHex) > 0.5
+                ? getLuminance(color) > 0.5
                     ? "#000000"
                     : "#ffffff"
                 : theme.textBubble;

--- a/packages/cells/src/cells/multi-select-cell.tsx
+++ b/packages/cells/src/cells/multi-select-cell.tsx
@@ -235,7 +235,7 @@ const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
         multiValueLabel: (styles, { data, isDisabled }) => {
             return {
                 ...styles,
-                paddingRight: isDisabled ? BUBBLE_PADDING : undefined,
+                paddingRight: isDisabled ? BUBBLE_PADDING : 0,
                 paddingLeft: BUBBLE_PADDING,
                 paddingTop: 0,
                 paddingBottom: 0,

--- a/packages/cells/src/cells/multi-select-cell.tsx
+++ b/packages/cells/src/cells/multi-select-cell.tsx
@@ -1,0 +1,511 @@
+import * as React from "react";
+
+import {
+    type CustomCell,
+    type ProvideEditorCallback,
+    type CustomRenderer,
+    type Rectangle,
+    measureTextCached,
+    getMiddleCenterBias,
+    useTheme,
+    GridCellKind,
+    roundedRect,
+} from "@glideapps/glide-data-grid";
+
+import { styled } from "@linaria/react";
+import chroma from "chroma-js";
+import Select, { type MenuProps, components, type StylesConfig } from "react-select";
+import CreatableSelect from "react-select/creatable";
+
+type SelectOption = { value: string; label?: string; color?: string };
+
+interface MultiSelectCellProps {
+    readonly kind: "multi-select-cell";
+    /* The list of values of this cell. */
+    readonly values: string[] | undefined | null;
+    /* The list of possible options that can be selected.
+    The options can be provided as a list of strings
+    or as a list of objects with the following properties:
+    - value: The value of this option.
+    - label: The label of this option. If not provided, the value will be used as the label.
+    - color: The color of this option. If not provided, the default color will be used. */
+    readonly options?: readonly (SelectOption | string)[];
+    /* If true, users can create new values that are not part of the configured options. */
+    readonly allowCreation?: boolean;
+    /* If true, users can select the same value multiple times. */
+    readonly allowDuplicates?: boolean;
+}
+
+const BUBBLE_HEIGHT = 20;
+const BUBBLE_PADDING = 6;
+const BUBBLE_MARGIN = 4;
+/* This prefix is used when allowDuplicates is enabled to make sure that
+all underlying values are unique. */
+const VALUE_PREFIX = "__value";
+const VALUE_PREFIX_REGEX = new RegExp(`^${VALUE_PREFIX}\\d+__`);
+
+const Wrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    margin-top: auto;
+    margin-bottom: auto;
+    .gdg-multi-select {
+        font-family: var(--gdg-font-family);
+        font-size: var(--gdg-editor-font-size);
+    }
+`;
+
+const PortalWrap = styled.div`
+    font-family: var(--gdg-font-family);
+    font-size: var(--gdg-editor-font-size);
+    color: var(--gdg-text-dark);
+
+    > div {
+        border-radius: 4px;
+        border: 1px solid var(--gdg-border-color);
+    }
+`;
+
+/**
+ * Prepares the options for usage with the react-select component.
+ *
+ * @param options The options to prepare.
+ * @returns The prepared options in the format required by react-select.
+ */
+export const prepareOptions = (
+    options: readonly (string | SelectOption)[]
+): { value: string; label?: string; color?: string }[] => {
+    return options.map(option => {
+        if (typeof option === "string" || option === null || option === undefined) {
+            return { value: option, label: option ?? "", color: undefined };
+        }
+
+        return {
+            value: option.value,
+            label: option.label ?? option.value ?? "",
+            color: option.color ?? undefined,
+        };
+    });
+};
+
+/**
+ * Resolve a list values to values compatible with react-select.
+ * If allowDuplicates is true, the values will be prefixed with a numbered prefix to
+ * make sure that all values are unique.
+ *
+ * @param values The values to resolve.
+ * @param options The options to use for the resolution.
+ * @param allowDuplicates If true, the values can contain duplicates.
+ * @returns The list of values compatible with react-select.
+ */
+export const resolveValues = (
+    values: string[] | null | undefined,
+    options: readonly SelectOption[],
+    allowDuplicates?: boolean
+): { value: string; label?: string; color?: string }[] => {
+    if (values === undefined || values === null) {
+        return [];
+    }
+
+    return values.map((value, index) => {
+        const valuePrefix = allowDuplicates ? `${VALUE_PREFIX}${index}__` : "";
+        const matchedOption = options.find(option => {
+            return option.value === value;
+        });
+        if (matchedOption) {
+            return {
+                ...matchedOption,
+                value: `${valuePrefix}${matchedOption.value}`,
+            };
+        }
+        return { value: `${valuePrefix}${value}`, label: value };
+    });
+};
+
+interface CustomMenuProps extends MenuProps<any> {}
+
+const CustomMenu: React.FC<CustomMenuProps> = p => {
+    const { Menu } = components;
+    const { children, ...rest } = p;
+    return <Menu {...rest}>{children}</Menu>;
+};
+
+export type MultiSelectCell = CustomCell<MultiSelectCellProps>;
+
+const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
+    const { value: cell, initialValue, onChange, onFinishedEditing } = p;
+    const { options: optionsIn, values: valuesIn, allowCreation, allowDuplicates } = cell.data;
+
+    const theme = useTheme();
+    const [value, setValue] = React.useState(valuesIn);
+    const [menuOpen, setMenuOpen] = React.useState(true);
+    const [inputValue, setInputValue] = React.useState(initialValue ?? "");
+
+    const options = React.useMemo(() => {
+        return prepareOptions(optionsIn ?? []);
+    }, [optionsIn]);
+
+    const menuDisabled = allowCreation && allowDuplicates && options.length === 0;
+
+    // Prevent the grid from handling the keydown as long as the menu is open:
+    // This allows usage of enter without triggering the grid to finish editing.
+    const onKeyDown = React.useCallback(
+        (e: React.KeyboardEvent) => {
+            if (menuOpen) {
+                e.stopPropagation();
+            }
+        },
+        [menuOpen]
+    );
+
+    // Apply styles to the react-select component.
+    // All components: https://react-select.com/components
+    const colorStyles: StylesConfig<SelectOption, true> = {
+        control: base => ({
+            ...base,
+            border: 0,
+            boxShadow: "none",
+            backgroundColor: theme.bgCell,
+        }),
+        menu: styles => ({
+            ...styles,
+            backgroundColor: theme.bgCell,
+        }),
+        option: (styles, state) => {
+            return {
+                ...styles,
+                fontSize: theme.editorFontSize,
+                fontFamily: theme.fontFamily,
+                color: theme.textDark,
+                ...(state.isFocused ? { backgroundColor: theme.accentLight, cursor: "pointer" } : {}),
+                ":active": {
+                    ...styles[":active"],
+                    color: theme.accentFg,
+                    backgroundColor: theme.accentColor,
+                },
+            };
+        },
+        input: (styles, { isDisabled }) => {
+            if (isDisabled) {
+                return {
+                    display: "none",
+                };
+            }
+            return {
+                ...styles,
+                fontSize: theme.editorFontSize,
+                fontFamily: theme.fontFamily,
+                color: theme.textDark,
+            };
+        },
+        placeholder: styles => {
+            return {
+                ...styles,
+                fontSize: theme.editorFontSize,
+                fontFamily: theme.fontFamily,
+                color: theme.textLight,
+            };
+        },
+        noOptionsMessage: styles => {
+            return {
+                ...styles,
+                fontSize: theme.editorFontSize,
+                fontFamily: theme.fontFamily,
+                color: theme.textLight,
+            };
+        },
+        clearIndicator: styles => {
+            return {
+                ...styles,
+                color: theme.textLight,
+                ":hover": {
+                    color: theme.textDark,
+                    cursor: "pointer",
+                },
+            };
+        },
+        multiValue: (styles, { data }) => {
+            const color = chroma(data.color ?? theme.bgBubble);
+            return {
+                ...styles,
+                backgroundColor: color.css(),
+                borderRadius: `${theme.roundingRadius ?? BUBBLE_HEIGHT / 2}px`,
+            };
+        },
+        multiValueLabel: (styles, { data, isDisabled }) => {
+            return {
+                ...styles,
+                paddingRight: isDisabled ? BUBBLE_PADDING : undefined,
+                paddingLeft: BUBBLE_PADDING,
+                paddingTop: 0,
+                paddingBottom: 0,
+                color: data.color
+                    ? // If a color is set for this option,
+                      // we use it to determine the text color.
+                      chroma(data.color).luminance() > 0.5
+                        ? "black"
+                        : "white"
+                    : theme.textBubble,
+                fontSize: theme.editorFontSize,
+                fontFamily: theme.fontFamily,
+                justifyContent: "center",
+                alignItems: "center",
+                display: "flex",
+                height: BUBBLE_HEIGHT,
+            };
+        },
+        multiValueRemove: (styles, { data, isDisabled, isFocused }) => {
+            if (isDisabled) {
+                return {
+                    display: "none",
+                };
+            }
+            const color = chroma(data.color ?? theme.bgBubble);
+            return {
+                ...styles,
+                color: data.color
+                    ? // If a color is set for this option,
+                      // we use it to determine the text color.
+                      color.luminance() > 0.5
+                        ? "black"
+                        : "white"
+                    : theme.textBubble,
+                backgroundColor: isFocused
+                    ? color.luminance() > 0.5
+                        ? color.darken(0.5).css()
+                        : color.brighten(0.5).css()
+                    : undefined,
+                borderRadius: isFocused ? `${theme.roundingRadius ?? BUBBLE_HEIGHT / 2}px` : undefined,
+                ":hover": {
+                    cursor: "pointer",
+                },
+            };
+        },
+    };
+
+    // This is used to submit the values to the grid.
+    const submitValues = React.useCallback(
+        (values: string[]) => {
+            // Change the list of values to the actual values by removing the prefix.
+            // This is only relevant in the case of allowDuplicates being true.
+            const mappedValues = values.map(v => {
+                return allowDuplicates && v.startsWith(VALUE_PREFIX)
+                    ? v.replace(new RegExp(VALUE_PREFIX_REGEX), "")
+                    : v;
+            });
+            setValue(mappedValues);
+            onChange({
+                ...cell,
+                data: {
+                    ...cell.data,
+                    values: mappedValues,
+                },
+            });
+        },
+        [cell, onChange, allowDuplicates]
+    );
+
+    const handleKeyDown: React.KeyboardEventHandler = event => {
+        switch (event.key) {
+            case "Enter":
+            case "Tab":
+                if (!inputValue) {
+                    // If the user pressed enter or tab without entering anything,
+                    // we finish editing based on the current state.
+                    onFinishedEditing(cell, [0, 1]);
+                    return;
+                }
+
+                if (allowDuplicates && allowCreation) {
+                    // This is a workaround to allow the user to enter new values
+                    // multiple times.
+                    setInputValue("");
+                    submitValues([...(value ?? []), inputValue]);
+                    setMenuOpen(false);
+                    event.preventDefault();
+                }
+        }
+    };
+
+    const SelectComponent = allowCreation ? CreatableSelect : Select;
+    return (
+        <Wrap onKeyDown={onKeyDown} data-testid={"multi-select-cell"}>
+            <SelectComponent
+                className="gdg-multi-select"
+                isMulti={true}
+                isDisabled={cell.readonly}
+                isClearable={true}
+                isSearchable={true}
+                inputValue={inputValue}
+                onInputChange={setInputValue}
+                options={options}
+                placeholder={cell.readonly ? "" : allowCreation ? "Add..." : undefined}
+                noOptionsMessage={input => {
+                    return allowCreation && allowDuplicates && input.inputValue
+                        ? `Create "${input.inputValue}"`
+                        : undefined;
+                }}
+                menuIsOpen={cell.readonly ? false : menuOpen}
+                onMenuOpen={() => setMenuOpen(true)}
+                onMenuClose={() => setMenuOpen(false)}
+                value={resolveValues(value, options, allowDuplicates)}
+                onKeyDown={cell.readonly ? undefined : handleKeyDown}
+                menuPlacement={"auto"}
+                menuPortalTarget={document.getElementById("portal")}
+                autoFocus={true}
+                openMenuOnFocus={true}
+                openMenuOnClick={true}
+                closeMenuOnSelect={true}
+                backspaceRemovesValue={true}
+                escapeClearsValue={false}
+                styles={colorStyles}
+                components={{
+                    DropdownIndicator: () => null,
+                    IndicatorSeparator: () => null,
+                    Menu: props => {
+                        if (menuDisabled) {
+                            return null;
+                        }
+                        return (
+                            <PortalWrap>
+                                <CustomMenu className={"click-outside-ignore"} {...props} />
+                            </PortalWrap>
+                        );
+                    },
+                }}
+                onChange={async e => {
+                    if (e === null) {
+                        return;
+                    }
+                    submitValues(e.map(x => x.value));
+                }}
+            />
+        </Wrap>
+    );
+};
+
+const renderer: CustomRenderer<MultiSelectCell> = {
+    kind: GridCellKind.Custom,
+    isMatch: (c): c is MultiSelectCell => (c.data as any).kind === "multi-select-cell",
+    draw: (args, cell) => {
+        const { ctx, theme, rect, highlighted } = args;
+        const { values, options: optionsIn } = cell.data;
+
+        if (values === undefined || values === null) {
+            return true;
+        }
+
+        const options = prepareOptions(optionsIn ?? []);
+
+        const drawArea: Rectangle = {
+            x: rect.x + theme.cellHorizontalPadding,
+            y: rect.y + theme.cellVerticalPadding,
+            width: rect.width - 2 * theme.cellHorizontalPadding,
+            height: rect.height - 2 * theme.cellVerticalPadding,
+        };
+        const rows = Math.max(1, Math.floor(drawArea.height / (BUBBLE_HEIGHT + BUBBLE_PADDING)));
+
+        let { x } = drawArea;
+        let row = 1;
+
+        let y =
+            rows === 1
+                ? drawArea.y + (drawArea.height - BUBBLE_HEIGHT) / 2
+                : drawArea.y + (drawArea.height - rows * BUBBLE_HEIGHT - (rows - 1) * BUBBLE_PADDING) / 2;
+        for (const value of values) {
+            const matchedOption = options.find(t => t.value === value);
+            const color = chroma(matchedOption?.color ?? (highlighted ? theme.bgBubbleSelected : theme.bgBubble));
+            const displayText = matchedOption?.label ?? value;
+            const metrics = measureTextCached(displayText, ctx);
+            const width = metrics.width + BUBBLE_PADDING * 2;
+            const textY = BUBBLE_HEIGHT / 2;
+
+            if (x !== drawArea.x && x + width > drawArea.x + drawArea.width && row < rows) {
+                row++;
+                y += BUBBLE_HEIGHT + BUBBLE_PADDING;
+                x = drawArea.x;
+            }
+
+            ctx.fillStyle = color.hex();
+            ctx.beginPath();
+            roundedRect(ctx, x, y, width, BUBBLE_HEIGHT, theme.roundingRadius ?? BUBBLE_HEIGHT / 2);
+            ctx.fill();
+
+            // If a color is set for this option, we use it to determine the text color.
+            // Otherwise, use the configured textBubble color.
+            ctx.fillStyle = matchedOption?.color ? (color.luminance() > 0.5 ? "#000000" : "#ffffff") : theme.textBubble;
+            ctx.fillText(displayText, x + BUBBLE_PADDING, y + textY + getMiddleCenterBias(ctx, theme));
+
+            x += width + BUBBLE_MARGIN;
+            if (x > drawArea.x + drawArea.width + theme.cellHorizontalPadding && row >= rows) {
+                break;
+            }
+        }
+
+        return true;
+    },
+    measure: (ctx, cell, t) => {
+        const { values, options } = cell.data;
+
+        if (!values) {
+            return t.cellHorizontalPadding * 2;
+        }
+
+        // Resolve the values to the actual display labels:
+        const labels = resolveValues(values, prepareOptions(options ?? []), cell.data.allowDuplicates).map(
+            x => x.label ?? x.value
+        );
+
+        return (
+            labels.reduce((acc, data) => ctx.measureText(data).width + acc + BUBBLE_PADDING * 2 + BUBBLE_MARGIN, 0) +
+            2 * t.cellHorizontalPadding -
+            4
+        );
+    },
+    provideEditor: () => ({
+        editor: Editor,
+        disablePadding: true,
+        deletedValue: v => ({
+            ...v,
+            copyData: "",
+            data: {
+                ...v.data,
+                values: [],
+            },
+        }),
+    }),
+    onPaste: (val: string, cell: MultiSelectCellProps) => {
+        if (!val || !val.trim()) {
+            // Empty values should result in empty strings
+            return {
+                ...cell,
+                values: [],
+            };
+        }
+        let values = val.split(",").map(s => s.trim());
+
+        if (!cell.allowDuplicates) {
+            // Remove all duplicates
+            values = values.filter((v, index) => values.indexOf(v) === index);
+        }
+
+        if (!cell.allowCreation) {
+            // Only allow values that are part of the options:
+            const options = prepareOptions(cell.options ?? []);
+            values = values.filter(v => options.find(o => o.value === v));
+        }
+
+        if (values.length === 0) {
+            // We were not able to parse any values, return undefined to
+            // not change the cell value.
+            return undefined;
+        }
+        return {
+            ...cell,
+            values,
+        };
+    },
+};
+
+export default renderer;

--- a/packages/cells/src/index.ts
+++ b/packages/cells/src/index.ts
@@ -11,6 +11,7 @@ import DatePickerRenderer, { type DatePickerCell } from "./cells/date-picker-cel
 import LinksCellRenderer, { type LinksCell } from "./cells/links-cell.js";
 import ButtonCellRenderer, { type ButtonCell } from "./cells/button-cell.js";
 import TreeViewCellRenderer, { type TreeViewCell } from "./cells/tree-view-cell.js";
+import MultiSelectCellRenderer, { type MultiSelectCell } from "./cells/multi-select-cell.js";
 
 const cells = [
     StarCellRenderer,
@@ -25,6 +26,7 @@ const cells = [
     LinksCellRenderer,
     ButtonCellRenderer,
     TreeViewCellRenderer,
+    MultiSelectCellRenderer,
 ];
 
 export {
@@ -40,6 +42,7 @@ export {
     LinksCellRenderer as LinksCell,
     ButtonCellRenderer as ButtonCell,
     TreeViewCellRenderer as TreeViewCell,
+    MultiSelectCellRenderer as MultiSelectCell,
     cells as allCells,
 };
 
@@ -56,4 +59,5 @@ export type {
     LinksCell as LinksCellType,
     ButtonCell as ButtonCellType,
     TreeViewCell as TreeViewCellType,
+    MultiSelectCell as MultiSelectCellType,
 };

--- a/packages/cells/test/multi-select-cell.test.tsx
+++ b/packages/cells/test/multi-select-cell.test.tsx
@@ -1,0 +1,256 @@
+import * as React from "react";
+
+import { render, cleanup } from "@testing-library/react";
+import { expect, describe, it, afterEach } from "vitest";
+
+import { GridCellKind } from "@glideapps/glide-data-grid";
+import renderer, { type MultiSelectCell, prepareOptions, resolveValues } from "../src/cells/multi-select-cell.js";
+
+describe("prepareOptions", () => {
+    const testCases = [
+        {
+            input: ["option1", "option2"],
+            expected: [
+                { value: "option1", label: "option1", color: undefined },
+                { value: "option2", label: "option2", color: undefined },
+            ],
+        },
+        {
+            input: [{ value: "value1", label: "Label 1", color: "red" }],
+            expected: [{ value: "value1", label: "Label 1", color: "red" }],
+        },
+        {
+            input: ["option3", { value: "value2", color: "blue" }],
+            expected: [
+                { value: "option3", label: "option3", color: undefined },
+                { value: "value2", label: "value2", color: "blue" },
+            ],
+        },
+        {
+            input: [null, { value: "value3" }],
+            expected: [
+                { value: null, label: "", color: undefined },
+                { value: "value3", label: "value3", color: undefined },
+            ],
+        },
+        {
+            input: [],
+            expected: [],
+        },
+        {
+            input: [undefined, null],
+            expected: [
+                { value: undefined, label: "", color: undefined },
+                { value: null, label: "", color: undefined },
+            ],
+        },
+        {
+            input: ["option4", null, { value: "value4" }, undefined],
+            expected: [
+                { value: "option4", label: "option4", color: undefined },
+                { value: null, label: "", color: undefined },
+                { value: "value4", label: "value4", color: undefined },
+                { value: undefined, label: "", color: undefined },
+            ],
+        },
+        {
+            input: [{ value: "value5" }],
+            expected: [{ value: "value5", label: "value5", color: undefined }],
+        },
+        {
+            input: ["123", "456"],
+            expected: [
+                { value: "123", label: "123", color: undefined },
+                { value: "456", label: "456", color: undefined },
+            ],
+        },
+        {
+            input: ["hello world", "special@char#"],
+            expected: [
+                { value: "hello world", label: "hello world", color: undefined },
+                { value: "special@char#", label: "special@char#", color: undefined },
+            ],
+        },
+    ];
+
+    it.each(testCases)("should correctly prepare options for react-select", testCase => {
+        const result = prepareOptions(testCase.input as any);
+        expect(result).toEqual(testCase.expected);
+    });
+});
+
+describe("resolveValues", () => {
+    const options = [
+        { value: "option1", label: "Option 1", color: "red" },
+        { value: "option2", label: "Option 2", color: "blue" },
+    ];
+
+    const testCases = [
+        // Empty values array
+        {
+            values: [],
+            allowDuplicates: false,
+            expected: [],
+        },
+        // Null values
+        {
+            values: null,
+            allowDuplicates: false,
+            expected: [],
+        },
+        // Undefined values
+        {
+            values: undefined,
+            allowDuplicates: false,
+            expected: [],
+        },
+        // Unique values without duplicates
+        {
+            values: ["option1", "nonExistingOption"],
+            allowDuplicates: false,
+            expected: [
+                { value: "option1", label: "Option 1", color: "red" },
+                { value: "nonExistingOption", label: "nonExistingOption" },
+            ],
+        },
+        // Values with duplicates, allowDuplicates = false
+        {
+            values: ["option1", "option1", "nonExistingOption"],
+            allowDuplicates: false,
+            expected: [
+                { value: "option1", label: "Option 1", color: "red" },
+                { value: "option1", label: "Option 1", color: "red" },
+                { value: "nonExistingOption", label: "nonExistingOption" },
+            ],
+        },
+        // Values with duplicates, allowDuplicates = true
+        {
+            values: ["option1", "option1", "nonExistingOption"],
+            allowDuplicates: true,
+            expected: [
+                { value: "__value0__option1", label: "Option 1", color: "red" },
+                { value: "__value1__option1", label: "Option 1", color: "red" },
+                { value: "__value2__nonExistingOption", label: "nonExistingOption" },
+            ],
+        },
+    ];
+
+    it.each(testCases)("should resolve values correctly", ({ values, allowDuplicates, expected }) => {
+        const result = resolveValues(values, options, allowDuplicates);
+        expect(result).toEqual(expected);
+    });
+});
+
+describe("onPaste", () => {
+    const options = [{ value: "option1", label: "Option 1" }, { value: "option2", color: "blue" }, "option3"];
+
+    const testCases = [
+        // Test case: Empty input string
+        {
+            input: "",
+            cellProps: { kind: "multi-select-cell", values: [], options },
+            expected: { kind: "multi-select-cell", options, values: [] },
+        },
+        // Test case: Input string with duplicates, allowDuplicates is false
+        {
+            input: "option1,option1,option2",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowDuplicates: false },
+            expected: { kind: "multi-select-cell", options, values: ["option1", "option2"], allowDuplicates: false },
+        },
+        // Test case: Input string with values not in options, allowCreation is false
+        {
+            input: "option1,unknownOption",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowCreation: false },
+            expected: { kind: "multi-select-cell", options, values: ["option1"], allowCreation: false },
+        },
+        // Test case: Input string with all values not in options, allowCreation is false
+        {
+            input: "unknownOption1,unknownOption2",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowCreation: false },
+            expected: undefined,
+        },
+        // Test case: Input with spaces around values
+        {
+            input: " option1 , option2 ",
+            cellProps: { kind: "multi-select-cell", values: [], options },
+            expected: { kind: "multi-select-cell", options, values: ["option1", "option2"] },
+        },
+        // Test case: Input with special characters
+        {
+            input: "special@char,option2",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowCreation: true },
+            expected: { kind: "multi-select-cell", options, values: ["special@char", "option2"], allowCreation: true },
+        },
+        // Test case: Input string with duplicates, allowDuplicates is true
+        {
+            input: "option1,option1,option2",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowDuplicates: true },
+            expected: {
+                kind: "multi-select-cell",
+                options,
+                values: ["option1", "option1", "option2"],
+                allowDuplicates: true,
+            },
+        },
+        // Test case: Input string with values not in options, allowCreation is true
+        {
+            input: "option1,unknownOption",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowCreation: true },
+            expected: { kind: "multi-select-cell", options, values: ["option1", "unknownOption"], allowCreation: true },
+        },
+        // Test case: All values filtered out
+        {
+            input: "unknownOption1,unknownOption2",
+            cellProps: { kind: "multi-select-cell", values: [], options, allowCreation: false },
+            expected: undefined,
+        },
+    ];
+
+    testCases.forEach(({ input, cellProps, expected }) => {
+        it(`should correctly handle pasting "${input}"`, () => {
+            // @ts-ignore
+            const result = renderer.onPaste(input, cellProps);
+            expect(result).toEqual(expected);
+        });
+    });
+});
+
+describe("Multi Select Editor", () => {
+    afterEach(cleanup);
+
+    function getMockCell(props: Partial<MultiSelectCell> = {}): MultiSelectCell {
+        return {
+            ...props,
+            kind: GridCellKind.Custom,
+            allowOverlay: true,
+            copyData: "option1",
+            readonly: false,
+            data: {
+                kind: "multi-select-cell",
+                options: [
+                    { value: "option1", label: "Option 1", color: "red" },
+                    { value: "option2", label: "Option 2", color: "blue" },
+                ],
+                values: ["option1"],
+            },
+        };
+    }
+
+    it("renders into the dom with correct value", () => {
+        // @ts-ignore
+        const Editor = renderer.provideEditor?.(getMockCell()).editor;
+        if (Editor === undefined) {
+            throw new Error("Editor is invalid");
+        }
+
+        const result = render(<Editor isHighlighted={false} value={getMockCell()} />);
+        // Check if the element is actually there
+        const cellEditor = result.getByTestId("multi-select-cell");
+        expect(cellEditor).not.toBeUndefined();
+
+        const input = cellEditor.getElementsByClassName("gdg-multi-select");
+        expect(input).not.toBeUndefined();
+    });
+
+    // TODO: Add additional tests for the editor
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,14 +29,7 @@ export type {
 export { ImageOverlayEditor } from "./internal/data-grid-overlay-editor/private/image-overlay-editor.js";
 export { default as MarkdownDiv } from "./internal/markdown-div/markdown-div.js";
 export { GrowingEntry as TextCellEntry } from "./internal/growing-entry/growing-entry.js";
-export {
-    parseToRgba,
-    withAlpha,
-    blend,
-    interpolateColors,
-    getLuminance,
-    toHex,
-} from "./internal/data-grid/color-parser.js";
+export { parseToRgba, withAlpha, blend, interpolateColors, getLuminance } from "./internal/data-grid/color-parser.js";
 export {
     measureTextCached,
     getMiddleCenterBias,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,14 @@ export type {
 export { ImageOverlayEditor } from "./internal/data-grid-overlay-editor/private/image-overlay-editor.js";
 export { default as MarkdownDiv } from "./internal/markdown-div/markdown-div.js";
 export { GrowingEntry as TextCellEntry } from "./internal/growing-entry/growing-entry.js";
-export { parseToRgba, withAlpha, blend, interpolateColors } from "./internal/data-grid/color-parser.js";
+export {
+    parseToRgba,
+    withAlpha,
+    blend,
+    interpolateColors,
+    getLuminance,
+    toHex,
+} from "./internal/data-grid/color-parser.js";
 export {
     measureTextCached,
     getMiddleCenterBias,

--- a/packages/core/src/internal/data-grid/color-parser.ts
+++ b/packages/core/src/internal/data-grid/color-parser.ts
@@ -122,21 +122,3 @@ export function getLuminance(color: string): number {
     const [r, g, b] = parseToRgba(color);
     return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
 }
-
-/**
- * Takes in any color and returns it as a hex code.
- * @category Drawing
- */
-export function toHex(color: string): string {
-    const [r, g, b, a] = parseToRgba(color);
-
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    const hex = (x: number) => {
-        const h = Math.min(Math.max(0, x), 255).toString(16);
-        // NOTE: padStart could be used here but it breaks Node 6 compat
-        // https://github.com/ricokahler/color2k/issues/351
-        return h.length === 1 ? `0${h}` : h;
-    };
-
-    return `#${hex(r)}${hex(g)}${hex(b)}${a < 1 ? hex(Math.round(a * 255)) : ""}`;
-}

--- a/packages/core/src/internal/data-grid/color-parser.ts
+++ b/packages/core/src/internal/data-grid/color-parser.ts
@@ -104,3 +104,39 @@ export function interpolateColors(leftColor: string, rightColor: string, val: nu
     const b = Math.floor((left[2] * nScaler + right[2] * hScaler) / a);
     return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
+
+/**
+ * Returns a number (float) representing the luminance of a color.
+ *
+ * @category Drawing
+ */
+export function getLuminance(color: string): number {
+    if (color === "transparent") return 0;
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    function f(x: number) {
+        const channel = x / 255;
+        return channel <= 0.040_45 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+    }
+
+    const [r, g, b] = parseToRgba(color);
+    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+/**
+ * Takes in any color and returns it as a hex code.
+ * @category Drawing
+ */
+export function toHex(color: string): string {
+    const [r, g, b, a] = parseToRgba(color);
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const hex = (x: number) => {
+        const h = Math.min(Math.max(0, x), 255).toString(16);
+        // NOTE: padStart could be used here but it breaks Node 6 compat
+        // https://github.com/ricokahler/color2k/issues/351
+        return h.length === 1 ? `0${h}` : h;
+    };
+
+    return `#${hex(r)}${hex(g)}${hex(b)}${a < 1 ? hex(Math.round(a * 255)) : ""}`;
+}

--- a/packages/core/test/color-parser.test.ts
+++ b/packages/core/test/color-parser.test.ts
@@ -33,12 +33,6 @@ describe("blend", () => {
     });
 });
 
-describe("toHex", () => {
-    test("Smoke test", () => {
-        expect(toHex("rgba(255, 255, 255, 1)")).toEqual("#ffffff");
-    });
-});
-
 describe("getLuminance", () => {
     test("Smoke test", () => {
         expect(getLuminance("rgba(255, 255, 255, 1)")).toEqual(1);

--- a/packages/core/test/color-parser.test.ts
+++ b/packages/core/test/color-parser.test.ts
@@ -4,7 +4,6 @@ import {
     interpolateColors,
     parseToRgba,
     withAlpha,
-    toHex,
     getLuminance,
 } from "../src/internal/data-grid/color-parser.js";
 import { expect, describe, test } from "vitest";

--- a/packages/core/test/color-parser.test.ts
+++ b/packages/core/test/color-parser.test.ts
@@ -1,5 +1,12 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { blend, interpolateColors, parseToRgba, withAlpha } from "../src/internal/data-grid/color-parser.js";
+import {
+    blend,
+    interpolateColors,
+    parseToRgba,
+    withAlpha,
+    toHex,
+    getLuminance,
+} from "../src/internal/data-grid/color-parser.js";
 import { expect, describe, test } from "vitest";
 
 describe("interpolateColors", () => {
@@ -23,5 +30,17 @@ describe("withAlpha", () => {
 describe("blend", () => {
     test("Smoke test", () => {
         expect(blend("rgba(255, 255, 255, 0.2)", "rgba(123, 123, 123, 1)")).toEqual("rgba(149.4, 149.4, 149.4, 1)");
+    });
+});
+
+describe("toHex", () => {
+    test("Smoke test", () => {
+        expect(toHex("rgba(255, 255, 255, 1)")).toEqual("#ffffff");
+    });
+});
+
+describe("getLuminance", () => {
+    test("Smoke test", () => {
+        expect(getLuminance("rgba(255, 255, 255, 1)")).toEqual(1);
     });
 });


### PR DESCRIPTION
This PR adds a new multi-select cell type to the cell package:

<img width="419" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/6a8f63e5-3eab-4795-b9c4-12ee0f74929e">

It can be configured with the following properties:

```typescript
type SelectOption = { value: string; label?: string; color?: string };

interface MultiSelectCellProps {
    readonly kind: "multi-select-cell";
    /* The list of values of this cell. */
    readonly values: string[] | undefined | null;
    /* The list of possible options that can be selected.
    The options can be provided as a list of strings 
    or as a list of objects with the following properties:
    - value: The value of this option.
    - label: The label of this option. If not provided, the value will be used as the label.
    - color: The color of this option. If not provided, the default color will be used. */
    readonly options?: readonly (SelectOption | string)[];
    /* If true, users can create new values that are not part of the configured options. */
    readonly allowCreation?: boolean;
    /* If true, users can select the same value multiple times. */
    readonly allowDuplicates?: boolean;
}
```

The rounding of the tags can be configured via the `roundingRadius` theme option:

<img width="209" alt="image" src="https://github.com/glideapps/glide-data-grid/assets/2852129/eca1e950-ee07-4702-beb2-360cfdda8483">

And the default colors can be configured via the `bgBubble`, `bgBubbleSelected`, and `textBubble` theme options.

Closes https://github.com/glideapps/glide-data-grid/issues/839