### PR TITLE
emit onHeaderClicked in row marker column

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2354,10 +2354,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             }
 
             if (args.kind === "header") {
-                if (clickLocation < 0) {
-                    return;
-                }
-
                 if (args.isEdge) {
                     if (args.isDoubleClick === true) {
                         void normalSizeColumn(col);
@@ -2367,16 +2363,15 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
             }
 
-            if (args.kind === groupHeaderKind) {
-                if (clickLocation < 0) {
-                    return;
-                }
-
-                if (args.button === 0 && col === lastMouseDownCol && row === lastMouseDownRow) {
-                    onGroupHeaderClicked?.(clickLocation, { ...args, preventDefault });
-                    if (!isPrevented.current) {
-                        handleGroupHeaderSelection(args);
-                    }
+            if (
+                args.kind === groupHeaderKind &&
+                args.button === 0 &&
+                col === lastMouseDownCol &&
+                row === lastMouseDownRow
+            ) {
+                onGroupHeaderClicked?.(clickLocation, { ...args, preventDefault });
+                if (!isPrevented.current) {
+                    handleGroupHeaderSelection(args);
                 }
             }
 

--- a/packages/core/src/docs/examples/row-selections.stories.tsx
+++ b/packages/core/src/docs/examples/row-selections.stories.tsx
@@ -53,6 +53,9 @@ export const RowSelections: React.FC<RowSelectionsProps> = p => {
                 kind: p.rowMarkersKind,
                 checkboxStyle: p.rowMarkersCheckboxStyle,
             }}
+            onHeaderClicked={(col, event) => {
+                console.log("onHeaderClicked", col, event);
+            }}
             columns={cols}
             rows={400}
         />

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -892,7 +892,7 @@ describe("data-editor", () => {
             clientY: 16, // Header
         });
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
     });
 
     test("Group header sections", async () => {


### PR DESCRIPTION
Resolves https://github.com/glideapps/glide-data-grid/issues/974
Undoes https://github.com/glideapps/glide-data-grid/pull/294

Rationale:
- Allows tapping into that click handler to perform custom actions
- Given that a column index of `-1` is provided for row marker columns, it is very easy to ignore if unwanted from the consuming side.

I'm not really expecting this to be merged, but sharing in case anyone needs this change as well.