### PR TITLE
Take cell padding into account when measuring column title width

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -62,7 +62,7 @@ export function measureColumn(
             }
         }
     }
-    max = Math.max(max, ctx.measureText(c.title).width + 16 + (c.icon === undefined ? 0 : 28));
+    max = Math.max(max, ctx.measureText(c.title).width + theme.cellHorizontalPadding * 2 + (c.icon === undefined ? 0 : 28));
     const final = Math.max(Math.ceil(minColumnWidth), Math.min(Math.floor(maxColumnWidth), Math.ceil(max)));
 
     return {

--- a/packages/core/test/use-column-sizer.test.tsx
+++ b/packages/core/test/use-column-sizer.test.tsx
@@ -165,6 +165,44 @@ describe("use-column-sizer", () => {
         expect(result.current.sizedColumns[0].width).toBe(212);
     });
 
+    it("Measures column width based on title if longer than data", async () => {
+        const columns: GridColumn[] = [
+            {
+                title: "Some very very long title that exceeds displayData width",
+                id: "ColumnA",
+            },
+            {
+                title: "Short title",
+                id: "ColumnB",
+            },
+        ];
+
+        const { result } = renderHook(() =>
+            useColumnSizer(
+                columns,
+                500,
+                getShortCellsForSelection,
+                400,
+                20,
+                500,
+                mergeAndRealizeTheme(theme, {cellHorizontalPadding: 12}),
+                getCellRenderer,
+                abortController
+            )
+        );
+
+        const columnA = result.current.sizedColumns.find(col => col.title === "Some very very long title that exceeds displayData width");
+        const columnB = result.current.sizedColumns.find(col => col.title === "Short title");
+
+        expect(columnA).toBeDefined();
+        expect(columnB).toBeDefined();
+
+        // Width of column title plus twice the cellHorizontalPadding
+        expect(columnA?.width).toBe(80);
+        // Maximum width of cell data
+        expect(columnB?.width).toBe(40);
+    });
+
     it("Measures the last row", async () => {
         // eslint-disable-next-line sonarjs/no-identical-functions
         renderHook(() =>


### PR DESCRIPTION
Small fix for taking `theme.cellHorizontalPadding` into account (like how most [cells](https://github.com/sfc-gh-jipark/glide-data-grid/blob/cf6c69a7f79427adb69e88bb099ae1e43b87e706/packages/core/src/cells/text-cell.tsx#L59) are being measured) when measuring column width based on column title in `use-column-sizer`. Currently, it's based on hardcoded 16px (twice the default 8px cellHorizontalPadding) so measurement is inaccurate when custom theme is configured