### PR TITLE
feat: draw grid lines for selected rows cols

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -499,7 +499,7 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
     readonly gridSelection?: GridSelection;
     /**
      * Emitted whenever the grid selection changes. Specifying
-     * this function will make the grid’s selection controlled, so
+     * this function will make the grid's selection controlled, so
      * so you will need to specify {@link gridSelection} as well. See
      * the "Controlled Selection" example for details.
      *
@@ -686,6 +686,22 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
      * Allows overriding the default portal element.
      */
     readonly portalElementRef?: React.RefObject<HTMLElement>;
+
+    /**
+     * When true (default) draws accent-coloured grid lines around selected columns in the header. Set to false to
+     * revert to the original behaviour where only the header background is accented.
+     * @group Style
+     * @defaultValue true
+     */
+    readonly columnSelectionGridLines?: boolean;
+
+    /**
+     * When true (default) draws accent-coloured grid lines around selected rows in the header. Set to false to
+     * revert to the original behaviour where only the header background is accented.
+     * @group Style
+     * @defaultValue true
+     */
+    readonly rowSelectionGridLines?: boolean;
 }
 
 type ScrollToFn = (
@@ -892,6 +908,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         scrollToActiveCell = true,
         drawFocusRing: drawFocusRingIn = true,
         portalElementRef,
+        columnSelectionGridLines = false,
+        rowSelectionGridLines = false,
     } = p;
 
     const drawFocusRing = drawFocusRingIn === "no-editor" ? overlay === undefined : drawFocusRingIn;
@@ -4264,6 +4282,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     gridRef={gridRef}
                     getCellRenderer={getCellRenderer}
                     resizeIndicator={resizeIndicator}
+                    columnSelectionGridLines={columnSelectionGridLines}
+                    rowSelectionGridLines={rowSelectionGridLines}
                 />
                 {renameGroupNode}
                 {overlay !== undefined && (

--- a/packages/core/src/docs/examples/selection-gridlines.stories.tsx
+++ b/packages/core/src/docs/examples/selection-gridlines.stories.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
+import {
+    BeautifulWrapper,
+    Description,
+    MoreInfo,
+    useMockDataGenerator,
+    defaultProps,
+} from "../../data-editor/stories/utils.js";
+import { SimpleThemeWrapper } from "../../stories/story-utils.js";
+
+export default {
+    title: "Glide-Data-Grid/DataEditor Demos",
+
+    decorators: [
+        (Story: React.ComponentType) => (
+            <SimpleThemeWrapper>
+                <BeautifulWrapper
+                    title="Column & Row Selection Grid Lines"
+                    description={
+                        <>
+                            <Description>
+                                Demonstrates the <code>columnSelectionGridLines</code> and
+                                <code>rowSelectionGridLines</code> props which control whether accent-coloured grid
+                                lines are drawn around selected columns and rows.
+                            </Description>
+                            <MoreInfo>
+                                Use the story controls to toggle the behaviours on and off.
+                            </MoreInfo>
+                        </>
+                    }>
+                    <Story />
+                </BeautifulWrapper>
+            </SimpleThemeWrapper>
+        ),
+    ],
+};
+
+interface SelectionGridLineProps {
+    columnSelectionGridLines: boolean;
+    rowSelectionGridLines: boolean;
+}
+
+export const SelectionGridLine: React.FC<SelectionGridLineProps> = p => {
+    const { cols, getCellContent } = useMockDataGenerator(10);
+    return (
+        <DataEditor
+            {...defaultProps}
+            getCellContent={getCellContent}
+            columns={cols}
+            rows={1000}
+            columnSelectionGridLines={p.columnSelectionGridLines}
+            rowSelectionGridLines={p.rowSelectionGridLines}
+            rowMarkers="both"
+        />
+    );
+};
+
+(SelectionGridLine as any).args = {
+    columnSelectionGridLines: true,
+    rowSelectionGridLines: true,
+};
+
+(SelectionGridLine as any).argTypes = {
+    columnSelectionGridLines: {
+        control: {
+            type: "boolean",
+        },
+    },
+    rowSelectionGridLines: {
+        control: {
+            type: "boolean",
+        },
+    },
+}; 

--- a/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
@@ -439,6 +439,8 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             dragAndDropState={dragOffset}
             onMouseMoveRaw={onMouseMove}
             ref={gridRef}
+            columnSelectionGridLines={p.columnSelectionGridLines}
+            rowSelectionGridLines={p.rowSelectionGridLines}
         />
     );
 };

--- a/packages/core/src/internal/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/internal/data-grid-search/data-grid-search.tsx
@@ -549,6 +549,8 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                 smoothScrollX={p.smoothScrollX}
                 smoothScrollY={p.smoothScrollY}
                 resizeIndicator={p.resizeIndicator}
