### PR TITLE
Theme options for edit hover indicators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "root",
-    "version": "6.0.4-alpha3",
+    "version": "6.0.4-alpha6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "root",
-            "version": "6.0.4-alpha3",
+            "version": "6.0.4-alpha6",
             "license": "MIT",
             "workspaces": [
                 "./packages/core",
@@ -21231,10 +21231,10 @@
         },
         "packages/cells": {
             "name": "@glideapps/glide-data-grid-cells",
-            "version": "6.0.4-alpha3",
+            "version": "6.0.4-alpha6",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "6.0.4-alpha3",
+                "@glideapps/glide-data-grid": "6.0.4-alpha6",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
@@ -21255,7 +21255,7 @@
         },
         "packages/core": {
             "name": "@glideapps/glide-data-grid",
-            "version": "6.0.4-alpha3",
+            "version": "6.0.4-alpha6",
             "license": "MIT",
             "dependencies": {
                 "@linaria/react": "^4.5.3",
@@ -21327,10 +21327,10 @@
         },
         "packages/source": {
             "name": "@glideapps/glide-data-grid-source",
-            "version": "6.0.4-alpha3",
+            "version": "6.0.4-alpha6",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "6.0.4-alpha3"
+                "@glideapps/glide-data-grid": "6.0.4-alpha6"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
@@ -23270,7 +23270,7 @@
             "version": "file:packages/cells",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "6.0.4-alpha3",
+                "@glideapps/glide-data-grid": "6.0.4-alpha6",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
@@ -23290,7 +23290,7 @@
             "version": "file:packages/source",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "6.0.4-alpha3",
+                "@glideapps/glide-data-grid": "6.0.4-alpha6",
                 "eslint": "^8.19.0",
                 "eslint-plugin-import": "^2.22.0",
                 "eslint-plugin-react": "^7.21.5",

--- a/packages/core/src/cells/number-cell.tsx
+++ b/packages/core/src/cells/number-cell.tsx
@@ -12,7 +12,7 @@ const NumberOverlayEditor = React.lazy(
 export const numberCellRenderer: InternalCellRenderer<NumberCell> = {
     getAccessibilityString: c => c.data?.toString() ?? "",
     kind: GridCellKind.Number,
-    needsHover: textCell => textCell.hoverEffect === true,
+    needsHover: cell => cell.hoverEffect === true,
     needsHoverPosition: false,
     useLabel: true,
     drawPrep: prepTextCell,

--- a/packages/core/src/cells/number-cell.tsx
+++ b/packages/core/src/cells/number-cell.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { drawTextCell, prepTextCell } from "../internal/data-grid/render/data-grid-lib.js";
 import { GridCellKind, type NumberCell } from "../internal/data-grid/data-grid-types.js";
 import type { InternalCellRenderer } from "./cell-types.js";
+import { drawEditHoverIndicator } from "../internal/data-grid/render/draw-edit-hover-indicator.js";
 
 const NumberOverlayEditor = React.lazy(
     async () => await import("../internal/data-grid-overlay-editor/private/number-overlay-editor.js")
@@ -11,11 +12,19 @@ const NumberOverlayEditor = React.lazy(
 export const numberCellRenderer: InternalCellRenderer<NumberCell> = {
     getAccessibilityString: c => c.data?.toString() ?? "",
     kind: GridCellKind.Number,
-    needsHover: false,
+    needsHover: textCell => textCell.hoverEffect === true,
     needsHoverPosition: false,
     useLabel: true,
     drawPrep: prepTextCell,
-    draw: a => drawTextCell(a, a.cell.displayData, a.cell.contentAlign),
+    draw: a => {
+        const { hoverAmount, cell, ctx, theme, rect, overrideCursor } = a;
+        const { hoverEffect, displayData, hoverEffectTheme } = cell;
+
+        if (hoverEffect === true && hoverAmount > 0) {
+            drawEditHoverIndicator(ctx, theme, hoverEffectTheme, displayData, rect, hoverAmount, overrideCursor);
+        }
+        drawTextCell(a, a.cell.displayData, a.cell.contentAlign);
+    },
     measure: (ctx, cell, theme) => ctx.measureText(cell.displayData).width + theme.cellHorizontalPadding * 2,
     onDelete: c => ({
         ...c,

--- a/packages/core/src/cells/text-cell.tsx
+++ b/packages/core/src/cells/text-cell.tsx
@@ -1,15 +1,10 @@
 /* eslint-disable react/display-name */
 import * as React from "react";
 import { GrowingEntry } from "../internal/growing-entry/growing-entry.js";
-import {
-    drawTextCell,
-    measureTextCached,
-    prepTextCell,
-    roundedRect,
-} from "../internal/data-grid/render/data-grid-lib.js";
+import { drawTextCell, prepTextCell } from "../internal/data-grid/render/data-grid-lib.js";
 import { GridCellKind, type TextCell } from "../internal/data-grid/data-grid-types.js";
 import type { InternalCellRenderer } from "./cell-types.js";
-import { withAlpha } from "../internal/data-grid/color-parser.js";
+import { drawEditHoverIndicator } from "../internal/data-grid/render/draw-edit-hover-indicator.js";
 
 export const textCellRenderer: InternalCellRenderer<TextCell> = {
     getAccessibilityString: c => c.data?.toString() ?? "",
@@ -20,33 +15,9 @@ export const textCellRenderer: InternalCellRenderer<TextCell> = {
     useLabel: true,
     draw: a => {
         const { cell, hoverAmount, hyperWrapping, ctx, rect, theme, overrideCursor } = a;
-        const { displayData, contentAlign, hoverEffect, allowWrapping } = cell;
+        const { displayData, contentAlign, hoverEffect, allowWrapping, hoverEffectTheme } = cell;
         if (hoverEffect === true && hoverAmount > 0) {
-            ctx.textBaseline = "alphabetic";
-            const padX = theme.cellHorizontalPadding;
-            const padY = theme.cellVerticalPadding;
-            const m = measureTextCached(displayData, ctx, theme.baseFontFull, "alphabetic");
-            const maxH = rect.height - padY;
-            const h = Math.min(maxH, m.actualBoundingBoxAscent * 2.5);
-            ctx.beginPath();
-            roundedRect(
-                ctx,
-                rect.x + padX / 2,
-                rect.y + (rect.height - h) / 2 + 1,
-                m.width + padX * 3,
-                h - 1,
-                theme.roundingRadius ?? 4
-            );
-            ctx.globalAlpha = hoverAmount;
-            ctx.fillStyle = withAlpha(theme.textDark, 0.1);
-            ctx.fill();
-
-            // restore
-            ctx.globalAlpha = 1;
-            ctx.fillStyle = theme.textDark;
-            ctx.textBaseline = "middle";
-
-            overrideCursor?.("text");
+            drawEditHoverIndicator(ctx, theme, hoverEffectTheme, displayData, rect, hoverAmount, overrideCursor);
         }
         drawTextCell(a, displayData, contentAlign, allowWrapping, hyperWrapping);
     },

--- a/packages/core/src/data-editor/stories/utils.tsx
+++ b/packages/core/src/data-editor/stories/utils.tsx
@@ -618,6 +618,15 @@ function getColumnsForCellTypes(): GridColumnWithMockingInfo[] {
                     data: name,
                     displayData: name,
                     allowOverlay: true,
+                    hoverEffect: true,
+                    themeOverride: {
+                        cellVerticalPadding: 8,
+                        cellHorizontalPadding: 8,
+                    },
+                    hoverEffectTheme: {
+                        bgColor: "#f4f4f4",
+                        fullSize: true,
+                    },
                 };
             },
         },
@@ -633,6 +642,15 @@ function getColumnsForCellTypes(): GridColumnWithMockingInfo[] {
                     data: age,
                     displayData: `${age}`,
                     allowOverlay: true,
+                    hoverEffect: true,
+                    themeOverride: {
+                        cellVerticalPadding: 8,
+                        cellHorizontalPadding: 8,
+                    },
+                    hoverEffectTheme: {
+                        bgColor: "#f4f4f4",
+                        fullSize: true,
+                    },
                 };
             },
         },

--- a/packages/core/src/docs/examples/all-cell-kinds.stories.tsx
+++ b/packages/core/src/docs/examples/all-cell-kinds.stories.tsx
@@ -39,7 +39,7 @@ export const AllCellKinds: React.VFC = () => {
             columns={cols}
             onCellEdited={setCellValue}
             onPaste={true}
-            // rowHeight={55}
+            rowHeight={44}
             onColumnResize={onColumnResize}
             highlightRegions={[
                 {
@@ -52,6 +52,9 @@ export const AllCellKinds: React.VFC = () => {
                     },
                 },
             ]}
+            cellActivationBehavior="single-click"
+            editorBloom={[-4, -4]}
+            drawFocusRing={false}
             rows={1000}
         />
     );

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -330,6 +330,11 @@ export interface ProtectedCell extends BaseGridCell {
     readonly kind: GridCellKind.Protected;
 }
 
+export interface HoverEffectTheme {
+    bgColor: string;
+    fullSize: boolean;
+}
+
 /** @category Cells */
 export interface TextCell extends BaseGridCell {
     readonly kind: GridCellKind.Text;
@@ -338,6 +343,7 @@ export interface TextCell extends BaseGridCell {
     readonly readonly?: boolean;
     readonly allowWrapping?: boolean;
     readonly hoverEffect?: boolean;
+    readonly hoverEffectTheme?: HoverEffectTheme;
 }
 
 /** @category Cells */
@@ -350,6 +356,8 @@ export interface NumberCell extends BaseGridCell {
     readonly allowNegative?: boolean;
     readonly thousandSeparator?: boolean | string;
     readonly decimalSeparator?: string;
+    readonly hoverEffect?: boolean;
+    readonly hoverEffectTheme?: HoverEffectTheme;
 }
 
 /** @category Cells */

--- a/packages/core/src/internal/data-grid/render/draw-edit-hover-indicator.ts
+++ b/packages/core/src/internal/data-grid/render/draw-edit-hover-indicator.ts
@@ -1,5 +1,7 @@
 import type { FullTheme } from "../../../common/styles.js";
-import { measureTextCached, roundedRect, type Rectangle, withAlpha, type HoverEffectTheme } from "../../../index.js";
+import type { Rectangle, HoverEffectTheme } from "../../../index.js";
+import { roundedRect, measureTextCached } from "./data-grid-lib.js";
+import { withAlpha } from "../color-parser.js";
 
 export function drawEditHoverIndicator(
     ctx: CanvasRenderingContext2D,

--- a/packages/core/src/internal/data-grid/render/draw-edit-hover-indicator.ts
+++ b/packages/core/src/internal/data-grid/render/draw-edit-hover-indicator.ts
@@ -1,0 +1,59 @@
+import type { FullTheme } from "../../../common/styles.js";
+import { measureTextCached, roundedRect, type Rectangle, withAlpha, type HoverEffectTheme } from "../../../index.js";
+
+export function drawEditHoverIndicator(
+    ctx: CanvasRenderingContext2D,
+    theme: FullTheme,
+    effectTheme: HoverEffectTheme | undefined,
+    displayData: string,
+    rect: Rectangle,
+    hoverAmount: number,
+    overrideCursor: ((cursor: React.CSSProperties["cursor"] | undefined) => void) | undefined
+) {
+    ctx.textBaseline = "alphabetic";
+
+    const effectRect = getHoverEffectRect(ctx, rect, displayData, theme, effectTheme?.fullSize ?? false);
+
+    ctx.beginPath();
+    roundedRect(ctx, effectRect.x, effectRect.y, effectRect.width, effectRect.height, theme.roundingRadius ?? 4);
+    ctx.globalAlpha = hoverAmount;
+    ctx.fillStyle = effectTheme?.bgColor ?? withAlpha(theme.textDark, 0.1);
+    ctx.fill();
+
+    // restore
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = theme.textDark;
+    ctx.textBaseline = "middle";
+
+    overrideCursor?.("text");
+}
+
+function getHoverEffectRect(
+    ctx: CanvasRenderingContext2D,
+    cellRect: Rectangle,
+    displayData: string,
+    theme: FullTheme,
+    fullSize: boolean
+): Rectangle {
+    const padX = theme.cellHorizontalPadding;
+    const padY = theme.cellVerticalPadding;
+
+    if (fullSize) {
+        return {
+            x: cellRect.x + padX / 2,
+            y: cellRect.y + padY / 2 + 1,
+            width: cellRect.width - padX,
+            height: cellRect.height - padY - 1,
+        };
+    }
+
+    const m = measureTextCached(displayData, ctx, theme.baseFontFull, "alphabetic");
+    const maxH = cellRect.height - padY;
+    const h = Math.min(maxH, m.actualBoundingBoxAscent * 2.5);
+    return {
+        x: cellRect.x + padX / 2,
+        y: cellRect.y + (cellRect.height - h) / 2 + 1,
+        width: m.width + padX * 3,
+        height: h - 1,
+    };
+}


### PR DESCRIPTION

https://github.com/glideapps/glide-data-grid/assets/18490534/e03293af-474f-43e7-96a3-2031a4c96dd3

This PR adds the hover effect for the number cell and adds some theming capabilities for it:

- `fullSize` - don't adapt to the cell's size, use the cell's padding.
- `bgColor` - the background color, defaults to the existing "darkText with opacity"

found TODOs:
- number cell editor does not fit the cell as the text one.