### PR TITLE
Keep focus in overlay editor

### DIFF
--- a/packages/core/src/cells/number-cell.tsx
+++ b/packages/core/src/cells/number-cell.tsx
@@ -27,7 +27,7 @@ export const numberCellRenderer: InternalCellRenderer<NumberCell> = {
             <React.Suspense fallback={null}>
                 <NumberOverlayEditor
                     highlight={isHighlighted}
-                    disabled={value.readonly === true}
+                    readOnly={value.readonly === true}
                     value={value.data}
                     fixedDecimals={value.fixedDecimals}
                     allowNegative={value.allowNegative}

--- a/packages/core/src/cells/row-id-cell.tsx
+++ b/packages/core/src/cells/row-id-cell.tsx
@@ -19,7 +19,7 @@ export const rowIDCellRenderer: InternalCellRenderer<RowIDCell> = {
             <GrowingEntry
                 highlight={isHighlighted}
                 autoFocus={value.readonly !== true}
-                disabled={value.readonly !== false}
+                readOnly={value.readonly === true}
                 value={value.data}
                 validatedSelection={validatedSelection}
                 onChange={e =>

--- a/packages/core/src/cells/text-cell.tsx
+++ b/packages/core/src/cells/text-cell.tsx
@@ -71,7 +71,7 @@ export const textCellRenderer: InternalCellRenderer<TextCell> = {
                     style={cell.allowWrapping === true ? { padding: "3px 8.5px" } : undefined}
                     highlight={isHighlighted}
                     autoFocus={value.readonly !== true}
-                    disabled={value.readonly === true}
+                    readOnly={value.readonly === true}
                     altNewline={true}
                     value={value.data}
                     validatedSelection={validatedSelection}

--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -220,7 +220,10 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                 onClickOutside={onClickOutside}
                 isOutsideClick={isOutsideClick}>
                 <DataGridOverlayEditorStyle
-                    ref={ref}
+                    ref={elem => {
+                        ref(elem);
+                        if (elem) elem.focus();
+                    }}
                     id={id}
                     className={classWrap}
                     style={styleOverride}
@@ -228,8 +231,11 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                     targetX={target.x - bloomX}
                     targetY={target.y - bloomY}
                     targetWidth={target.width + bloomX * 2}
-                    targetHeight={target.height + bloomY * 2}>
-                    <div className="gdg-clip-region" onKeyDown={onKeyDown}>
+                    targetHeight={target.height + bloomY * 2}
+                    tabIndex={-1}
+                    onKeyDown={onKeyDown}
+                >
+                    <div className="gdg-clip-region">
                         {editor}
                     </div>
                 </DataGridOverlayEditorStyle>

--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor.tsx
@@ -14,7 +14,6 @@ const BubblesOverlayEditor: React.FunctionComponent<Props> = p => {
                     {b}
                 </div>
             ))}
-            <textarea className="gdg-input" autoFocus={true} />
         </BubblesOverlayEditorStyle>
     );
 };

--- a/packages/core/src/internal/data-grid-overlay-editor/private/markdown-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/markdown-overlay-editor.tsx
@@ -59,7 +59,6 @@ export const MarkdownOverlayEditor: React.FunctionComponent<Props> = p => {
                     </div>
                 </>
             )}
-            <textarea className="gdg-md-edit-textarea gdg-input" autoFocus={true} />
         </MarkdownOverlayEditorStyle>
     );
 };

--- a/packages/core/src/internal/data-grid-overlay-editor/private/number-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/number-overlay-editor.tsx
@@ -7,6 +7,7 @@ import type { NumberFormatValues } from "react-number-format/types/types.js";
 interface Props {
     readonly value: number | undefined;
     readonly disabled?: boolean;
+    readonly readOnly?: boolean;
     readonly onChange: (values: NumberFormatValues) => void;
     readonly highlight: boolean;
     readonly validatedSelection?: SelectionRange;
@@ -34,6 +35,7 @@ const NumberOverlayEditor: React.FunctionComponent<Props> = p => {
         value,
         onChange,
         disabled,
+        readOnly,
         highlight,
         validatedSelection,
         fixedDecimals,
@@ -61,6 +63,7 @@ const NumberOverlayEditor: React.FunctionComponent<Props> = p => {
                     e.target.setSelectionRange(highlight ? 0 : e.target.value.length, e.target.value.length)
                 }
                 disabled={disabled === true}
+                readOnly={readOnly === true}
                 decimalScale={fixedDecimals}
                 allowNegative={allowNegative}
                 thousandSeparator={thousandSeparator ?? getThousandSeprator()}

--- a/packages/core/src/internal/data-grid-overlay-editor/private/uri-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/uri-overlay-editor.tsx
@@ -44,7 +44,6 @@ const UriOverlayEditor: React.FunctionComponent<Props> = p => {
                     <EditPencil />
                 </div>
             )}
-            <textarea className="gdg-input" autoFocus={true} />
         </UriOverlayEditorStyle>
     );
 };


### PR DESCRIPTION
Tries to fix #910 

We should add some tests to check that click within cell and then pressing escape works for each internal cell editor.