+                columnSelectionGridLines={p.columnSelectionGridLines}
+                rowSelectionGridLines={p.rowSelectionGridLines}
             />
             {searchbox}
         </>

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -307,6 +307,18 @@ export interface DataGridProps {
      * @group Style
      */
     readonly resizeIndicator: "full" | "header" | "none" | undefined;
+
+    /** Enables accent-coloured grid lines for selected columns in the header.
+     * @defaultValue false
+     * @group Style
+     */
+    readonly columnSelectionGridLines?: boolean;
+
+    /** Enables accent-coloured grid lines for selected rows in the header.
+     * @defaultValue false
+     * @group Style
+     */
+    readonly rowSelectionGridLines?: boolean;
 }
 
 type DamageUpdateList = readonly {
@@ -320,7 +332,11 @@ export interface DataGridRef {
     focus: () => void;
     getBounds: (col?: number, row?: number) => Rectangle | undefined;
     damage: (cells: DamageUpdateList) => void;
-    getMouseArgsForPosition: (posX: number, posY: number, ev?: MouseEvent | TouchEvent) => GridMouseEventArgs | undefined;
+    getMouseArgsForPosition: (
+        posX: number,
+        posY: number,
+        ev?: MouseEvent | TouchEvent
+    ) => GridMouseEventArgs | undefined;
 }
 
 const getRowData = (cell: InnerGridCell, getCellRenderer?: GetCellRendererCallback) => {
@@ -396,6 +412,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         experimental,
         getCellRenderer,
         resizeIndicator = "full",
+        columnSelectionGridLines = false,
+        rowSelectionGridLines = false,
     } = p;
     const translateX = p.translateX ?? 0;
     const translateY = p.translateY ?? 0;
@@ -446,7 +464,10 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     }, [cellYOffset, cellXOffset, translateX, translateY, enableFirefoxRescaling, enableSafariRescaling]);
 
     const mappedColumns = useMappedColumns(columns, freezeColumns);
-    const stickyX = React.useMemo(() => fixedShadowX ? getStickyWidth(mappedColumns, dragAndDropState) : 0,[mappedColumns, dragAndDropState, fixedShadowX]);
+    const stickyX = React.useMemo(
+        () => (fixedShadowX ? getStickyWidth(mappedColumns, dragAndDropState) : 0),
+        [mappedColumns, dragAndDropState, fixedShadowX]
+    );
 
     // row: -1 === columnHeader, -2 === groupHeader
     const getBoundsForItem = React.useCallback(
@@ -829,6 +850,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             getCellRenderer,
             minimumCellWidth,
             resizeIndicator,
+            columnSelectionGridLines,
+            rowSelectionGridLines,
         };
 
         // This confusing bit of code due to some poor design. Long story short, the damage property is only used
@@ -895,6 +918,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         getCellRenderer,
         minimumCellWidth,
         resizeIndicator,
+        columnSelectionGridLines,
+        rowSelectionGridLines,
     ]);
 
     const lastDrawRef = React.useRef(draw);
@@ -951,15 +976,15 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     const cursor = isDragging
         ? "grabbing"
         : canDrag || isResizing
-        ? "col-resize"
-        : overFill || isFilling
-        ? "crosshair"
-        : cursorOverride !== undefined
-        ? cursorOverride
-        : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
-        ? "pointer"
-        : "default";
-    
+          ? "col-resize"
+          : overFill || isFilling
+            ? "crosshair"
+            : cursorOverride !== undefined
+              ? cursorOverride
+              : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
+                ? "pointer"
+                : "default";
+
     const style = React.useMemo(
         () => ({
             // width,
@@ -1716,7 +1741,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 }
 
                 return getMouseArgsForPosition(canvasRef.current, posX, posY, ev);
-            }
+            },
         }),
         [canvasRef, damage, getBoundsForItem]
     );

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -268,6 +268,17 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
         }
     }
     const drawHeaderTexture = () => {
+        
+        // Draw the bottom border of the header.
+        overlayCtx.beginPath();
+        overlayCtx.moveTo(0, overlayHeight - 0.5);
+        overlayCtx.lineTo(width, overlayHeight - 0.5);
+        overlayCtx.strokeStyle = blend(
+            theme.headerBottomBorderColor ?? theme.horizontalBorderColor ?? theme.borderColor,
+            theme.bgHeader
+        );
+        overlayCtx.stroke();
+
         drawGridHeaders(
             overlayCtx,
             effectiveCols,
@@ -308,17 +319,10 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
             freezeTrailingRows,
             rows,
             theme,
-            true
+            true,
+            arg.columnSelectionGridLines ? selection.columns : undefined,
+            arg.rowSelectionGridLines ? selection.rows : undefined
         );
-
-        overlayCtx.beginPath();
-        overlayCtx.moveTo(0, overlayHeight - 0.5);
-        overlayCtx.lineTo(width, overlayHeight - 0.5);
-        overlayCtx.strokeStyle = blend(
-            theme.headerBottomBorderColor ?? theme.horizontalBorderColor ?? theme.borderColor,
-            theme.bgHeader
-        );
-        overlayCtx.stroke();
 
         if (mustDrawHighlightRingsOnHeader) {
             drawHighlightRings(
@@ -716,7 +720,10 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
         verticalBorder,
         freezeTrailingRows,
         rows,
-        theme
+        theme,
+        false,
+        arg.columnSelectionGridLines ? selection.columns : undefined,
+        arg.rowSelectionGridLines ? selection.rows : undefined
     );
 
     highlightRedraw?.();

--- a/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
+++ b/packages/core/src/internal/data-grid/render/draw-grid-arg.ts
@@ -79,4 +79,6 @@ export interface DrawGridArg {
     readonly getCellRenderer: GetCellRendererCallback;
     readonly minimumCellWidth: number;
     readonly resizeIndicator: "full" | "header" | "none";
+    readonly columnSelectionGridLines: boolean;
+    readonly rowSelectionGridLines: boolean;
 }

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -339,6 +339,8 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 smoothScrollX={p.smoothScrollX}
                 smoothScrollY={p.smoothScrollY}
                 resizeIndicator={p.resizeIndicator}
+                columnSelectionGridLines={p.columnSelectionGridLines}
+                rowSelectionGridLines={p.rowSelectionGridLines}
             />
         </InfiniteScroller>
     );


### PR DESCRIPTION
Explicit borders for column and row selection to match Excel. Default false so users have to opt-in.

<img width="2042" height="1898" alt="CleanShot 2025-07-18 at 15 42 07@2x" src="https://github.com/user-attachments/assets/082000da-87d1-4b63-a36c-b0c45305e427" />
