### PR TITLE
fix(#1075): groupHeader action click event triggers twice

### DIFF
--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -711,3 +711,32 @@ export const SimpleEditable = () => {
         />
     );
 };
+
+export function GroupHeaderActionClick() {
+    const cols = [
+        { title: "Col1", width: 100, grow: 1, group: "Group"},
+    ];
+
+    const [clickCount, setClickCount] = useState(0);
+
+    return (
+        <div>
+            <h3>Click count: {clickCount}</h3>
+            <DataEditor
+                width={500}
+                height={500}
+                rows={0}
+                columns={cols}
+                getCellContent={() => ({ kind: GridCellKind.Text, data: '', displayData: '',allowOverlay: false })}
+                getGroupDetails={(name) => ({
+                  name,
+                  actions: [{
+                    icon: 'headerString',
+                    title: "Action",
+                    onClick: (e) => setClickCount(c => c + 1 ),
+                  }]
+                })}
+            />
+        </div>
+    );
+}

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -959,7 +959,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
         ? "pointer"
         : "default";
-    
+
     const style = React.useMemo(
         () => ({
             // width,
@@ -1219,11 +1219,6 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                         onHeaderIndicatorClick?.(col, headerBounds.bounds);
                     }
                 }
-            } else if (args.kind === groupHeaderKind) {
-                const action = groupHeaderActionForEvent(args.group, args.bounds, args.localEventX, args.localEventY);
-                if (action !== undefined && args.button === 0) {
-                    action.onClick(args);
-                }
             }
         },
         [
@@ -1232,7 +1227,6 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             isOverHeaderElement,
             onHeaderMenuClick,
             onHeaderIndicatorClick,
-            groupHeaderActionForEvent,
         ]
     );
     useEventListener("click", onClickImpl, windowEventTarget, false);


### PR DESCRIPTION
This PR fixes the #1075 issue. Basically, it removes the `click` event handler for the group header action click and the `pointerUp` event handles the callback function.