### PR TITLE
refactor: migrate from @storybook/addons to manager-api for Storybook 9

### DIFF
--- a/.storybook/addons/expand-all/register.mjs
+++ b/.storybook/addons/expand-all/register.mjs
@@ -1,5 +1,5 @@
-import { STORY_RENDERED } from "@storybook/core-events";
-import { addons } from "@storybook/addons";
+import { STORY_RENDERED, STORIES_EXPAND_ALL } from "@storybook/core-events";
+import { addons } from '@storybook/manager-api';
 
 let hasExpanded = false;
 
@@ -8,7 +8,7 @@ addons.register("expand-all", api => {
 
     emitter.on(STORY_RENDERED, () => {
         if (!hasExpanded) {
-            setTimeout(api.expandAll); // Calling on the next tick after storyRendered seems to work reliably.
+            setTimeout(api.emit(STORIES_EXPAND_ALL)); // Calling on the next tick after storyRendered seems to work reliably.
             hasExpanded = true;
         }
     });

--- a/.storybook/addons/expand-all/register.mjs
+++ b/.storybook/addons/expand-all/register.mjs
@@ -1,5 +1,5 @@
 import { STORY_RENDERED, STORIES_EXPAND_ALL } from "@storybook/core-events";
-import { addons } from '@storybook/manager-api';
+import { addons } from "@storybook/manager-api";
 
 let hasExpanded = false;
 
@@ -8,7 +8,7 @@ addons.register("expand-all", api => {
 
     emitter.on(STORY_RENDERED, () => {
         if (!hasExpanded) {
-            setTimeout(api.emit(STORIES_EXPAND_ALL)); // Calling on the next tick after storyRendered seems to work reliably.
+            setTimeout(() => api.emit(STORIES_EXPAND_ALL)); // Calling on the next tick after storyRendered seems to work reliably.
             hasExpanded = true;
         }
     });

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,5 +1,5 @@
-import { addons } from "@storybook/addons";
-import { create } from "@storybook/theming";
+import { addons } from "storybook/manager-api";
+import { create } from "storybook/theming";
 
 const glideTheme = create({
     base: "dark",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "@linaria/react": "^6.3.0",
                 "@storybook/addon-docs": "^9.0.11",
                 "@storybook/addon-links": "^9.0.11",
-                "@storybook/addons": "^7.6.20",
                 "@storybook/react-vite": "^9.0.11",
                 "@storybook/react-webpack5": "^9.0.11",
                 "@testing-library/dom": "^10.4.1",
@@ -2086,16 +2085,6 @@
             "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
             "license": "MIT"
         },
-        "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "react": ">=16.8.0"
-            }
-        },
         "node_modules/@emotion/utils": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
@@ -3646,22 +3635,6 @@
                 }
             }
         },
-        "node_modules/@storybook/addons": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.6.20.tgz",
-            "integrity": "sha512-ilXE2CrdI+Z/nJ4Ur5lTCk2yM/DzzLpAeUxIq1TDk5lsMcjYJIH5/pmpFMM/uCsvd8TLRCZsAAju1tbhzXVy1w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/manager-api": "7.6.20",
-                "@storybook/preview-api": "7.6.20",
-                "@storybook/types": "7.6.20"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            }
-        },
         "node_modules/@storybook/builder-vite": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.0.11.tgz",
@@ -3717,53 +3690,6 @@
                 }
             }
         },
-        "node_modules/@storybook/channels": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.20.tgz",
-            "integrity": "sha512-4hkgPSH6bJclB2OvLnkZOGZW1WptJs09mhQ6j6qLjgBZzL/ZdD6priWSd7iXrmPiN5TzUobkG4P4Dp7FjkiO7A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/global": "^5.0.0",
-                "qs": "^6.10.0",
-                "telejson": "^7.2.0",
-                "tiny-invariant": "^1.3.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            }
-        },
-        "node_modules/@storybook/client-logger": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.20.tgz",
-            "integrity": "sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/global": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            }
-        },
-        "node_modules/@storybook/core-events": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.20.tgz",
-            "integrity": "sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ts-dedent": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            }
-        },
         "node_modules/@storybook/core-webpack": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.0.11.tgz",
