### PR TITLE
Enforce readonly mode for `uri-cell`

### DIFF
--- a/packages/core/src/cells/uri-cell.tsx
+++ b/packages/core/src/cells/uri-cell.tsx
@@ -115,7 +115,10 @@ export const uriCellRenderer: InternalCellRenderer<UriCell> = {
         const { onChange, value, forceEditMode, validatedSelection } = p;
         return (
             <UriOverlayEditor
-                forceEditMode={forceEditMode || (cell.hoverEffect === true && cell.onClickUri !== undefined)}
+                forceEditMode={
+                    value.readonly !== true &&
+                    (forceEditMode || (cell.hoverEffect === true && cell.onClickUri !== undefined))
+                }
                 uri={value.data}
                 preview={value.displayData ?? value.data}
                 validatedSelection={validatedSelection}

--- a/packages/core/src/internal/data-grid-overlay-editor/private/uri-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/uri-overlay-editor.tsx
@@ -16,7 +16,7 @@ interface Props {
 const UriOverlayEditor: React.FunctionComponent<Props> = p => {
     const { uri, onChange, forceEditMode, readonly, validatedSelection, preview } = p;
 
-    const [editMode, setEditMode] = React.useState<boolean>(uri === "" || forceEditMode);
+    const [editMode, setEditMode] = React.useState<boolean>(!readonly && (uri === "" || forceEditMode));
 
     const onEditClick = React.useCallback(() => {
         setEditMode(true);


### PR DESCRIPTION
If the `uri-cell` is configured as `readonly`, there shouldn't be any way that it still allows editing (this is currently the case). 