### PR TITLE
Add experimental support for custom event target

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,33 @@
+const path = require("path");
+
+module.exports = {
+    stories: ["../**/src/**/*.stories.tsx"],
+    addons: [getAbsolutePath("@storybook/addon-storysource"), getAbsolutePath("@storybook/addon-controls")],
+
+    typescript: {
+        reactDocgen: false,
+    },
+
+    async viteFinal(config) {
+        // We need to dynamically import these since they use ESM
+        const { mergeConfig } = await import("vite");
+        const linaria = (await import("@linaria/vite")).default;
+
+        return mergeConfig(config, {
+            plugins: [linaria()],
+        });
+    },
+
+    framework: {
+        name: getAbsolutePath("@storybook/react-vite"),
+        options: {},
+    },
+
+    docs: {
+        autodocs: false,
+    },
+};
+
+function getAbsolutePath(value) {
+    return path.dirname(require.resolve(path.join(value, "package.json")));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "root",
-    "version": "6.0.4-alpha6",
+    "version": "6.0.4-alpha8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "root",
-            "version": "6.0.4-alpha6",
+            "version": "6.0.4-alpha8",
             "license": "MIT",
             "workspaces": [
                 "./packages/core",
@@ -21231,10 +21231,10 @@
         },
         "packages/cells": {
             "name": "@glideapps/glide-data-grid-cells",
-            "version": "6.0.4-alpha6",
+            "version": "6.0.4-alpha8",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "6.0.4-alpha6",
+                "@glideapps/glide-data-grid": "6.0.4-alpha8",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
@@ -21255,7 +21255,7 @@
         },
         "packages/core": {
             "name": "@glideapps/glide-data-grid",
-            "version": "6.0.4-alpha6",
+            "version": "6.0.4-alpha8",
             "license": "MIT",
             "dependencies": {
                 "@linaria/react": "^4.5.3",
@@ -21327,10 +21327,10 @@
         },
         "packages/source": {
             "name": "@glideapps/glide-data-grid-source",
-            "version": "6.0.4-alpha6",
+            "version": "6.0.4-alpha8",
             "license": "MIT",
             "dependencies": {
-                "@glideapps/glide-data-grid": "6.0.4-alpha6"
+                "@glideapps/glide-data-grid": "6.0.4-alpha8"
             },
             "devDependencies": {
                 "@babel/cli": "^7.16.0",
@@ -23270,7 +23270,7 @@
             "version": "file:packages/cells",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "6.0.4-alpha6",
+                "@glideapps/glide-data-grid": "6.0.4-alpha8",
                 "@linaria/react": "^4.5.3",
                 "@toast-ui/editor": "3.1.10",
                 "@toast-ui/react-editor": "3.1.10",
@@ -23290,7 +23290,7 @@
             "version": "file:packages/source",
             "requires": {
                 "@babel/cli": "^7.16.0",
-                "@glideapps/glide-data-grid": "6.0.4-alpha6",
+                "@glideapps/glide-data-grid": "6.0.4-alpha8",
                 "eslint": "^8.19.0",
                 "eslint-plugin-import": "^2.22.0",
                 "eslint-plugin-react": "^7.21.5",

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -4123,6 +4123,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             onFinishEditing={onFinishEditing}
                             markdownDivCreateNode={markdownDivCreateNode}
                             isOutsideClick={isOutsideClick}
+                            customEventTarget={experimental?.eventTarget}
                         />
                     </React.Suspense>
                 )}

--- a/packages/core/src/docs/examples/custom-event-target.stories.tsx
+++ b/packages/core/src/docs/examples/custom-event-target.stories.tsx
@@ -116,7 +116,7 @@ export const CustomEventTarget: React.VFC = () => {
         <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
             <div style={{ marginBottom: 10, padding: 10, backgroundColor: "#f0f0f0", borderRadius: 4 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                    <span>Window click attempts blocked: {windowClickAttempts}</span>
+                    <span style={{ color: "#666" }}>Window click attempts blocked: {windowClickAttempts}</span>
                     <button
                         onClick={() => alert("This button should not work if window events are blocked!")}
                         style={{ padding: "5px 10px" }}>

--- a/packages/core/src/docs/examples/custom-event-target.stories.tsx
+++ b/packages/core/src/docs/examples/custom-event-target.stories.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
+import type { GridColumn, Item, TextCell } from "../../internal/data-grid/data-grid-types.js";
+import { GridCellKind } from "../../internal/data-grid/data-grid-types.js";
+import { BeautifulWrapper, Description, defaultProps } from "../../data-editor/stories/utils.js";
+import { SimpleThemeWrapper } from "../../stories/story-utils.js";
+
+export default {
+    title: "Glide-Data-Grid/DataEditor Demos",
+
+    decorators: [
+        (Story: React.ComponentType) => (
+            <SimpleThemeWrapper>
+                <BeautifulWrapper
+                    title="Custom Event Target"
+                    description={
+                        <Description>
+                            This example demonstrates using a custom event target for the data grid. All window events
+                            are blocked, but the grid still works because it&apos;s using the container div as its event
+                            target instead of window.
+                        </Description>
+                    }>
+                    <Story />
+                </BeautifulWrapper>
+            </SimpleThemeWrapper>
+        ),
+    ],
+};
+
+export const CustomEventTarget: React.VFC = () => {
+    // Create columns
+    const [cols] = React.useState<GridColumn[]>(() => {
+        return [
+            {
+                title: "Column A",
+                id: "a",
+                width: 150,
+            },
+            {
+                title: "Column B",
+                id: "b",
+                width: 150,
+            },
+            {
+                title: "Column C",
+                id: "c",
+                width: 150,
+            },
+        ];
+    });
+
+    // Create data
+    const getCellContent = React.useCallback((cell: Item): TextCell => {
+        const [col, row] = cell;
+        return {
+            kind: GridCellKind.Text,
+            allowOverlay: true,
+            displayData: `${col}, ${row}`,
+            data: `${col}, ${row}`,
+        };
+    }, []);
+
+    // Create a ref for our custom event target container
+    const containerRef = React.useRef<HTMLDivElement>(null);
+
+    // State to track if the container is mounted
+    const [containerMounted, setContainerMounted] = React.useState(false);
+
+    // State to track window click attempts
+    const [windowClickAttempts, setWindowClickAttempts] = React.useState(0);
+
+    // Update containerMounted state after the component mounts
+    React.useEffect(() => {
+        if (containerRef.current !== null) {
+            setContainerMounted(true);
+        }
+    }, []);
+
+    // Block all window events
+    React.useEffect(() => {
+        const blockEvent = (e: Event) => {
+            // Don't block events if they're inside our container
+            if (containerRef.current && e.target instanceof Node && containerRef.current.contains(e.target)) {
+                return;
+            }
+
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            if (e.cancelable) {
+                e.preventDefault();
+            }
+
+            // Count click attempts outside the grid
+            if (e.type === "click") {
+                setWindowClickAttempts(prev => prev + 1);
+            }
+        };
+
+        // Block all mouse and touch events on window
+        const events = ["mousedown", "mouseup", "mousemove", "click", "touchstart", "touchend", "touchmove"];
+
+        // Add event blockers to window
+        for (const event of events) {
+            window.addEventListener(event, blockEvent, true);
+        }
+
+        return () => {
+            // Clean up event blockers
+            for (const event of events) {
+                window.removeEventListener(event, blockEvent, true);
+            }
+        };
+    }, []);
+
+    return (
+        <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+            <div style={{ marginBottom: 10, padding: 10, backgroundColor: "#f0f0f0", borderRadius: 4 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <span>Window click attempts blocked: {windowClickAttempts}</span>
+                    <button
+                        onClick={() => alert("This button should not work if window events are blocked!")}
+                        style={{ padding: "5px 10px" }}>
+                        Try clicking me (should not work)
+                    </button>
+                </div>
+                <div style={{ marginTop: 10, fontSize: 14, color: "#666" }}>
+                    Try clicking outside the grid or on the button above - these clicks should be blocked. But the grid
+                    below should still be fully interactive!
+                </div>
+            </div>
+
+            <div
+                ref={containerRef}
+                style={{
+                    flex: 1,
+                    position: "relative",
+                    border: "2px solid #3c78d8",
+                    borderRadius: 4,
+                    padding: 10,
+                }}>
+                {containerMounted && (
+                    <DataEditor
+                        {...defaultProps}
+                        width="100%"
+                        height="100%"
+                        rows={1000}
+                        columns={cols}
+                        getCellContent={getCellContent}
+                        experimental={{
+                            customWindowEventTarget: containerRef.current as HTMLElement,
+                        }}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};

--- a/packages/core/src/docs/examples/custom-event-target.stories.tsx
+++ b/packages/core/src/docs/examples/custom-event-target.stories.tsx
@@ -147,7 +147,7 @@ export const CustomEventTarget: React.VFC = () => {
                         columns={cols}
                         getCellContent={getCellContent}
                         experimental={{
-                            customWindowEventTarget: containerRef.current as HTMLElement,
+                            windowEventTarget: containerRef.current as HTMLElement,
                         }}
                     />
                 )}

--- a/packages/core/src/docs/examples/custom-event-target.stories.tsx
+++ b/packages/core/src/docs/examples/custom-event-target.stories.tsx
@@ -136,7 +136,7 @@ export const CustomEventTarget: React.VFC = () => {
                     position: "relative",
                     border: "2px solid #3c78d8",
                     borderRadius: 4,
-                    padding: 10,
+                    padding: 15,
                 }}>
                 {containerMounted && (
                     <DataEditor
@@ -147,7 +147,7 @@ export const CustomEventTarget: React.VFC = () => {
                         columns={cols}
                         getCellContent={getCellContent}
                         experimental={{
-                            windowEventTarget: containerRef.current as HTMLElement,
+                            eventTarget: containerRef.current as HTMLElement,
                         }}
                     />
                 )}

--- a/packages/core/src/internal/click-outside-container/click-outside-container.tsx
+++ b/packages/core/src/internal/click-outside-container/click-outside-container.tsx
@@ -2,25 +2,30 @@ import * as React from "react";
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
     onClickOutside: () => void;
     isOutsideClick?: (event: MouseEvent | TouchEvent) => boolean;
+    // If provided, it will use the provided element as the event target
+    // instead of document.
+    customEventTarget?: HTMLElement | Window | Document;
 }
 
 export default class ClickOutsideContainer extends React.PureComponent<Props> {
     private wrapperRef = React.createRef<HTMLDivElement>();
 
     public componentDidMount() {
-        document.addEventListener("touchend", this.clickOutside, true);
-        document.addEventListener("mousedown", this.clickOutside, true);
-        document.addEventListener("contextmenu", this.clickOutside, true);
+        const eventTarget = this.props.customEventTarget ?? document;
+        eventTarget.addEventListener("touchend", this.clickOutside, true);
+        eventTarget.addEventListener("mousedown", this.clickOutside, true);
+        eventTarget.addEventListener("contextmenu", this.clickOutside, true);
     }
 
     public componentWillUnmount() {
-        document.removeEventListener("touchend", this.clickOutside, true);
-        document.removeEventListener("mousedown", this.clickOutside, true);
-        document.removeEventListener("contextmenu", this.clickOutside, true);
+        const eventTarget = this.props.customEventTarget ?? document;
+        eventTarget.removeEventListener("touchend", this.clickOutside, true);
+        eventTarget.removeEventListener("mousedown", this.clickOutside, true);
+        eventTarget.removeEventListener("contextmenu", this.clickOutside, true);
     }
 
-    private clickOutside = (event: MouseEvent | TouchEvent) => {
-        if (this.props.isOutsideClick && !this.props.isOutsideClick(event)) {
+    private clickOutside = (event: Event) => {
+        if (this.props.isOutsideClick && !this.props.isOutsideClick(event as MouseEvent | TouchEvent)) {
             return;
         }
         if (this.wrapperRef.current !== null && !this.wrapperRef.current.contains(event.target as Node | null)) {
@@ -37,7 +42,7 @@ export default class ClickOutsideContainer extends React.PureComponent<Props> {
     };
 
     public render(): React.ReactNode {
-        const { onClickOutside, isOutsideClick, ...rest } = this.props;
+        const { onClickOutside, isOutsideClick, customEventTarget, ...rest } = this.props;
         return (
             <div {...rest} ref={this.wrapperRef}>
                 {this.props.children}

--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -44,6 +44,7 @@ interface DataGridOverlayEditorProps {
         prevValue: GridCell
     ) => boolean | ValidatedGridCell;
     readonly isOutsideClick?: (e: MouseEvent | TouchEvent) => boolean;
+    readonly customEventTarget?: HTMLElement | Window | Document;
 }
 
 const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps> = p => {
@@ -65,6 +66,7 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
         getCellRenderer,
         provideEditor,
         isOutsideClick,
+        customEventTarget,
     } = p;
 
     const [tempValue, setTempValueRaw] = React.useState<GridCell | undefined>(forceEditMode ? content : undefined);
@@ -218,7 +220,8 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                 style={makeCSSStyle(theme)}
                 className={className}
                 onClickOutside={onClickOutside}
-                isOutsideClick={isOutsideClick}>
+                isOutsideClick={isOutsideClick}
+                customEventTarget={customEventTarget}>
                 <DataGridOverlayEditorStyle
                     ref={ref}
                     id={id}

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -1445,7 +1445,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 windowEventTargetRef.current = docRoot as any;
             }
         },
-        [canvasRef, experimental]
+        [canvasRef, experimental?.eventTarget]
     );
 
     const onDragStartImpl = React.useCallback(

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -259,7 +259,7 @@ export interface DataGridProps {
                * Allows providing a custom event target for event listeners.
                * If not provided, the grid will use the window as the event target.
                */
-              readonly windowEventTarget?: HTMLElement | Window | Document;
+              readonly eventTarget?: HTMLElement | Window | Document;
           }
         | undefined;
 
@@ -401,9 +401,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     const cellXOffset = Math.max(freezeColumns, Math.min(columns.length - 1, cellXOffsetReal));
 
     const ref = React.useRef<HTMLCanvasElement | null>(null);
-    const windowEventTargetRef = React.useRef<HTMLElement | Window | Document>(
-        experimental?.windowEventTarget ?? window
-    );
+    const windowEventTargetRef = React.useRef<HTMLElement | Window | Document>(experimental?.eventTarget ?? window);
     const windowEventTarget = windowEventTargetRef.current;
 
     const imageLoader = imageWindowLoader;
@@ -1436,13 +1434,15 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 canvasRef.current = instance;
             }
 
-            if (instance === null) {
-                windowEventTargetRef.current = experimental?.windowEventTarget ?? window;
+            if (experimental?.eventTarget) {
+                windowEventTargetRef.current = experimental.eventTarget;
+            } else if (instance === null) {
+                windowEventTargetRef.current = window;
             } else {
                 const docRoot = instance.getRootNode();
 
-                windowEventTargetRef.current =
-                    docRoot === document ? experimental?.windowEventTarget ?? window : (docRoot as Document);
+                if (docRoot === document) windowEventTargetRef.current = window;
+                windowEventTargetRef.current = docRoot as any;
             }
         },
         [canvasRef, experimental]

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -257,8 +257,7 @@ export interface DataGridProps {
               readonly renderStrategy?: "single-buffer" | "double-buffer" | "direct";
               /**
                * Allows providing a custom event target for event listeners.
-               * This is useful for scenarios where the grid is in a different context (e.g., iframe)
-               * or when you want to attach events to a specific DOM element.
+               * If not provided, the grid will use the window as the event target.
                */
               readonly windowEventTarget?: HTMLElement | Window | Document;
           }

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -260,7 +260,7 @@ export interface DataGridProps {
                * This is useful for scenarios where the grid is in a different context (e.g., iframe)
                * or when you want to attach events to a specific DOM element.
                */
-              readonly customWindowEventTarget?: HTMLElement | Window | Document;
+              readonly windowEventTarget?: HTMLElement | Window | Document;
           }
         | undefined;
 
@@ -403,7 +403,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
 
     const ref = React.useRef<HTMLCanvasElement | null>(null);
     const windowEventTargetRef = React.useRef<HTMLElement | Window | Document>(
-        experimental?.customWindowEventTarget ?? window
+        experimental?.windowEventTarget ?? window
     );
     const windowEventTarget = windowEventTargetRef.current;
 
@@ -1438,12 +1438,12 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             }
 
             if (instance === null) {
-                windowEventTargetRef.current = experimental?.customWindowEventTarget ?? window;
+                windowEventTargetRef.current = experimental?.windowEventTarget ?? window;
             } else {
                 const docRoot = instance.getRootNode();
 
                 windowEventTargetRef.current =
-                    docRoot === document ? experimental?.customWindowEventTarget ?? window : (docRoot as Document);
+                    docRoot === document ? experimental?.windowEventTarget ?? window : (docRoot as Document);
             }
         },
         [canvasRef, experimental]

--- a/setup-react-18-test.sh
+++ b/setup-react-18-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-npm i -D react@latest react-dom@latest @testing-library/react@latest @testing-library/react-hooks@latest @testing-library/user-event@14.5.1 react-test-renderer@latest
+npm i -D react@latest react-dom@latest @testing-library/react@latest @testing-library/react-hooks@latest @testing-library/user-event@14.5.1 react-test-renderer@latest @testing-library/dom


### PR DESCRIPTION
Implements support for a custom event target in the data grid to allow event handling on a specified DOM element rather than on `window`. This can be set via `windowEventTarget` as part of the `experimental` properties.

Closes https://github.com/glideapps/glide-data-grid/issues/1022