### PR TITLE
Improve Performance in Row Grouping

### DIFF
--- a/packages/core/src/docs/examples/row-grouping.stories.tsx
+++ b/packages/core/src/docs/examples/row-grouping.stories.tsx
@@ -35,14 +35,10 @@ export default {
 
 export const RowGrouping: React.VFC<any> = (p: { freezeColumns: number }) => {
     const { cols, getCellContent } = useMockDataGenerator(100);
-    const rows = 1000;
+    const rows = 100_000;
 
     const [rowGrouping, setRowGrouping] = React.useState<RowGroupingOptions>(() => ({
         groups: [
-            {
-                headerIndex: 0,
-                isCollapsed: false,
-            },
             {
                 headerIndex: 10,
                 isCollapsed: true,
@@ -57,10 +53,12 @@ export const RowGrouping: React.VFC<any> = (p: { freezeColumns: number }) => {
                     },
                 ],
             },
-            {
-                headerIndex: 30,
-                isCollapsed: false,
-            },
+            ...Array.from({ length: 100 }, (_value, i): RowGroupingOptions["groups"][number] => {
+                return {
+                    headerIndex: (rows / 100) * i,
+                    isCollapsed: false,
+                };
+            }),
         ],
         height: 55,
         navigationBehavior: "block",

--- a/packages/core/src/docs/examples/row-grouping.stories.tsx
+++ b/packages/core/src/docs/examples/row-grouping.stories.tsx
@@ -53,6 +53,10 @@ export const RowGrouping: React.VFC<any> = (p: { freezeColumns: number }) => {
                     },
                 ],
             },
+            {
+                headerIndex: 30,
+                isCollapsed: false,
+            },
             ...Array.from({ length: 100 }, (_value, i): RowGroupingOptions["groups"][number] => {
                 return {
                     headerIndex: (rows / 100) * i,


### PR DESCRIPTION
There is a performance bottleneck when using the row grouping feature. It is noticeable with a large number of rows and about >~20 groups or so.

Profiler showed that the call to `mapRowIndexToPath` during row height resolution takes most of the time, and it gets slower scrolling towards the end of the list. 

`rowIndex` property was added to identify the exact position of the group in the list. This allowed to create a map that then could be looked up to identify whether the row is a group row or not and resolve the height accordingly, avoiding the expensive call to `mapRowIndexToPath`.

For further performance improvements, with `rowIndex` property functions like `rowNumberMapperOut` and `mapRowIndexToPath` could be changed to do a binary search, because `mapRowIndexToPath` can be used as `mapper` function in the `getCellContent` consumer code.

### scrolling profiler recordings:

before change
![image](https://github.com/glideapps/glide-data-grid/assets/1696091/e1137084-6dc1-4ff8-9b3c-4679b7fd1974)

after
![image](https://github.com/glideapps/glide-data-grid/assets/1696091/4027dd09-1102-4d31-8311-eb78b0ceeb00)

related to https://github.com/glideapps/glide-data-grid/issues/823