@@ -3779,16 +3705,6 @@
             },
             "peerDependencies": {
                 "storybook": "^9.0.11"
-            }
-        },
-        "node_modules/@storybook/csf": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
-            "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^2.19.0"
             }
         },
         "node_modules/@storybook/csf-plugin": {
@@ -3826,33 +3742,6 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
-            }
-        },
-        "node_modules/@storybook/manager-api": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.6.20.tgz",
-            "integrity": "sha512-gOB3m8hO3gBs9cBoN57T7jU0wNKDh+hi06gLcyd2awARQlAlywnLnr3s1WH5knih6Aq+OpvGBRVKkGLOkaouCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/channels": "7.6.20",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/csf": "^0.1.2",
-                "@storybook/global": "^5.0.0",
-                "@storybook/router": "7.6.20",
-                "@storybook/theming": "7.6.20",
-                "@storybook/types": "7.6.20",
-                "dequal": "^2.0.2",
-                "lodash": "^4.17.21",
-                "memoizerific": "^1.11.3",
-                "store2": "^2.14.2",
-                "telejson": "^7.2.0",
-                "ts-dedent": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
             }
         },
         "node_modules/@storybook/preset-react-webpack": {
@@ -4005,33 +3894,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@storybook/preview-api": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.20.tgz",
-            "integrity": "sha512-3ic2m9LDZEPwZk02wIhNc3n3rNvbi7VDKn52hDXfAxnL5EYm7yDICAkaWcVaTfblru2zn0EDJt7ROpthscTW5w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/channels": "7.6.20",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/csf": "^0.1.2",
-                "@storybook/global": "^5.0.0",
-                "@storybook/types": "7.6.20",
-                "@types/qs": "^6.9.5",
-                "dequal": "^2.0.2",
-                "lodash": "^4.17.21",
-                "memoizerific": "^1.11.3",
-                "qs": "^6.10.0",
-                "synchronous-promise": "^2.0.15",
-                "ts-dedent": "^2.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
             }
         },
         "node_modules/@storybook/react": {
@@ -4223,60 +4085,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@storybook/router": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.6.20.tgz",
-            "integrity": "sha512-mCzsWe6GrH47Xb1++foL98Zdek7uM5GhaSlrI7blWVohGa0qIUYbfJngqR4ZsrXmJeeEvqowobh+jlxg3IJh+w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/client-logger": "7.6.20",
-                "memoizerific": "^1.11.3",
-                "qs": "^6.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            }
-        },
-        "node_modules/@storybook/theming": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.6.20.tgz",
-            "integrity": "sha512-iT1pXHkSkd35JsCte6Qbanmprx5flkqtSHC6Gi6Umqoxlg9IjiLPmpHbaIXzoC06DSW93hPj5Zbi1lPlTvRC7Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/global": "^5.0.0",
-                "memoizerific": "^1.11.3"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@storybook/types": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.20.tgz",
-            "integrity": "sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@storybook/channels": "7.6.20",
-                "@types/babel__core": "^7.0.0",
-                "@types/express": "^4.7.0",
-                "file-system-cache": "2.3.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -4507,17 +4315,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "node_modules/@types/body-parser": {
-            "version": "1.19.6",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/chai": {
             "version": "4.3.11",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
@@ -4537,16 +4334,6 @@
             "version": "0.22.35",
             "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
             "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4589,32 +4376,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/express": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "node_modules/@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
         "node_modules/@types/hast": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -4628,13 +4389,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
             "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/http-errors": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true,
             "license": "MIT"
         },
@@ -4669,13 +4423,6 @@
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
             "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/mime": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true,
             "license": "MIT"
         },
@@ -4749,20 +4496,6 @@
                 "prosemirror-state": "*"
             }
         },
-        "node_modules/@types/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/range-parser": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/react": {
             "version": "18.3.23",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
@@ -4814,29 +4547,6 @@
             "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/send": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/mime": "^1",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/serve-static": {
-            "version": "1.15.8",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-            "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "*"
-            }
         },
         "node_modules/@types/unist": {
             "version": "2.0.6",
@@ -8987,17 +8697,6 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-        "node_modules/file-system-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
-            "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fs-extra": "11.1.1",
-                "ramda": "0.29.0"
-            }
-        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -9262,21 +8961,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.x"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/fs-monkey": {
@@ -11129,13 +10813,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/map-or-similar": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-            "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/markdown-it": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -11214,16 +10891,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
             "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-        },
-        "node_modules/memoizerific": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-            "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "map-or-similar": "^1.5.0"
-            }
         },
         "node_modules/meow": {
             "version": "12.1.1",
@@ -12410,17 +12077,6 @@
                 }
             ]
         },
