### PR TITLE
Fix the bubble overlay editor with long text bubbles

### DIFF
--- a/packages/core/src/data-editor/stories/utils.tsx
+++ b/packages/core/src/data-editor/stories/utils.tsx
@@ -730,7 +730,14 @@ Try out [Glide](https://www.glideapps.com/)
             getContent: () => {
                 return {
                     kind: GridCellKind.Bubble,
-                    data: [faker.lorem.word(), faker.lorem.word(), faker.lorem.word()],
+                    data: [
+                        faker.lorem.word(),
+                        faker.lorem.word(),
+                        faker.lorem.word(),
+                        faker.lorem.words(2),
+                        faker.lorem.words(2),
+                        faker.lorem.words(2),
+                    ],
                     allowOverlay: true,
                 };
             },

--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
@@ -7,6 +7,7 @@ export const BubblesOverlayEditorStyle = styled.div`
     flex-wrap: wrap;
     margin-top: auto;
     margin-bottom: auto;
+    overflow: auto;
 
     .boe-bubble {
         display: flex;
@@ -20,6 +21,7 @@ export const BubblesOverlayEditorStyle = styled.div`
         background-color: var(--gdg-bg-bubble);
         color: var(--gdg-text-dark);
         margin: 2px;
+        white-space: nowrap;
     }
 
     textarea {


### PR DESCRIPTION
The bubble overlay editor is currently broken if the bubble length gets too long. This PR fixes this issue via some CSS changes.

Before:
<img width="551" alt="Screenshot 2024-04-09 at 22 12 06" src="https://github.com/glideapps/glide-data-grid/assets/2852129/32e44324-861e-478c-9b3e-0b93e9af95ca">

After:
https://github.com/glideapps/glide-data-grid/assets/2852129/cf0bb498-135a-4032-9d66-d0b1e1ce011a

