### PR TITLE
Allow theming of bubble dimensions

### DIFF
--- a/packages/cells/src/cells/multi-select-cell.tsx
+++ b/packages/cells/src/cells/multi-select-cell.tsx
@@ -36,9 +36,6 @@ interface MultiSelectCellProps {
     readonly allowDuplicates?: boolean;
 }
 
-const BUBBLE_HEIGHT = 20;
-const BUBBLE_PADDING = 6;
-const BUBBLE_MARGIN = 4;
 /* This prefix is used when allowDuplicates is enabled to make sure that
 all underlying values are unique. */
 const VALUE_PREFIX = "__value";
@@ -229,14 +226,14 @@ const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
             return {
                 ...styles,
                 backgroundColor: data.color ?? theme.bgBubble,
-                borderRadius: `${theme.roundingRadius ?? BUBBLE_HEIGHT / 2}px`,
+                borderRadius: `${theme.roundingRadius ?? theme.bubbleHeight / 2}px`,
             };
         },
         multiValueLabel: (styles, { data, isDisabled }) => {
             return {
                 ...styles,
-                paddingRight: isDisabled ? BUBBLE_PADDING : 0,
-                paddingLeft: BUBBLE_PADDING,
+                paddingRight: isDisabled ? theme.bubblePadding : 0,
+                paddingLeft: theme.bubblePadding,
                 paddingTop: 0,
                 paddingBottom: 0,
                 color: data.color
@@ -251,7 +248,7 @@ const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
                 justifyContent: "center",
                 alignItems: "center",
                 display: "flex",
-                height: BUBBLE_HEIGHT,
+                height: theme.bubbleHeight,
             };
         },
         multiValueRemove: (styles, { data, isDisabled, isFocused }) => {
@@ -270,7 +267,7 @@ const Editor: ReturnType<ProvideEditorCallback<MultiSelectCell>> = p => {
                         : "white"
                     : theme.textBubble,
                 backgroundColor: undefined,
-                borderRadius: isFocused ? `${theme.roundingRadius ?? BUBBLE_HEIGHT / 2}px` : undefined,
+                borderRadius: isFocused ? `${theme.roundingRadius ?? theme.bubbleHeight / 2}px` : undefined,
                 ":hover": {
                     cursor: "pointer",
                 },
@@ -398,32 +395,32 @@ const renderer: CustomRenderer<MultiSelectCell> = {
             width: rect.width - 2 * theme.cellHorizontalPadding,
             height: rect.height - 2 * theme.cellVerticalPadding,
         };
-        const rows = Math.max(1, Math.floor(drawArea.height / (BUBBLE_HEIGHT + BUBBLE_PADDING)));
+        const rows = Math.max(1, Math.floor(drawArea.height / (theme.bubbleHeight + theme.bubblePadding)));
 
         let { x } = drawArea;
         let row = 1;
 
         let y =
             rows === 1
-                ? drawArea.y + (drawArea.height - BUBBLE_HEIGHT) / 2
-                : drawArea.y + (drawArea.height - rows * BUBBLE_HEIGHT - (rows - 1) * BUBBLE_PADDING) / 2;
+                ? drawArea.y + (drawArea.height - theme.bubbleHeight) / 2
+                : drawArea.y + (drawArea.height - rows * theme.bubbleHeight - (rows - 1) * theme.bubblePadding) / 2;
         for (const value of values) {
             const matchedOption = options.find(t => t.value === value);
             const color = matchedOption?.color ?? (highlighted ? theme.bgBubbleSelected : theme.bgBubble);
             const displayText = matchedOption?.label ?? value;
             const metrics = measureTextCached(displayText, ctx);
-            const width = metrics.width + BUBBLE_PADDING * 2;
-            const textY = BUBBLE_HEIGHT / 2;
+            const width = metrics.width + theme.bubblePadding * 2;
+            const textY = theme.bubbleHeight / 2;
 
             if (x !== drawArea.x && x + width > drawArea.x + drawArea.width && row < rows) {
                 row++;
-                y += BUBBLE_HEIGHT + BUBBLE_PADDING;
+                y += theme.bubbleHeight + theme.bubblePadding;
                 x = drawArea.x;
             }
 
             ctx.fillStyle = color;
             ctx.beginPath();
-            roundedRect(ctx, x, y, width, BUBBLE_HEIGHT, theme.roundingRadius ?? BUBBLE_HEIGHT / 2);
+            roundedRect(ctx, x, y, width, theme.bubbleHeight, theme.roundingRadius ?? theme.bubbleHeight / 2);
             ctx.fill();
 
             // If a color is set for this option, we use either black or white as the text color depending on the background.
@@ -433,9 +430,9 @@ const renderer: CustomRenderer<MultiSelectCell> = {
                     ? "#000000"
                     : "#ffffff"
                 : theme.textBubble;
-            ctx.fillText(displayText, x + BUBBLE_PADDING, y + textY + getMiddleCenterBias(ctx, theme));
+            ctx.fillText(displayText, x + theme.bubblePadding, y + textY + getMiddleCenterBias(ctx, theme));
 
-            x += width + BUBBLE_MARGIN;
+            x += width + theme.bubbleMargin;
             if (x > drawArea.x + drawArea.width + theme.cellHorizontalPadding && row >= rows) {
                 break;
             }
@@ -443,11 +440,11 @@ const renderer: CustomRenderer<MultiSelectCell> = {
 
         return true;
     },
-    measure: (ctx, cell, t) => {
+    measure: (ctx, cell, theme) => {
         const { values, options } = cell.data;
 
         if (!values) {
-            return t.cellHorizontalPadding * 2;
+            return theme.cellHorizontalPadding * 2;
         }
 
         // Resolve the values to the actual display labels:
@@ -455,11 +452,16 @@ const renderer: CustomRenderer<MultiSelectCell> = {
             x => x.label ?? x.value
         );
 
-        return (
-            labels.reduce((acc, data) => ctx.measureText(data).width + acc + BUBBLE_PADDING * 2 + BUBBLE_MARGIN, 0) +
-            2 * t.cellHorizontalPadding -
-            4
+        const bubblesWidth = labels.reduce(
+            (acc, data) => ctx.measureText(data).width + acc + theme.bubblePadding * 2 + theme.bubbleMargin,
+            0
         );
+
+        if (labels.length === 0) {
+            return theme.cellHorizontalPadding * 2;
+        }
+
+        return bubblesWidth + 2 * theme.cellHorizontalPadding - theme.bubbleMargin;
     },
     provideEditor: () => ({
         editor: Editor,

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -21,9 +21,6 @@ interface TagsCellProps {
 
 export type TagsCell = CustomCell<TagsCellProps>;
 
-const tagHeight = 20;
-const innerPad = 6;
-
 const EditorWrap = styled.div<{ tagHeight: number; innerPad: number }>`
     display: flex;
     flex-direction: column;
@@ -94,6 +91,8 @@ const renderer: CustomRenderer<TagsCell> = {
             width: rect.width - 2 * theme.cellHorizontalPadding,
             height: rect.height - 2 * theme.cellVerticalPadding,
         };
+        const tagHeight = theme.bubbleHeight;
+        const innerPad = theme.bubblePadding;
         const rows = Math.max(1, Math.floor(drawArea.height / (tagHeight + innerPad)));
 
         let x = drawArea.x;
@@ -130,11 +129,14 @@ const renderer: CustomRenderer<TagsCell> = {
     provideEditor: () => {
         // eslint-disable-next-line react/display-name
         return p => {
-            const { onChange, value } = p;
+            const { onChange, value, theme } = p;
             const { readonly = false } = value;
             const { possibleTags, tags } = value.data;
             return (
-                <EditorWrap tagHeight={tagHeight} innerPad={innerPad} className={readonly ? "gdg-readonly" : ""}>
+                <EditorWrap
+                    tagHeight={theme.bubbleHeight}
+                    innerPad={theme.bubblePadding}
+                    className={readonly ? "gdg-readonly" : ""}>
                     {possibleTags.map(t => {
                         const selected = tags.indexOf(t.tag) !== -1;
                         return (

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -387,6 +387,9 @@ The data grid uses the `Theme` provided to the DataEditer in the `theme` prop. T
 | fontFamily            | string              | --gdg-font-family             | The font family used by the data grid.                                                            |
 | editorFontSize        | string              | --gdg-editor-font-size        | The font size used by overlay editors.                                                            |
 | lineHeight            | number              | None                          | A unitless scaler which defines the height of a line of text relative to the ink size.            |
+| bubbleHeight          | number              | --gdg-bubble-height           | The height (in pixels) of a bubble.                                                               |
+| bubblePadding         | number              | --gdg-bubble-padding          | The left & right padding (in pixels) of a bubble.                                                 |
+| bubbleMargin          | number              | --gdg-bubble-margin           | The margin (in pixels) between bubbles.                                                           |
 
 ---
 

--- a/packages/core/src/cells/bubble-cell.tsx
+++ b/packages/core/src/cells/bubble-cell.tsx
@@ -12,8 +12,14 @@ export const bubbleCellRenderer: InternalCellRenderer<BubbleCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
-    measure: (ctx, cell, t) =>
-        cell.data.reduce((acc, data) => ctx.measureText(data).width + acc + 20, 0) + 2 * t.cellHorizontalPadding - 4,
+    measure: (ctx, cell, theme) => {
+        const bubblesWidth = cell.data.reduce(
+            (acc, data) => ctx.measureText(data).width + acc + theme.bubblePadding * 2 + theme.bubbleMargin,
+            0
+        );
+        if (cell.data.length === 0) return theme.cellHorizontalPadding * 2;
+        return bubblesWidth + 2 * theme.cellHorizontalPadding - theme.bubbleMargin;
+    },
     draw: a => drawBubbles(a, a.cell.data),
     provideEditor: () => p => {
         const { value } = p;
@@ -22,14 +28,10 @@ export const bubbleCellRenderer: InternalCellRenderer<BubbleCell> = {
     onPaste: () => undefined,
 };
 
-const itemMargin = 4;
-
 function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
     const { rect, theme, ctx, highlighted } = args;
     const { x, y, width: w, height: h } = rect;
-    const bubbleHeight = 20;
-    const bubblePad = 8;
-    const bubbleMargin = itemMargin;
+
     let renderX = x + theme.cellHorizontalPadding;
 
     const renderBoxes: { x: number; width: number }[] = [];
@@ -41,7 +43,7 @@ function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
             width: textWidth,
         });
 
-        renderX += textWidth + bubblePad * 2 + bubbleMargin;
+        renderX += textWidth + theme.bubblePadding * 2 + theme.bubbleMargin;
     }
 
     ctx.beginPath();
@@ -49,10 +51,10 @@ function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
         roundedRect(
             ctx,
             rectInfo.x,
-            y + (h - bubbleHeight) / 2,
-            rectInfo.width + bubblePad * 2,
-            bubbleHeight,
-            theme.roundingRadius ?? bubbleHeight / 2
+            y + (h - theme.bubbleHeight) / 2,
+            rectInfo.width + theme.bubblePadding * 2,
+            theme.bubbleHeight,
+            theme.roundingRadius ?? theme.bubbleHeight / 2
         );
     }
     ctx.fillStyle = highlighted ? theme.bgBubbleSelected : theme.bgBubble;
@@ -61,6 +63,6 @@ function drawBubbles(args: BaseDrawArgs, data: readonly string[]) {
     for (const [i, rectInfo] of renderBoxes.entries()) {
         ctx.beginPath();
         ctx.fillStyle = theme.textBubble;
-        ctx.fillText(data[i], rectInfo.x + bubblePad, y + h / 2 + getMiddleCenterBias(ctx, theme));
+        ctx.fillText(data[i], rectInfo.x + theme.bubblePadding, y + h / 2 + getMiddleCenterBias(ctx, theme));
     }
 }

--- a/packages/core/src/cells/drilldown-cell.tsx
+++ b/packages/core/src/cells/drilldown-cell.tsx
@@ -17,12 +17,17 @@ export const drilldownCellRenderer: InternalCellRenderer<DrilldownCell> = {
     needsHover: false,
     useLabel: false,
     needsHoverPosition: false,
-    measure: (ctx, cell, t) =>
+    measure: (ctx, cell, theme) =>
         cell.data.reduce(
-            (acc, data) => ctx.measureText(data.text).width + acc + 20 + (data.img !== undefined ? 18 : 0),
+            (acc, data) =>
+                ctx.measureText(data.text).width +
+                acc +
+                theme.bubblePadding * 2 +
+                theme.bubbleMargin +
+                (data.img !== undefined ? 18 : 0),
             0
         ) +
-        2 * t.cellHorizontalPadding -
+        2 * theme.cellHorizontalPadding -
         4,
     draw: a => drawDrilldownCell(a, a.cell.data),
     provideEditor: () => p => {
@@ -31,8 +36,6 @@ export const drilldownCellRenderer: InternalCellRenderer<DrilldownCell> = {
     },
     onPaste: () => undefined,
 };
-
-const itemMargin = 4;
 
 const drilldownCache: {
     [key: string]: HTMLCanvasElement;
@@ -133,8 +136,8 @@ function drawDrilldownCell(args: BaseDrawArgs, data: readonly DrilldownCellData[
     const y = Math.floor(rect.y + (rect.height - h) / 2);
 
     const bubbleHeight = h - 10;
-    const bubblePad = 8;
-    const bubbleMargin = itemMargin;
+    const bubblePad = theme.bubblePadding;
+    const bubbleMargin = theme.bubbleMargin;
     let renderX = x + theme.cellHorizontalPadding;
     const rounding = theme.roundingRadius ?? 6;
 

--- a/packages/core/src/common/styles.ts
+++ b/packages/core/src/common/styles.ts
@@ -27,6 +27,9 @@ export function makeCSSStyle(theme: Theme): Record<string, string> {
         "--gdg-bg-header-hovered": theme.bgHeaderHovered,
         "--gdg-bg-bubble": theme.bgBubble,
         "--gdg-bg-bubble-selected": theme.bgBubbleSelected,
+        "--gdg-bubble-height": `${theme.bubbleHeight}px`,
+        "--gdg-bubble-padding": `${theme.bubblePadding}px`,
+        "--gdg-bubble-margin": `${theme.bubbleMargin}px`,
         "--gdg-bg-search-result": theme.bgSearchResult,
         "--gdg-border-color": theme.borderColor,
         "--gdg-horizontal-border-color": theme.horizontalBorderColor ?? theme.borderColor,
@@ -72,6 +75,9 @@ export interface Theme {
     bgHeaderHovered: string;
     bgBubble: string;
     bgBubbleSelected: string;
+    bubbleHeight: number;
+    bubblePadding: number;
+    bubbleMargin: number;
     bgSearchResult: string;
     borderColor: string;
     drilldownBorder: string;
@@ -116,6 +122,9 @@ const dataEditorBaseTheme: Theme = {
 
     bgBubble: "#EDEDF3",
     bgBubbleSelected: "#FFFFFF",
+    bubbleHeight: 20,
+    bubblePadding: 6,
+    bubbleMargin: 4,
 
     bgSearchResult: "#fff9e3",
 

--- a/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/private/bubbles-overlay-editor-style.tsx
@@ -1,7 +1,5 @@
 import { styled } from "@linaria/react";
 
-const BUBBLE_HEIGHT = 20;
-
 export const BubblesOverlayEditorStyle = styled.div`
     display: flex;
     flex-wrap: wrap;
@@ -14,13 +12,13 @@ export const BubblesOverlayEditorStyle = styled.div`
         justify-content: center;
         align-items: center;
 
-        border-radius: var(--gdg-rounding-radius, ${BUBBLE_HEIGHT / 2}px);
+        border-radius: var(--gdg-rounding-radius, calc(var(--gdg-bubble-height) / 2));
 
-        padding: 0 8px;
-        height: ${BUBBLE_HEIGHT}px;
+        padding: 0 var(--gdg-bubble-padding);
+        height: var(--gdg-bubble-height);
         background-color: var(--gdg-bg-bubble);
         color: var(--gdg-text-dark);
-        margin: 2px;
+        margin: var(--gdg-bubble-margin);
         white-space: nowrap;
     }
 

--- a/packages/source/src/stories/use-data-source.stories.tsx
+++ b/packages/source/src/stories/use-data-source.stories.tsx
@@ -173,6 +173,9 @@ const testTheme: Theme = {
 
     bgBubble: "#EDEDF3",
     bgBubbleSelected: "#FFFFFF",
+    bubbleHeight: 20,
+    bubblePadding: 6,
+    bubbleMargin: 4,
 
     headerIconSize: 20,
     markerFontStyle: "13px",


### PR DESCRIPTION
Adds three new theming parameters `bubbleHeight`, `bubblePadding`, and `bubbleMargin` that allow configuring the bubble dimensions via the theme. Bubbles are used within multiple cells (e.g. bubble cell, multiselect cell, tags cell).