### PR TITLE
Cleanup row marker API and allow for circular checkboxes

### DIFF
--- a/packages/core/src/cells/marker-cell.tsx
+++ b/packages/core/src/cells/marker-cell.tsx
@@ -10,7 +10,8 @@ export const markerCellRenderer: InternalCellRenderer<MarkerCell> = {
     needsHoverPosition: false,
     drawPrep: prepMarkerRowCell,
     measure: () => 44,
-    draw: a => drawMarkerRowCell(a, a.cell.row, a.cell.checked, a.cell.markerKind, a.cell.drawHandle),
+    draw: a =>
+        drawMarkerRowCell(a, a.cell.row, a.cell.checked, a.cell.markerKind, a.cell.drawHandle, a.cell.checkboxStyle),
     onClick: e => {
         const { bounds, cell, posX: x, posY: y } = e;
         const { width, height } = bounds;
@@ -52,7 +53,8 @@ function drawMarkerRowCell(
     index: number,
     checked: boolean,
     markerKind: "checkbox" | "both" | "number" | "checkbox-visible",
-    drawHandle: boolean
+    drawHandle: boolean,
+    style: "circle" | "square"
 ) {
     const { ctx, rect, hoverAmount, theme } = args;
     const { x, y, width, height } = rect;
@@ -71,7 +73,9 @@ function drawMarkerRowCell(
             true,
             undefined,
             undefined,
-            18
+            18,
+            "center",
+            style
         );
         if (drawHandle) {
             ctx.globalAlpha = hoverAmount;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -24,9 +24,6 @@ import {
     isObjectEditorCallbackResult,
     type Item,
     type MarkerCell,
-    headerCellUnheckedMarker,
-    headerCellCheckedMarker,
-    headerCellIndeterminateMarker,
     type ValidatedGridCell,
     type ImageEditorType,
     type CustomCell,
@@ -1032,29 +1029,25 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const totalHeaderHeight = enableGroups ? headerHeight + groupHeaderHeight : headerHeight;
 
     const numSelectedRows = gridSelection.rows.length;
-    const rowMarkerHeader =
-        rowMarkers === "none"
-            ? ""
-            : numSelectedRows === 0
-            ? headerCellUnheckedMarker
-            : numSelectedRows === rows
-            ? headerCellCheckedMarker
-            : headerCellIndeterminateMarker;
+    const rowMarkerChecked =
+        rowMarkers === "none" ? undefined : numSelectedRows === 0 ? false : numSelectedRows === rows ? true : undefined;
 
     const mangledCols = React.useMemo(() => {
         if (rowMarkers === "none") return columns;
         return [
             {
-                title: rowMarkerHeader,
+                title: "",
                 width: rowMarkerWidth,
                 icon: undefined,
                 hasMenu: false,
                 style: "normal" as const,
                 themeOverride: rowMarkerTheme,
+                rowMarker: rowMarkerCheckboxStyle,
+                rowMarkerChecked,
             },
             ...columns,
         ];
-    }, [columns, rowMarkerWidth, rowMarkers, rowMarkerHeader, rowMarkerTheme]);
+    }, [rowMarkers, columns, rowMarkerWidth, rowMarkerTheme, rowMarkerCheckboxStyle, rowMarkerChecked]);
 
     const [visibleRegionY, visibleRegionTy] = React.useMemo(() => {
         return [

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -90,6 +90,14 @@ const DataGridOverlayEditor = React.lazy(
 
 let idCounter = 0;
 
+export interface RowMarkerOptions {
+    kind: "checkbox" | "number" | "clickable-number" | "checkbox-visible" | "both" | "none";
+    checkboxStyle?: "circle" | "square";
+    startIndex?: number;
+    width?: number;
+    theme?: Partial<Theme>;
+}
+
 interface MouseState {
     readonly previousSelection?: GridSelection;
     readonly fillHandle?: boolean;
@@ -307,20 +315,23 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
      * @defaultValue `none`
      * @group Style
      */
-    readonly rowMarkers?: "checkbox" | "number" | "clickable-number" | "checkbox-visible" | "both" | "none";
+    readonly rowMarkers?: RowMarkerOptions["kind"] | RowMarkerOptions;
     /**
      * Sets the width of row markers in pixels, if unset row markers will automatically size.
      * @group Style
+     * @deprecated Use `rowMarkers` instead.
      */
     readonly rowMarkerWidth?: number;
     /** Changes the starting index for row markers.
      * @defaultValue 1
      * @group Style
+     * @deprecated Use `rowMarkers` instead.
      */
     readonly rowMarkerStartIndex?: number;
 
     /** Changes the theme of the row marker column
      * @group Style
+     * @deprecated Use `rowMarkers` instead.
      */
     readonly rowMarkerTheme?: Partial<Theme>;
 
@@ -699,8 +710,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const safeWindow = typeof window === "undefined" ? null : window;
 
     const {
-        rowMarkers = "none",
-        rowMarkerWidth: rowMarkerWidthRaw,
         imageEditorOverride,
         getRowThemeOverride,
         markdownDivCreateNode,
@@ -753,8 +762,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         freezeColumns = 0,
         cellActivationBehavior = "second-click",
         rowSelectionMode = "auto",
-        rowMarkerStartIndex = 1,
-        rowMarkerTheme,
         onHeaderMenuClick,
         getGroupDetails,
         onSearchClose: onSearchCloseIn,
@@ -807,6 +814,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         isOutsideClick,
         renderers,
     } = p;
+
+    const rowMarkersObj = typeof p.rowMarkers === "string" ? undefined : p.rowMarkers;
+
+    const rowMarkers = rowMarkersObj?.kind ?? (p.rowMarkers as RowMarkerOptions["kind"]) ?? "none";
+    const rowMarkerWidthRaw = rowMarkersObj?.width ?? p.rowMarkerWidth;
+    const rowMarkerStartIndex = rowMarkersObj?.startIndex ?? p.rowMarkerStartIndex ?? 1;
+    const rowMarkerTheme = rowMarkersObj?.theme ?? p.rowMarkerTheme;
+    const rowMarkerCheckboxStyle = rowMarkersObj?.checkboxStyle ?? "square";
 
     const minColumnWidth = Math.max(minColumnWidthIn, 20);
     const maxColumnWidth = Math.max(maxColumnWidthIn, minColumnWidth);
@@ -1226,6 +1241,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 return {
                     kind: InnerGridCellKind.Marker,
                     allowOverlay: false,
+                    checkboxStyle: rowMarkerCheckboxStyle,
                     checked: gridSelection?.rows.hasIndex(row) === true,
                     markerKind: rowMarkers === "clickable-number" ? "number" : rowMarkers,
                     row: rowMarkerStartIndex + row,
@@ -1290,15 +1306,16 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             showTrailingBlankRow,
             mangledRows,
             hasRowMarkers,
+            rowMarkerCheckboxStyle,
             gridSelection?.rows,
-            onRowMoved,
             rowMarkers,
+            rowMarkerStartIndex,
+            onRowMoved,
             rowMarkerOffset,
             trailingRowOptions?.hint,
             trailingRowOptions?.addIcon,
             experimental?.strict,
             getCellContent,
-            rowMarkerStartIndex,
         ]
     );
 

--- a/packages/core/src/docs/examples/row-markers.stories.tsx
+++ b/packages/core/src/docs/examples/row-markers.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { type DataEditorProps } from "../../data-editor/data-editor.js";
+import { type RowMarkerOptions } from "../../data-editor/data-editor.js";
 import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
 import {
     BeautifulWrapper,
@@ -33,7 +33,7 @@ export default {
 };
 
 interface RowMarkersProps {
-    markers: DataEditorProps["rowMarkers"];
+    markers: RowMarkerOptions["kind"];
 }
 
 export const RowMarkers: React.VFC<RowMarkersProps> = p => {
@@ -43,7 +43,11 @@ export const RowMarkers: React.VFC<RowMarkersProps> = p => {
         <DataEditor
             {...defaultProps}
             getCellContent={getCellContent}
-            rowMarkers={p.markers}
+            verticalBorder={false}
+            rowMarkers={{
+                kind: p.markers,
+                checkboxStyle: "circle",
+            }}
             columns={cols}
             rows={400}
         />
@@ -55,6 +59,6 @@ export const RowMarkers: React.VFC<RowMarkersProps> = p => {
 (RowMarkers as any).argTypes = {
     markers: {
         control: { type: "select" },
-        options: ["both", "checkbox", "number", "none", "clickable-number"],
+        options: ["both", "checkbox", "number", "none", "clickable-number", "checkbox-visible"],
     },
 };

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -496,6 +496,7 @@ export interface MarkerCell extends BaseGridCell {
     readonly row: number;
     readonly drawHandle: boolean;
     readonly checked: boolean;
+    readonly checkboxStyle: "square" | "circle";
     readonly markerKind: "checkbox" | "number" | "both" | "checkbox-visible";
 }
 

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -143,15 +143,6 @@ export type CellArray = readonly (readonly GridCell[])[];
  */
 export type Item = readonly [col: number, row: number];
 
-/** @category Types */
-export const headerCellCheckboxPrefix = "___gdg_header_cell_";
-/** @category Types */
-export const headerCellCheckedMarker = headerCellCheckboxPrefix + "checked";
-/** @category Types */
-export const headerCellUnheckedMarker = headerCellCheckboxPrefix + "unchecked";
-/** @category Types */
-export const headerCellIndeterminateMarker = headerCellCheckboxPrefix + "indeterminate";
-
 export interface BaseGridColumn {
     readonly title: string;
     readonly group?: string;
@@ -199,8 +190,14 @@ export type GetCellsThunk = () => Promise<CellArray>;
 /** @category Columns */
 export type GridColumn = SizedGridColumn | AutoGridColumn;
 
+export type InnerColumnExtension = {
+    growOffset?: number;
+    rowMarker?: "square" | "circle";
+    rowMarkerChecked?: BooleanIndeterminate | boolean;
+};
+
 /** @category Columns */
-export type InnerGridColumn = SizedGridColumn & { growOffset?: number };
+export type InnerGridColumn = SizedGridColumn & InnerColumnExtension;
 
 // export type SizedGridColumn = Omit<GridColumn, "width"> & { readonly width: number };
 

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -4,7 +4,7 @@ import {
     type Item,
     type GridSelection,
     type InnerGridCell,
-    type SizedGridColumn,
+    type InnerGridColumn,
     type Rectangle,
     type BaseGridCell,
 } from "../data-grid-types.js";
@@ -14,13 +14,13 @@ import type { BaseDrawArgs, PrepResult } from "../../../cells/cell-types.js";
 import { split as splitText, clearCache } from "canvas-hypertxt";
 import type { FullyDefined } from "../../../common/support.js";
 
-export interface MappedGridColumn extends FullyDefined<SizedGridColumn> {
+export interface MappedGridColumn extends FullyDefined<InnerGridColumn> {
     sourceIndex: number;
     sticky: boolean;
 }
 
 export function useMappedColumns(
-    columns: readonly SizedGridColumn[],
+    columns: readonly InnerGridColumn[],
     freezeColumns: number
 ): readonly MappedGridColumn[] {
     return React.useMemo(
@@ -41,6 +41,9 @@ export function useMappedColumns(
                     title: c.title,
                     trailingRowOptions: c.trailingRowOptions,
                     width: c.width,
+                    growOffset: c.growOffset,
+                    rowMarker: c.rowMarker,
+                    rowMarkerChecked: c.rowMarkerChecked,
                 })
             ),
         [columns, freezeColumns]

--- a/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
@@ -5,16 +5,7 @@ import type { HoverValues } from "../animation-manager.js";
 import type { CellSet } from "../cell-set.js";
 import { withAlpha } from "../color-parser.js";
 import type { SpriteManager, SpriteVariant } from "../data-grid-sprites.js";
-import {
-    headerCellCheckboxPrefix,
-    type DrawHeaderCallback,
-    type Rectangle,
-    GridColumnMenuIcon,
-    BooleanIndeterminate,
-    headerCellCheckedMarker,
-    headerCellUnheckedMarker,
-    type GridSelection,
-} from "../data-grid-types.js";
+import { type DrawHeaderCallback, type Rectangle, GridColumnMenuIcon, type GridSelection } from "../data-grid-types.js";
 import { drawMenuDots, getMiddleCenterBias, roundedPoly, type MappedGridColumn } from "./data-grid-lib.js";
 import type { GroupDetails, GroupDetailsCallback } from "./data-grid-render.cells.js";
 import { walkColumns, walkGroups } from "./data-grid-render.walk.js";
@@ -326,17 +317,14 @@ function drawHeaderInner(
     spriteManager: SpriteManager,
     touchMode: boolean,
     isRtl: boolean,
-    isCheckboxHeader: boolean,
     menuBounds: Rectangle
 ) {
-    if (isCheckboxHeader) {
-        let checked: boolean | BooleanIndeterminate = undefined;
-        if (c.title === headerCellCheckedMarker) checked = true;
-        if (c.title === headerCellUnheckedMarker) checked = false;
+    if (c.rowMarker !== undefined) {
+        const checked = c.rowMarkerChecked;
         if (checked !== true) {
             ctx.globalAlpha = hoverAmount;
         }
-        drawCheckbox(ctx, theme, checked, x, y, width, height, false, undefined, undefined, 18);
+        drawCheckbox(ctx, theme, checked, x, y, width, height, false, undefined, undefined, 18, "center", c.rowMarker);
         if (checked !== true) {
             ctx.globalAlpha = 1;
         }
@@ -469,25 +457,17 @@ export function drawHeader(
     drawHeaderCallback: DrawHeaderCallback | undefined,
     touchMode: boolean
 ) {
-    const isCheckboxHeader = c.title.startsWith(headerCellCheckboxPrefix);
     const isRtl = direction(c.title) === "rtl";
     const menuBounds = getHeaderMenuBounds(x, y, width, height, isRtl);
 
     if (drawHeaderCallback !== undefined) {
-        let passCol = c;
-        if (isCheckboxHeader) {
-            passCol = {
-                ...c,
-                title: "",
-            };
-        }
         drawHeaderCallback(
             {
                 ctx,
                 theme,
                 rect: { x, y, width, height },
-                column: passCol,
-                columnIndex: passCol.sourceIndex,
+                column: c,
+                columnIndex: c.sourceIndex,
                 isSelected: selected,
                 hoverAmount,
                 isHovered,
@@ -510,7 +490,6 @@ export function drawHeader(
                     spriteManager,
                     touchMode,
                     isRtl,
-                    isCheckboxHeader,
                     menuBounds
                 )
         );
@@ -529,7 +508,6 @@ export function drawHeader(
             spriteManager,
             touchMode,
             isRtl,
-            isCheckboxHeader,
             menuBounds
         );
     }

--- a/packages/core/src/internal/data-grid/render/draw-checkbox.ts
+++ b/packages/core/src/internal/data-grid/render/draw-checkbox.ts
@@ -16,12 +16,13 @@ export function drawCheckbox(
     hoverX: number = -20,
     hoverY: number = -20,
     maxSize: number = 32,
-    alignment: BaseGridCell["contentAlign"] = "center"
+    alignment: BaseGridCell["contentAlign"] = "center",
+    style: "circle" | "square" = "square"
 ) {
     const centerY = Math.floor(y + height / 2);
-    const rectBordRadius = theme.roundingRadius ?? 4;
-    const checkBoxWidth = getSquareWidth(maxSize, height, theme.cellVerticalPadding);
-    const checkBoxHalfWidth = checkBoxWidth / 2;
+    const rectBordRadius = style === "circle" ? 10_000 : theme.roundingRadius ?? 4;
+    let checkBoxWidth = getSquareWidth(maxSize, height, theme.cellVerticalPadding);
+    let checkBoxHalfWidth = checkBoxWidth / 2;
     const posX = getSquareXPosFromAlign(alignment, x, width, theme.cellHorizontalPadding, checkBoxWidth);
     const bb = getSquareBB(posX, centerY, checkBoxWidth);
     const hovered = pointIsWithinBB(x + hoverX, y + hoverY, bb);
@@ -37,6 +38,11 @@ export function drawCheckbox(
                 checkBoxWidth,
                 rectBordRadius
             );
+
+            if (style === "circle") {
+                checkBoxHalfWidth *= 0.8;
+                checkBoxWidth *= 0.8;
+            }
 
             ctx.fillStyle = highlighted ? theme.accentColor : theme.textMedium;
             ctx.fill();

--- a/packages/core/src/internal/data-grid/render/draw-checkbox.ts
+++ b/packages/core/src/internal/data-grid/render/draw-checkbox.ts
@@ -101,6 +101,11 @@ export function drawCheckbox(
             ctx.fillStyle = hovered ? theme.textMedium : theme.textLight;
             ctx.fill();
 
+            if (style === "circle") {
+                checkBoxHalfWidth *= 0.8;
+                checkBoxWidth *= 0.8;
+            }
+
             ctx.beginPath();
             ctx.moveTo(posX - checkBoxWidth / 3, centerY);
             ctx.lineTo(posX + checkBoxWidth / 3, centerY);


### PR DESCRIPTION
- Implement cleaner row marker API
- Clean up row header marker to not use magic strings and support circle mode
