### PR TITLE
bug: getSkipPoint never returns number type value

### DIFF
--- a/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
@@ -7,6 +7,7 @@ export function getSkipPoint(drawRegions: readonly Rectangle[]): number | undefi
     for (const dr of drawRegions) {
         drawRegionsLowestY = Math.min(drawRegionsLowestY ?? dr.y, dr.y);
     }
+    return drawRegionsLowestY;
 }
 
 export type WalkRowsCallback = (


### PR DESCRIPTION
It seems `getSkipPoint` suppose to return either `number` or `undefined` but it's actually never returns `number`