### PR TITLE
Use Range type instead of Item type

### DIFF
--- a/packages/source/src/use-async-data-source.ts
+++ b/packages/source/src/use-async-data-source.ts
@@ -13,7 +13,8 @@ import range from "lodash/range.js";
 import chunk from "lodash/chunk.js";
 import React from "react";
 
-export type RowCallback<T> = (range: Item) => Promise<readonly T[]>;
+type Range = readonly [startIndex: number, endIndex: number];
+export type RowCallback<T> = (range: Range) => Promise<readonly T[]>;
 export type RowToCell<T> = (row: T, col: number) => GridCell;
 export type RowEditedCallback<T> = (cell: Item, newVal: EditableGridCell, rowData: T) => T | undefined;
 export function useAsyncDataSource<TRowType>(


### PR DESCRIPTION
Item type is not semantically correct here. An Item is a [row, col] pair, but this callback argument should be a [startIndex, endIndex] pair.

