### PR TITLE
Use `pointerdown` instead of `mousedown` for outside click detection

### DIFF
--- a/packages/core/src/internal/click-outside-container/click-outside-container.tsx
+++ b/packages/core/src/internal/click-outside-container/click-outside-container.tsx
@@ -13,14 +13,14 @@ export default class ClickOutsideContainer extends React.PureComponent<Props> {
     public componentDidMount() {
         const eventTarget = this.props.customEventTarget ?? document;
         eventTarget.addEventListener("touchend", this.clickOutside, true);
-        eventTarget.addEventListener("mousedown", this.clickOutside, true);
+        eventTarget.addEventListener("pointerdown", this.clickOutside, true);
         eventTarget.addEventListener("contextmenu", this.clickOutside, true);
     }
 
     public componentWillUnmount() {
         const eventTarget = this.props.customEventTarget ?? document;
         eventTarget.removeEventListener("touchend", this.clickOutside, true);
-        eventTarget.removeEventListener("mousedown", this.clickOutside, true);
+        eventTarget.removeEventListener("pointerdown", this.clickOutside, true);
         eventTarget.removeEventListener("contextmenu", this.clickOutside, true);
     }
 

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -24,6 +24,7 @@ import {
     prep,
     sendClick,
     sendTouchClick,
+    sendPointerClick,
     getCellCenterPositionForDefaultGrid,
     Context,
     standardBeforeEach,
@@ -1585,7 +1586,7 @@ describe("data-editor", () => {
         const overlay = screen.getByDisplayValue("j");
         expect(document.body.contains(overlay)).toBe(true);
 
-        sendClick(canvas, {
+        sendPointerClick(canvas, {
             clientX: 300, // Col B
             clientY: 36 + 32 * 5 + 16, // Row 1 (0 indexed)
         });

--- a/packages/core/test/test-utils.tsx
+++ b/packages/core/test/test-utils.tsx
@@ -46,6 +46,14 @@ export function sendTouchClick(el: Element | Node | Document | Window, options?:
     });
 }
 
+export function sendPointerClick(el: Element | Node | Document | Window, options?: any): void {
+    fireEvent.pointerDown(el, options);
+
+    fireEvent.pointerUp(el, options);
+
+    fireEvent.click(el, options);
+}
+
 export const makeCell = (cell: Item): GridCell => {
     const [col, row] = cell;
     switch (col) {


### PR DESCRIPTION
This change replaces the `mousedown` event with `pointerdown` to improve compatibility across input devices. `pointerdown` is part of the Pointer Events API, which provides a unified event model for handling input from various pointing devices — including mouse, touch, and stylus.

Using `pointerdown` ensures better support for touchscreens and other non-mouse inputs.

**Reference:** [MDN – Pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)