### PR TITLE
feat: onRowAppended and onColumnAppended

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export { useColumnSizer } from "./data-editor/use-column-sizer.js";
 export type { DataEditorRef } from "./data-editor/data-editor.js";
 export { DataEditorAll as DataEditor } from "./data-editor-all.js";
 export type { DataEditorAllProps as DataEditorProps } from "./data-editor-all.js";
+export { emptyGridSelection } from "./data-editor/data-editor.js";
 
 export { DataEditor as DataEditorCore } from "./data-editor/data-editor.js";
 export type { DataEditorProps as DataEditorCoreProps } from "./data-editor/data-editor.js";

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2962,6 +2962,42 @@ describe("data-editor", () => {
         expect(Element.prototype.scrollTo).toHaveBeenCalled();
     });
 
+    test("appendRow ref without trailing row", async () => {
+        const spy = vi.fn();
+        const ref = React.createRef<DataEditorRef>();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor {...basicProps} onRowAppended={spy} ref={ref} trailingRowOptions={undefined} />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        await act(async () => {
+            await ref.current?.appendRow(1, false);
+        });
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    test("appendColumn ref", async () => {
+        const spy = vi.fn();
+        const ref = React.createRef<DataEditorRef>();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor {...basicProps} onColumnAppended={spy} ref={ref} trailingRowOptions={undefined} />,
+            { wrapper: Context }
+        );
+        prep();
+
+        await act(async () => {
+            await ref.current?.appendColumn(0, false);
+        });
+
+        expect(spy).toHaveBeenCalled();
+    });
+
     test("Click row marker", async () => {
         const spy = vi.fn();
         vi.useFakeTimers();

--- a/packages/core/test/test-utils.tsx
+++ b/packages/core/test/test-utils.tsx
@@ -253,6 +253,7 @@ export const Context: React.FC = p => {
 export const EventedDataEditor = React.forwardRef<DataEditorRef, DataEditorProps>((p, ref) => {
     const [sel, setSel] = React.useState<GridSelection | undefined>(p.gridSelection);
     const [extraRows, setExtraRows] = React.useState(0);
+    const [extraCols, setExtraCols] = React.useState(0);
 
     const onGridSelectionChange = React.useCallback(
         (s: GridSelection) => {
@@ -267,14 +268,35 @@ export const EventedDataEditor = React.forwardRef<DataEditorRef, DataEditorProps
         void p.onRowAppended?.();
     }, [p]);
 
+    const onColumnAppended = React.useCallback(() => {
+        setExtraCols(cv => cv + 1);
+        void p.onColumnAppended?.();
+    }, [p]);
+
+    const columns = React.useMemo(() => p.columns.concat(Array.from({ length: extraCols }, (_, i) => ({ title: `Z${i}`, width: 50 }))), [p.columns, extraCols]);
+
+    const getCellContent = React.useCallback(
+        (cell: Item): GridCell => {
+            const [c] = cell;
+            if (c >= p.columns.length) {
+                return { kind: GridCellKind.Text, allowOverlay: true, data: "", displayData: "" };
+            }
+            return p.getCellContent(cell);
+        },
+        [p, p.getCellContent]
+    );
+
     return (
         <DataEditor
             {...p}
+            columns={columns}
+            getCellContent={getCellContent}
             ref={ref}
             gridSelection={sel}
             onGridSelectionChange={onGridSelectionChange}
             rows={p.rows + extraRows}
             onRowAppended={p.onRowAppended === undefined ? undefined : onRowAppened}
+            onColumnAppended={p.onColumnAppended === undefined ? undefined : onColumnAppended}
         />
     );
 });


### PR DESCRIPTION
- adds an `onColumnAppended` function
- allows for `onRowAppended` to be called without trailingRow when new selection would move it beyond row limit