-        "node_modules/ramda": {
-            "version": "0.29.0",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-            "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/ramda"
-            }
-        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13555,13 +13211,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/store2": {
-            "version": "2.14.4",
-            "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz",
-            "integrity": "sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/storybook": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.0.11.tgz",
@@ -13996,23 +13645,6 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
-        "node_modules/synchronous-promise": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-            "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/telejson": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
-            "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "memoizerific": "^1.11.3"
-            }
-        },
         "node_modules/terser": {
             "version": "5.43.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.0.tgz",
@@ -14416,19 +14048,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -17728,12 +17347,6 @@
             "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
             "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
         },
-        "@emotion/use-insertion-effect-with-fallbacks": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-            "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-            "dev": true
-        },
         "@emotion/utils": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
@@ -18776,17 +18389,6 @@
                 "@storybook/global": "^5.0.0"
             }
         },
-        "@storybook/addons": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-7.6.20.tgz",
-            "integrity": "sha512-ilXE2CrdI+Z/nJ4Ur5lTCk2yM/DzzLpAeUxIq1TDk5lsMcjYJIH5/pmpFMM/uCsvd8TLRCZsAAju1tbhzXVy1w==",
-            "dev": true,
-            "requires": {
-                "@storybook/manager-api": "7.6.20",
-                "@storybook/preview-api": "7.6.20",
-                "@storybook/types": "7.6.20"
-            }
-        },
         "@storybook/builder-vite": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.0.11.tgz",
@@ -18820,38 +18422,6 @@
                 "webpack-virtual-modules": "^0.6.0"
             }
         },
-        "@storybook/channels": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.20.tgz",
-            "integrity": "sha512-4hkgPSH6bJclB2OvLnkZOGZW1WptJs09mhQ6j6qLjgBZzL/ZdD6priWSd7iXrmPiN5TzUobkG4P4Dp7FjkiO7A==",
-            "dev": true,
-            "requires": {
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/global": "^5.0.0",
-                "qs": "^6.10.0",
-                "telejson": "^7.2.0",
-                "tiny-invariant": "^1.3.1"
-            }
-        },
-        "@storybook/client-logger": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.20.tgz",
-            "integrity": "sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==",
-            "dev": true,
-            "requires": {
-                "@storybook/global": "^5.0.0"
-            }
-        },
-        "@storybook/core-events": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.20.tgz",
-            "integrity": "sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==",
-            "dev": true,
-            "requires": {
-                "ts-dedent": "^2.0.0"
-            }
-        },
         "@storybook/core-webpack": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-9.0.11.tgz",
@@ -18859,15 +18429,6 @@
             "dev": true,
             "requires": {
                 "ts-dedent": "^2.0.0"
-            }
-        },
-        "@storybook/csf": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
-            "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^2.19.0"
             }
         },
         "@storybook/csf-plugin": {
@@ -18890,28 +18451,6 @@
             "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.4.0.tgz",
             "integrity": "sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==",
             "dev": true
-        },
-        "@storybook/manager-api": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-7.6.20.tgz",
-            "integrity": "sha512-gOB3m8hO3gBs9cBoN57T7jU0wNKDh+hi06gLcyd2awARQlAlywnLnr3s1WH5knih6Aq+OpvGBRVKkGLOkaouCQ==",
-            "dev": true,
-            "requires": {
-                "@storybook/channels": "7.6.20",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/csf": "^0.1.2",
-                "@storybook/global": "^5.0.0",
-                "@storybook/router": "7.6.20",
-                "@storybook/theming": "7.6.20",
-                "@storybook/types": "7.6.20",
-                "dequal": "^2.0.2",
-                "lodash": "^4.17.21",
-                "memoizerific": "^1.11.3",
-                "store2": "^2.14.2",
-                "telejson": "^7.2.0",
-                "ts-dedent": "^2.0.0"
-            }
         },
         "@storybook/preset-react-webpack": {
             "version": "9.0.11",
@@ -19001,28 +18540,6 @@
                         "min-indent": "^1.0.1"
                     }
                 }
