### PR TITLE
fix: use correct font to measure column title width

### DIFF
--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -62,7 +62,9 @@ export function measureColumn(
             }
         }
     }
+    ctx.font = theme.headerFontFull;
     max = Math.max(max, ctx.measureText(c.title).width + theme.cellHorizontalPadding * 2 + (c.icon === undefined ? 0 : 28));
+    ctx.font = theme.baseFontFull;
     const final = Math.max(Math.ceil(minColumnWidth), Math.min(Math.floor(maxColumnWidth), Math.ceil(max)));
 
     return {

--- a/packages/core/src/data-editor/use-column-sizer.ts
+++ b/packages/core/src/data-editor/use-column-sizer.ts
@@ -62,9 +62,10 @@ export function measureColumn(
             }
         }
     }
+    const currentFont = ctx.font;
     ctx.font = theme.headerFontFull;
     max = Math.max(max, ctx.measureText(c.title).width + theme.cellHorizontalPadding * 2 + (c.icon === undefined ? 0 : 28));
-    ctx.font = theme.baseFontFull;
+    ctx.font = currentFont;
     const final = Math.max(Math.ceil(minColumnWidth), Math.min(Math.floor(maxColumnWidth), Math.ceil(max)));
 
     return {


### PR DESCRIPTION
The `measureColumn` code is incorrectly using the `baseFontFull` when measuring the width of the title (header), when `headerFontFull` should be used instead.

When the header is wider than the data, and therefore determines the auto-sized width, the computed width can be too narrow, cutting off the right padding and some of the text. This is assuming the header font is larger/bolder than the base font. Could have the inverse problem (auto-size too wide), as well.

Before:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/fc4ee77b-aeae-4a07-8324-40e135b53b6b" />

After:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/f555003b-1932-4375-8ccb-419caf8eb4d2" />
