### PR TITLE
Disable header row marker on single selection

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -877,6 +877,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const rowMarkerTheme = rowMarkersObj?.theme ?? p.rowMarkerTheme;
     const headerRowMarkerTheme = rowMarkersObj?.headerTheme;
     const headerRowMarkerAlwaysVisible = rowMarkersObj?.headerAlwaysVisible;
+    const headerRowMarkerDisabled = rowSelect !== "multi";
     const rowMarkerCheckboxStyle = rowMarkersObj?.checkboxStyle ?? "square";
 
     const minColumnWidth = Math.max(minColumnWidthIn, 20);
@@ -1112,6 +1113,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 rowMarkerChecked,
                 headerRowMarkerTheme,
                 headerRowMarkerAlwaysVisible,
+                headerRowMarkerDisabled,
             },
             ...columns,
         ];
@@ -1124,6 +1126,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         rowMarkerChecked,
         headerRowMarkerTheme,
         headerRowMarkerAlwaysVisible,
+        headerRowMarkerDisabled,
     ]);
 
     const visibleRegionRef = React.useRef<VisibleRegion>({
@@ -1795,7 +1798,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         } else {
                             setSelectedRows(CompactSelection.fromSingleSelection(newSlice), undefined, isMultiRow);
                         }
-                    } else if (isMultiRow || args.isTouch || rowSelectionMode === "multi") {
+                    } else if (rowSelect === "multi" && (isMultiRow || args.isTouch || rowSelectionMode === "multi")) {
                         if (isSelected) {
                             setSelectedRows(selectedRows.remove(row), undefined, true);
                         } else {

--- a/packages/core/src/docs/examples/row-selections.stories.tsx
+++ b/packages/core/src/docs/examples/row-selections.stories.tsx
@@ -20,8 +20,10 @@ export default {
                     title="Row selections"
                     description={
                         <Description>
-                            You can enable row selections by setting <PropName>rowSelect</PropName> prop to multi for
-                            multi-selection or single for single-selection.
+                            You can enable row selections by setting <PropName>rowSelect</PropName> prop to{" "}
+                            <PropName>multi</PropName> for multi-selection or <PropName>single</PropName> for
+                            single-selection. The row marker behavior and appearance can be controlled by setting the{" "}
+                            <PropName>rowMarkers</PropName> prop.
                         </Description>
                     }>
                     <Story />

--- a/packages/core/src/docs/examples/row-selections.stories.tsx
+++ b/packages/core/src/docs/examples/row-selections.stories.tsx
@@ -22,7 +22,7 @@ export default {
                         <Description>
                             You can enable row selections by setting <PropName>rowSelect</PropName> prop to{" "}
                             <PropName>multi</PropName> for multi-selection or <PropName>single</PropName> for
-                            single-selection. The row marker behavior and appearance can be controlled by setting the{" "}
+                            single-selection. The row marker behavior and appearance can be controlled via the{" "}
                             <PropName>rowMarkers</PropName> prop.
                         </Description>
                     }>

--- a/packages/core/src/docs/examples/row-selections.stories.tsx
+++ b/packages/core/src/docs/examples/row-selections.stories.tsx
@@ -59,8 +59,8 @@ export const RowSelections: React.FC<RowSelectionsProps> = p => {
 (RowSelections as any).args = {
     rowSelect: "single",
     rowSelectionMode: "auto",
-    rowMarkersKind: "checkbox",
-    rowMarkersCheckboxStyle: "square",
+    rowMarkersKind: "checkbox-visible",
+    rowMarkersCheckboxStyle: "circle",
 };
 (RowSelections as any).argTypes = {
     rowSelect: {

--- a/packages/core/src/docs/examples/row-selections.stories.tsx
+++ b/packages/core/src/docs/examples/row-selections.stories.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
+import { type RowMarkerOptions } from "../../data-editor/data-editor.js";
+import {
+    BeautifulWrapper,
+    Description,
+    PropName,
+    useMockDataGenerator,
+    defaultProps,
+} from "../../data-editor/stories/utils.js";
+import { SimpleThemeWrapper } from "../../stories/story-utils.js";
+
+export default {
+    title: "Glide-Data-Grid/DataEditor Demos",
+
+    decorators: [
+        (Story: React.ComponentType) => (
+            <SimpleThemeWrapper>
+                <BeautifulWrapper
+                    title="Row selections"
+                    description={
+                        <Description>
+                            You can enable row selections by setting <PropName>rowSelect</PropName> prop to multi for
+                            multi-selection or single for single-selection.
+                        </Description>
+                    }>
+                    <Story />
+                </BeautifulWrapper>
+            </SimpleThemeWrapper>
+        ),
+    ],
+};
+
+interface RowSelectionsProps {
+    rowSelect: "none" | "single" | "multi";
+    rowSelectionMode: "auto" | "multi";
+    rowMarkersKind: RowMarkerOptions["kind"];
+    rowMarkersCheckboxStyle: RowMarkerOptions["checkboxStyle"];
+}
+
+export const RowSelections: React.FC<RowSelectionsProps> = p => {
+    const { cols, getCellContent } = useMockDataGenerator(30);
+
+    return (
+        <DataEditor
+            {...defaultProps}
+            rowSelect={p.rowSelect}
+            rowSelectionMode={p.rowSelectionMode}
+            getCellContent={getCellContent}
+            rowMarkers={{
+                kind: p.rowMarkersKind,
+                checkboxStyle: p.rowMarkersCheckboxStyle,
+            }}
+            columns={cols}
+            rows={400}
+        />
+    );
+};
+(RowSelections as any).args = {
+    rowSelect: "single",
+    rowSelectionMode: "auto",
+    rowMarkersKind: "checkbox",
+    rowMarkersCheckboxStyle: "square",
+};
+(RowSelections as any).argTypes = {
+    rowSelect: {
+        control: { type: "select" },
+        options: ["none", "single", "multi"],
+    },
+    rowSelectionMode: {
+        control: { type: "select" },
+        options: ["auto", "multi"],
+    },
+    rowMarkersKind: {
+        control: { type: "select" },
+        options: ["both", "checkbox", "number", "none", "clickable-number", "checkbox-visible"],
+    },
+    rowMarkersCheckboxStyle: {
+        control: { type: "select" },
+        options: ["square", "circle"],
+    },
+};

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -197,6 +197,7 @@ export type InnerColumnExtension = {
     rowMarkerChecked?: BooleanIndeterminate | boolean;
     headerRowMarkerTheme?: Partial<Theme>;
     headerRowMarkerAlwaysVisible?: boolean;
+    headerRowMarkerDisabled?: boolean;
 };
 
 /** @category Columns */

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -47,6 +47,7 @@ export function useMappedColumns(
                     rowMarkerChecked: c.rowMarkerChecked,
                     headerRowMarkerTheme: c.headerRowMarkerTheme,
                     headerRowMarkerAlwaysVisible: c.headerRowMarkerAlwaysVisible,
+                    headerRowMarkerDisabled: c.headerRowMarkerDisabled,
                 })
             ),
         [columns, freezeColumns]

--- a/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.header.ts
@@ -428,7 +428,7 @@ function drawHeaderInner(
     isRtl: boolean,
     headerLayout: HeaderLayout
 ) {
-    if (c.rowMarker !== undefined) {
+    if (c.rowMarker !== undefined && c.headerRowMarkerDisabled !== true) {
         const checked = c.rowMarkerChecked;
         if (checked !== true && c.headerRowMarkerAlwaysVisible !== true) {
             ctx.globalAlpha = hoverAmount;

--- a/packages/core/test/data-grid-lib.test.ts
+++ b/packages/core/test/data-grid-lib.test.ts
@@ -21,6 +21,7 @@ function makeCol(title: string, sourceIndex: number, sticky: boolean, width: num
         grow: undefined,
         headerRowMarkerAlwaysVisible: undefined,
         headerRowMarkerTheme: undefined,
+        headerRowMarkerDisabled: undefined,
         hasMenu: undefined,
         icon: undefined,
         id: undefined,


### PR DESCRIPTION
Configuring `rowSelect` as `single` still shows a not-functional checkbox in the row marker header. I would expect that this isn't shown since this feature doesn't really make sense for single-row selection. This PR disables the row marker header for `rowSelect` == `single`.

https://github.com/glideapps/glide-data-grid/assets/2852129/7f6d9a94-a0a4-4e34-863d-ed77dbdaa407

Closes https://github.com/glideapps/glide-data-grid/issues/934

In addition, in the current impl. it was also possible to have multi-selection even if `row select` is set to `single.` For example, touch devices would falsely allow multi-selection. This PR also enforces the `single` configuration. 