### PR TITLE
fix: shift + enter key should move up in editor overlay

### DIFF
--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -128,10 +128,10 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                 event.stopPropagation();
                 event.preventDefault();
                 customMotion.current = [0, 0];
-            } else if (event.key === "Enter" && !event.shiftKey) {
+            } else if (event.key === "Enter") {
                 event.stopPropagation();
                 event.preventDefault();
-                customMotion.current = [0, 1];
+                customMotion.current = [0, event.shiftKey ? -1 : 1];
                 save = true;
             } else if (event.key === "Tab") {
                 event.stopPropagation();

--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -129,18 +129,21 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
                     event.stopPropagation();
                     event.preventDefault();
                     customMotion.current = [0, 0];
+                    break;
                 }
                 case "Enter": {
                     event.stopPropagation();
                     event.preventDefault();
                     customMotion.current = [0, event.shiftKey ? -1 : 1];
                     save = true;
+                    break;
                 }
                 case "Tab": {
                     event.stopPropagation();
                     event.preventDefault();
                     customMotion.current = [event.shiftKey ? -1 : 1, 0];
                     save = true;
+                    break;
                 }
             }
             window.setTimeout(() => {

--- a/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/internal/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -124,22 +124,25 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
     const onKeyDown = React.useCallback(
         async (event: React.KeyboardEvent) => {
             let save = false;
-            if (event.key === "Escape") {
-                event.stopPropagation();
-                event.preventDefault();
-                customMotion.current = [0, 0];
-            } else if (event.key === "Enter") {
-                event.stopPropagation();
-                event.preventDefault();
-                customMotion.current = [0, event.shiftKey ? -1 : 1];
-                save = true;
-            } else if (event.key === "Tab") {
-                event.stopPropagation();
-                event.preventDefault();
-                customMotion.current = [event.shiftKey ? -1 : 1, 0];
-                save = true;
+            switch (event.key) {
+                case "Escape": {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    customMotion.current = [0, 0];
+                }
+                case "Enter": {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    customMotion.current = [0, event.shiftKey ? -1 : 1];
+                    save = true;
+                }
+                case "Tab": {
+                    event.stopPropagation();
+                    event.preventDefault();
+                    customMotion.current = [event.shiftKey ? -1 : 1, 0];
+                    save = true;
+                }
             }
-
             window.setTimeout(() => {
                 if (!finished.current && customMotion.current !== undefined) {
                     onFinishEditing(save ? tempValue : undefined, customMotion.current);


### PR DESCRIPTION
To be consistent with Excel/Sheets + Tab key behavior: shift+Enter should move cell up (this PR), shift+Tab should move cell left (already implemented)

Seems like this was implemented previously but accidentally left out in a refactor?

https://github.com/glideapps/glide-data-grid/blame/e62d735c78d9057e31cd47d14ccd64536abf133b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx#L95-L112

https://github.com/glideapps/glide-data-grid/commit/e62d735c78d9057e31cd47d14ccd64536abf133b#diff-00eaebe06648bd396e82c6c0602a97edf0d2b3169790d287b9100fcb920e9637R99-R102