-            }
-        },
-        "@storybook/preview-api": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.20.tgz",
-            "integrity": "sha512-3ic2m9LDZEPwZk02wIhNc3n3rNvbi7VDKn52hDXfAxnL5EYm7yDICAkaWcVaTfblru2zn0EDJt7ROpthscTW5w==",
-            "dev": true,
-            "requires": {
-                "@storybook/channels": "7.6.20",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/core-events": "7.6.20",
-                "@storybook/csf": "^0.1.2",
-                "@storybook/global": "^5.0.0",
-                "@storybook/types": "7.6.20",
-                "@types/qs": "^6.9.5",
-                "dequal": "^2.0.2",
-                "lodash": "^4.17.21",
-                "memoizerific": "^1.11.3",
-                "qs": "^6.10.0",
-                "synchronous-promise": "^2.0.15",
-                "ts-dedent": "^2.0.0",
-                "util-deprecate": "^1.0.2"
             }
         },
         "@storybook/react": {
@@ -19121,41 +18638,6 @@
                 "@storybook/builder-webpack5": "9.0.11",
                 "@storybook/preset-react-webpack": "9.0.11",
                 "@storybook/react": "9.0.11"
-            }
-        },
-        "@storybook/router": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/router/-/router-7.6.20.tgz",
-            "integrity": "sha512-mCzsWe6GrH47Xb1++foL98Zdek7uM5GhaSlrI7blWVohGa0qIUYbfJngqR4ZsrXmJeeEvqowobh+jlxg3IJh+w==",
-            "dev": true,
-            "requires": {
-                "@storybook/client-logger": "7.6.20",
-                "memoizerific": "^1.11.3",
-                "qs": "^6.10.0"
-            }
-        },
-        "@storybook/theming": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-7.6.20.tgz",
-            "integrity": "sha512-iT1pXHkSkd35JsCte6Qbanmprx5flkqtSHC6Gi6Umqoxlg9IjiLPmpHbaIXzoC06DSW93hPj5Zbi1lPlTvRC7Q==",
-            "dev": true,
-            "requires": {
-                "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
-                "@storybook/client-logger": "7.6.20",
-                "@storybook/global": "^5.0.0",
-                "memoizerific": "^1.11.3"
-            }
-        },
-        "@storybook/types": {
-            "version": "7.6.20",
-            "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.20.tgz",
-            "integrity": "sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==",
-            "dev": true,
-            "requires": {
-                "@storybook/channels": "7.6.20",
-                "@types/babel__core": "^7.0.0",
-                "@types/express": "^4.7.0",
-                "file-system-cache": "2.3.0"
             }
         },
         "@testing-library/dom": {
@@ -19309,16 +18791,6 @@
                 "@babel/types": "^7.20.7"
             }
         },
-        "@types/body-parser": {
-            "version": "1.19.6",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-            "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-            "dev": true,
-            "requires": {
-                "@types/connect": "*",
-                "@types/node": "*"
-            }
-        },
         "@types/chai": {
             "version": "4.3.11",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
@@ -19338,15 +18810,6 @@
             "version": "0.22.35",
             "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
             "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/connect": {
-            "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-            "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -19384,30 +18847,6 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
         },
-        "@types/express": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
-            "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
-            "dev": true,
-            "requires": {
-                "@types/body-parser": "*",
-                "@types/express-serve-static-core": "^4.17.33",
-                "@types/qs": "*",
-                "@types/serve-static": "*"
-            }
-        },
-        "@types/express-serve-static-core": {
-            "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
-            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/qs": "*",
-                "@types/range-parser": "*",
-                "@types/send": "*"
-            }
-        },
         "@types/hast": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -19421,12 +18860,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
             "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==",
-            "dev": true
-        },
-        "@types/http-errors": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-            "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
             "dev": true
         },
         "@types/istanbul-lib-coverage": {
@@ -19457,12 +18890,6 @@
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
             "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-            "dev": true
-        },
-        "@types/mime": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-            "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
         },
         "@types/node": {
@@ -19526,18 +18953,6 @@
                 "prosemirror-state": "*"
             }
         },
-        "@types/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-            "dev": true
-        },
-        "@types/range-parser": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-            "dev": true
-        },
         "@types/react": {
             "version": "18.3.23",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
@@ -19581,27 +18996,6 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
             "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
             "dev": true
-        },
-        "@types/send": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-            "dev": true,
-            "requires": {
-                "@types/mime": "^1",
-                "@types/node": "*"
-            }
-        },
-        "@types/serve-static": {
-            "version": "1.15.8",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-            "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-            "dev": true,
-            "requires": {
-                "@types/http-errors": "*",
-                "@types/node": "*",
-                "@types/send": "*"
-            }
         },
         "@types/unist": {
             "version": "2.0.6",
@@ -22503,16 +21897,6 @@
                 "flat-cache": "^3.0.4"
             }
         },
-        "file-system-cache": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
-            "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
-            "dev": true,
-            "requires": {
-                "fs-extra": "11.1.1",
-                "ramda": "0.29.0"
-            }
-        },
         "fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -22687,17 +22071,6 @@
             "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
             "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
             "dev": true
-        },
-        "fs-extra": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
         },
         "fs-monkey": {
             "version": "1.0.6",
@@ -23955,12 +23328,6 @@
                 "semver": "^5.6.0"
             }
         },
