### PR TITLE
Fix search bar disabled state

### DIFF
--- a/packages/cells/src/cells/links-cell.tsx
+++ b/packages/cells/src/cells/links-cell.tsx
@@ -218,12 +218,12 @@ const LinksCellEditorStyle = styled.div`
         padding: 6px 8px;
         cursor: pointer;
 
-        :hover,
-        :focus-visible {
+        &:hover,
+        &:focus-visible {
             background-color: var(--gdg-accent-light);
         }
 
-        :disabled {
+        &:disabled {
             opacity: 0.4;
             pointer-events: none;
         }
@@ -274,8 +274,8 @@ const LinksCellEditorStyle = styled.div`
 
             color: var(--gdg-text-medium);
 
-            :hover,
-            :focus-visible {
+            &:hover,
+            &:focus-visible {
                 background-color: var(--gdg-accent-light);
                 color: var(--gdg-text-dark);
             }

--- a/packages/core/src/internal/data-grid-search/data-grid-search-style.tsx
+++ b/packages/core/src/internal/data-grid-search/data-grid-search-style.tsx
@@ -61,7 +61,7 @@ export const SearchWrapper = styled.div`
         cursor: pointer;
         color: var(--gdg-text-medium);
 
-        :hover {
+        &:hover {
             color: var(--gdg-text-dark);
         }
 
@@ -70,7 +70,7 @@ export const SearchWrapper = styled.div`
             height: 16px;
         }
 
-        :disabled {
+        &:disabled {
             opacity: 0.4;
             pointer-events: none;
         }

--- a/packages/core/src/internal/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/internal/data-grid-search/data-grid-search.tsx
@@ -391,7 +391,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
 
         return (
             <SearchWrapper
-                className={showSearch ? "" : "out"}
+                className={"gdg-search-bar" + (showSearch ? "" : " out")}
                 onMouseDown={cancelEvent}
                 onMouseMove={cancelEvent}
                 onMouseUp={cancelEvent}


### PR DESCRIPTION
The new linaria version seems to require a `&` before css selectors like `:hover` or ":disabled`. This broke the disabled state of the buttons in the search input field. 