### PR TITLE
fix: highlight border to be drawn many times in different places in the frozen area

### DIFF
--- a/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid.render.rings.ts
@@ -117,6 +117,7 @@ export function drawHighlightRings(
                 ) {
                     const wasDashed: boolean = dashed;
                     const needsClip = !rectContains(s.clip, s.rect);
+                    ctx.beginPath();
                     if (needsClip) {
                         ctx.save();
                         ctx.rect(s.clip.x, s.clip.y, s.clip.width, s.clip.height);
@@ -133,6 +134,7 @@ export function drawHighlightRings(
                         s.style === "solid-outline"
                             ? blend(blend(s.color, theme.borderColor), theme.bgCell)
                             : withAlpha(s.color, 1);
+                    ctx.closePath();
                     ctx.strokeRect(s.rect.x + 0.5, s.rect.y + 0.5, s.rect.width - 1, s.rect.height - 1);
                     if (needsClip) {
                         ctx.restore();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/053cd3fc-5dfd-4662-ab20-ad381e5c9a2c)

There are multiple cropping regions, resulting in the border not being cropped