-        "map-or-similar": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
-            "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
-            "dev": true
-        },
         "markdown-it": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -24014,15 +23381,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
             "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-        },
-        "memoizerific": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
-            "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
-            "dev": true,
-            "requires": {
-                "map-or-similar": "^1.5.0"
-            }
         },
         "meow": {
             "version": "12.1.1",
@@ -24876,12 +24234,6 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
-        "ramda": {
-            "version": "0.29.0",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
-            "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
-            "dev": true
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -25724,12 +25076,6 @@
                 "internal-slot": "^1.1.0"
             }
         },
-        "store2": {
-            "version": "2.14.4",
-            "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz",
-            "integrity": "sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==",
-            "dev": true
-        },
         "storybook": {
             "version": "9.0.11",
             "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.0.11.tgz",
@@ -26015,21 +25361,6 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
-        "synchronous-promise": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-            "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
-            "dev": true
-        },
-        "telejson": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
-            "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
-            "dev": true,
-            "requires": {
-                "memoizerific": "^1.11.3"
-            }
-        },
         "terser": {
             "version": "5.43.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.0.tgz",
@@ -26310,12 +25641,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true
-        },
-        "type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "dev": true
         },
         "typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "@linaria/react": "^6.3.0",
         "@storybook/addon-docs": "^9.0.11",
         "@storybook/addon-links": "^9.0.11",
-        "@storybook/addons": "^7.6.20",
         "@storybook/react-vite": "^9.0.11",
         "@storybook/react-webpack5": "^9.0.11",
         "@testing-library/dom": "^10.4.1",

--- a/packages/core/src/data-editor/stories/data-editor-repros.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-repros.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { useState, useMemo } from "storybook/preview-api";
 import { BuilderThemeWrapper } from "../../stories/story-utils.js";
 import { type GridCell, GridCellKind, type Item } from "../../internal/data-grid/data-grid-types.js";
 import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
