### PR TITLE
Remove src from npmignore so we get sourcemaps

### DIFF
--- a/packages/cells/.npmignore
+++ b/packages/cells/.npmignore
@@ -1,4 +1,3 @@
-src
 package-lock.json
 .eslintrc
 tsconfig.json

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,3 +1,2 @@
-src
 tsconfig*
 coverage/*

--- a/packages/source/.npmignore
+++ b/packages/source/.npmignore
@@ -1,4 +1,3 @@
-src
 package-lock.json
 .eslintrc
 tsconfig.json


### PR DESCRIPTION
Sourcemaps `sources` seem to point to `../../src/...`, but those files are not in the npm package.

This PR removes that from `npmignore`