@@ -75,9 +76,9 @@ const filteringColumns = [
 ];
 
 export function FilterColumns() {
-    const [searchText, setSearchText] = React.useState("");
+    const [searchText, setSearchText] = useState("");
 
-    const cols = React.useMemo(() => {
+    const cols = useMemo(() => {
         if (searchText === "") {
             return filteringColumns;
         }

--- a/packages/core/src/data-editor/stories/data-editor-repros.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-repros.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 
-import { useState, useMemo } from "@storybook/addons";
 import { BuilderThemeWrapper } from "../../stories/story-utils.js";
 import { type GridCell, GridCellKind, type Item } from "../../internal/data-grid/data-grid-types.js";
 import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
@@ -76,9 +75,9 @@ const filteringColumns = [
 ];
 
 export function FilterColumns() {
-    const [searchText, setSearchText] = useState("");
+    const [searchText, setSearchText] = React.useState("");
 
-    const cols = useMemo(() => {
+    const cols = React.useMemo(() => {
         if (searchText === "") {
             return filteringColumns;
         }

--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import * as React from "react";
 
+import { useState, useCallback, useMemo } from "storybook/preview-api";
 import { BuilderThemeWrapper } from "../../stories/story-utils.js";
 import {
     CompactSelection,
@@ -151,9 +152,9 @@ function getDummyCols() {
 }
 
 export function Simplenotest() {
-    const [cols, setColumns] = React.useState(getDummyCols);
+    const [cols, setColumns] = useState(getDummyCols);
 
-    const onColumnResize = React.useCallback(
+    const onColumnResize = useCallback(
         (col: GridColumn, newSize: number) => {
             const index = cols.indexOf(col);
             const newCols = [...cols];
@@ -205,9 +206,9 @@ function getDummyRelationData([col, row]: Item): GridCell {
 }
 
 export function RelationColumn() {
-    const [cols, setColumns] = React.useState(getDummyRelationColumn);
+    const [cols, setColumns] = useState(getDummyRelationColumn);
 
-    const onColumnResize = React.useCallback(
+    const onColumnResize = useCallback(
         (col: GridColumn, newSize: number) => {
             const index = cols.indexOf(col);
             const newCols = [...cols];
@@ -254,9 +255,9 @@ export function Minimal() {
 }
 
 export function Smooth() {
-    const [cols, setCols] = React.useState(getDummyCols);
+    const [cols, setCols] = useState(getDummyCols);
 
-    const onColumnResize = React.useCallback(
+    const onColumnResize = useCallback(
         (column: GridColumn, newSize: number) => {
             const index = cols.indexOf(column);
             if (index !== -1) {
@@ -288,7 +289,7 @@ export function Smooth() {
 }
 
 export function ManualControl() {
-    const [gridSelection, setGridSelection] = React.useState<GridSelection | undefined>(undefined);
+    const [gridSelection, setGridSelection] = useState<GridSelection | undefined>(undefined);
 
     const cb = (newVal: GridSelection) => {
         if ((newVal.current?.cell[0] ?? 0) % 2 === 0) {
@@ -383,20 +384,20 @@ DynamicAddRemoveColumns.args = {
 };
 
 export function GridSelectionOutOfRangeNoColumns() {
-    const dummyCols = React.useMemo(
+    const dummyCols = useMemo(
         () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
         []
     );
 
-    const [selected, setSelected] = React.useState<GridSelection | undefined>({
+    const [selected, setSelected] = useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const [cols, setCols] = React.useState(dummyCols);
+    const [cols, setCols] = useState(dummyCols);
 
-    const onSelected = React.useCallback((newSel?: GridSelection) => {
+    const onSelected = useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -444,13 +445,13 @@ function getResizableColumns(sizeMap: ResizableColumnsSizeMap): GridColumn[] {
 }
 
 export function ResizableColumns() {
-    const [colSizes, setColSizes] = React.useState(getResizableColumnsInitSize);
+    const [colSizes, setColSizes] = useState(getResizableColumnsInitSize);
 
-    const cols = React.useMemo(() => {
+    const cols = useMemo(() => {
         return getResizableColumns(colSizes);
     }, [colSizes]);
 
-    const onColumnResize = React.useCallback((column: GridColumn, newSize: number) => {
+    const onColumnResize = useCallback((column: GridColumn, newSize: number) => {
         setColSizes(prevColSizes => {
             return {
                 ...prevColSizes,
@@ -474,20 +475,20 @@ export function ResizableColumns() {
 }
 
 export function GridSelectionOutOfRangeLessColumnsThanSelection() {
-    const dummyCols = React.useMemo(
+    const dummyCols = useMemo(
         () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
         []
     );
 
-    const [selected, setSelected] = React.useState<GridSelection | undefined>({
+    const [selected, setSelected] = useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const [cols, setCols] = React.useState(dummyCols);
+    const [cols, setCols] = useState(dummyCols);
 
-    const onSelected = React.useCallback((newSel?: GridSelection) => {
+    const onSelected = useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -511,17 +512,17 @@ export function GridSelectionOutOfRangeLessColumnsThanSelection() {
 }
 
 export function GridAddNewRows() {
-    const cols = React.useMemo(getDummyCols, []);
+    const cols = useMemo(getDummyCols, []);
 
-    const [rowsCount, setRowsCount] = React.useState(10);
+    const [rowsCount, setRowsCount] = useState(10);
 
-    const onRowAppended = React.useCallback(() => {
+    const onRowAppended = useCallback(() => {
         setRowsCount(r => r + 1);
     }, []);
 
-    const [selected, setSelected] = React.useState<GridSelection | undefined>(undefined);
+    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
 
-    const onSelected = React.useCallback((newSel?: GridSelection) => {
+    const onSelected = useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -539,11 +540,11 @@ export function GridAddNewRows() {
 }
 
 export function GridNoTrailingBlankRow() {
-    const cols = React.useMemo(getDummyCols, []);
+    const cols = useMemo(getDummyCols, []);
 
-    const [selected, setSelected] = React.useState<GridSelection | undefined>(undefined);
+    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
 
-    const onSelected = React.useCallback((newSel?: GridSelection) => {
+    const onSelected = useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -560,7 +561,7 @@ export function GridNoTrailingBlankRow() {
 }
 
 export function MarkdownEdits() {
-    const dummyCols: GridColumn[] = React.useMemo(() => {
+    const dummyCols: GridColumn[] = useMemo(() => {
         return [
             {
                 title: "MD short",
@@ -573,7 +574,7 @@ export function MarkdownEdits() {
         ];
     }, []);
 
-    const dummyCells = React.useCallback(([col, _row]: Item) => {
+    const dummyCells = useCallback(([col, _row]: Item) => {
         if (col === 0) {
             const editable: EditableGridCell = {
                 data: "text",
@@ -610,13 +611,13 @@ export function MarkdownEdits() {
         return editable;
     }, []);
 
-    const [selected, setSelected] = React.useState<GridSelection | undefined>({
+    const [selected, setSelected] = useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const onSelected = React.useCallback((newSel?: GridSelection) => {
+    const onSelected = useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -633,7 +634,7 @@ export function MarkdownEdits() {
 }
 
 export const CanEditBoolean = () => {
-    const [vals, setVals] = React.useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
+    const [vals, setVals] = useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
     return (
         <DataEditor
             width="100%"
@@ -670,7 +671,7 @@ export const CanEditBoolean = () => {
 };
 
 export const SimpleEditable = () => {
-    const [vals, setVals] = React.useState<[string, string][]>(() => {
+    const [vals, setVals] = useState<[string, string][]>(() => {
         const result: [string, string][] = [];
         for (let i = 0; i < 2000; i++) {
             result.push(["Edit", "Me"]);
@@ -716,7 +717,7 @@ export function GroupHeaderActionClick() {
         { title: "Col1", width: 100, grow: 1, group: "Group"},
     ];
 
-    const [clickCount, setClickCount] = React.useState(0);
+    const [clickCount, setClickCount] = useState(0);
 
     return (
         <div>

--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 import * as React from "react";
 
-import { useState, useCallback, useMemo } from "@storybook/addons";
 import { BuilderThemeWrapper } from "../../stories/story-utils.js";
 import {
     CompactSelection,
@@ -152,9 +151,9 @@ function getDummyCols() {
 }
 
 export function Simplenotest() {
-    const [cols, setColumns] = useState(getDummyCols);
+    const [cols, setColumns] = React.useState(getDummyCols);
 
-    const onColumnResize = useCallback(
+    const onColumnResize = React.useCallback(
         (col: GridColumn, newSize: number) => {
             const index = cols.indexOf(col);
             const newCols = [...cols];
@@ -206,9 +205,9 @@ function getDummyRelationData([col, row]: Item): GridCell {
 }
 
 export function RelationColumn() {
-    const [cols, setColumns] = useState(getDummyRelationColumn);
+    const [cols, setColumns] = React.useState(getDummyRelationColumn);
 
-    const onColumnResize = useCallback(
+    const onColumnResize = React.useCallback(
         (col: GridColumn, newSize: number) => {
             const index = cols.indexOf(col);
             const newCols = [...cols];
@@ -255,9 +254,9 @@ export function Minimal() {
 }
 
 export function Smooth() {
-    const [cols, setCols] = useState(getDummyCols);
+    const [cols, setCols] = React.useState(getDummyCols);
 
-    const onColumnResize = useCallback(
+    const onColumnResize = React.useCallback(
         (column: GridColumn, newSize: number) => {
             const index = cols.indexOf(column);
             if (index !== -1) {
@@ -289,7 +288,7 @@ export function Smooth() {
 }
 
 export function ManualControl() {
-    const [gridSelection, setGridSelection] = useState<GridSelection | undefined>(undefined);
+    const [gridSelection, setGridSelection] = React.useState<GridSelection | undefined>(undefined);
 
     const cb = (newVal: GridSelection) => {
         if ((newVal.current?.cell[0] ?? 0) % 2 === 0) {
@@ -384,20 +383,20 @@ DynamicAddRemoveColumns.args = {
 };
 
 export function GridSelectionOutOfRangeNoColumns() {
-    const dummyCols = useMemo(
+    const dummyCols = React.useMemo(
         () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
         []
     );
 
-    const [selected, setSelected] = useState<GridSelection | undefined>({
+    const [selected, setSelected] = React.useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const [cols, setCols] = useState(dummyCols);
+    const [cols, setCols] = React.useState(dummyCols);
 
-    const onSelected = useCallback((newSel?: GridSelection) => {
+    const onSelected = React.useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -445,13 +444,13 @@ function getResizableColumns(sizeMap: ResizableColumnsSizeMap): GridColumn[] {
 }
 
 export function ResizableColumns() {
-    const [colSizes, setColSizes] = useState(getResizableColumnsInitSize);
+    const [colSizes, setColSizes] = React.useState(getResizableColumnsInitSize);
 
-    const cols = useMemo(() => {
+    const cols = React.useMemo(() => {
         return getResizableColumns(colSizes);
     }, [colSizes]);
 
-    const onColumnResize = useCallback((column: GridColumn, newSize: number) => {
+    const onColumnResize = React.useCallback((column: GridColumn, newSize: number) => {
         setColSizes(prevColSizes => {
             return {
                 ...prevColSizes,
@@ -475,20 +474,20 @@ export function ResizableColumns() {
 }
 
 export function GridSelectionOutOfRangeLessColumnsThanSelection() {
-    const dummyCols = useMemo(
+    const dummyCols = React.useMemo(
         () => getDummyCols().map(v => ({ ...v, width: 300, title: "Making column smaller used to crash!" })),
         []
     );
 
-    const [selected, setSelected] = useState<GridSelection | undefined>({
+    const [selected, setSelected] = React.useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const [cols, setCols] = useState(dummyCols);
+    const [cols, setCols] = React.useState(dummyCols);
 
-    const onSelected = useCallback((newSel?: GridSelection) => {
+    const onSelected = React.useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -512,17 +511,17 @@ export function GridSelectionOutOfRangeLessColumnsThanSelection() {
 }
 
 export function GridAddNewRows() {
-    const cols = useMemo(getDummyCols, []);
+    const cols = React.useMemo(getDummyCols, []);
 
-    const [rowsCount, setRowsCount] = useState(10);
+    const [rowsCount, setRowsCount] = React.useState(10);
 
-    const onRowAppended = useCallback(() => {
+    const onRowAppended = React.useCallback(() => {
         setRowsCount(r => r + 1);
     }, []);
 
-    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
+    const [selected, setSelected] = React.useState<GridSelection | undefined>(undefined);
 
-    const onSelected = useCallback((newSel?: GridSelection) => {
+    const onSelected = React.useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -540,11 +539,11 @@ export function GridAddNewRows() {
 }
 
 export function GridNoTrailingBlankRow() {
-    const cols = useMemo(getDummyCols, []);
+    const cols = React.useMemo(getDummyCols, []);
 
-    const [selected, setSelected] = useState<GridSelection | undefined>(undefined);
+    const [selected, setSelected] = React.useState<GridSelection | undefined>(undefined);
 
-    const onSelected = useCallback((newSel?: GridSelection) => {
+    const onSelected = React.useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -561,7 +560,7 @@ export function GridNoTrailingBlankRow() {
 }
 
 export function MarkdownEdits() {
-    const dummyCols: GridColumn[] = useMemo(() => {
+    const dummyCols: GridColumn[] = React.useMemo(() => {
         return [
             {
                 title: "MD short",
@@ -574,7 +573,7 @@ export function MarkdownEdits() {
         ];
     }, []);
 
-    const dummyCells = useCallback(([col, _row]: Item) => {
+    const dummyCells = React.useCallback(([col, _row]: Item) => {
         if (col === 0) {
             const editable: EditableGridCell = {
                 data: "text",
@@ -611,13 +610,13 @@ export function MarkdownEdits() {
         return editable;
     }, []);
 
-    const [selected, setSelected] = useState<GridSelection | undefined>({
+    const [selected, setSelected] = React.useState<GridSelection | undefined>({
         current: { cell: [2, 8], range: { width: 1, height: 1, x: 2, y: 8 }, rangeStack: [] },
         columns: CompactSelection.empty(),
         rows: CompactSelection.empty(),
     });
 
-    const onSelected = useCallback((newSel?: GridSelection) => {
+    const onSelected = React.useCallback((newSel?: GridSelection) => {
         setSelected(newSel);
     }, []);
 
@@ -634,7 +633,7 @@ export function MarkdownEdits() {
 }
 
 export const CanEditBoolean = () => {
-    const [vals, setVals] = useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
+    const [vals, setVals] = React.useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
     return (
         <DataEditor
             width="100%"
@@ -671,7 +670,7 @@ export const CanEditBoolean = () => {
 };
 
 export const SimpleEditable = () => {
-    const [vals, setVals] = useState<[string, string][]>(() => {
+    const [vals, setVals] = React.useState<[string, string][]>(() => {
         const result: [string, string][] = [];
         for (let i = 0; i < 2000; i++) {
             result.push(["Edit", "Me"]);
@@ -717,7 +716,7 @@ export function GroupHeaderActionClick() {
         { title: "Col1", width: 100, grow: 1, group: "Group"},
     ];
 
-    const [clickCount, setClickCount] = useState(0);
+    const [clickCount, setClickCount] = React.useState(0);
 
     return (
         <div>


### PR DESCRIPTION
Replaced `@storybook/addons` with `storybook/manager-api` and `storybook/preview-api` according to migration guide of storybook to use storybook 9.

[Storybook 8:](https://storybook.js.org/docs/releases/migration-guide-from-older-version)
`@storybook/addons` split into `@storybook/manager-api` and `@storybook/preview-api`

[Storybook 9:](https://storybook.js.org/docs/releases/migration-guide)
`@storybook/manager-api` and `@storybook/preview-api` import as `storybook/manager-api` and `storybook/preview-api`

