### PR TITLE
refactor: improve typing for useRowGrouping

### DIFF
--- a/packages/core/src/data-editor/row-grouping-api.ts
+++ b/packages/core/src/data-editor/row-grouping-api.ts
@@ -34,7 +34,16 @@ export function useRowGrouping(options: RowGroupingOptions | undefined, rows: nu
         getRowGroupingForPath,
         updateRowGroupingByPath,
         mapper: React.useCallback<UseRowGroupingResult["mapper"]>(
-            (itemOrRow) => mapRowIndexToPath(itemOrRow, flattenedRowGroups),
+            (itemOrRow: number | Item) => {
+                if (typeof itemOrRow === "number") {
+                    return mapRowIndexToPath(itemOrRow, flattenedRowGroups);
+                }
+                const r = mapRowIndexToPath(itemOrRow[1], flattenedRowGroups);
+                return {
+                    ...r,
+                    originalIndex: [itemOrRow[0], r.originalIndex],
+                } as RowGroupingMapperResult<Item>;
+            },
             [flattenedRowGroups]
         ),
     };

--- a/packages/core/src/data-editor/row-grouping-api.ts
+++ b/packages/core/src/data-editor/row-grouping-api.ts
@@ -14,7 +14,6 @@ export interface RowGroupingMapperResult<T> {
 
 export type RowGroupingMapper = (itemOrRow: number | Item) => RowGroupingMapperResult<Item | number>;
 
-
 export interface UseRowGroupingResult {
     readonly mapper: RowGroupingMapper;
     readonly updateRowGroupingByPath: (
@@ -34,17 +33,8 @@ export function useRowGrouping(options: RowGroupingOptions | undefined, rows: nu
     return {
         getRowGroupingForPath,
         updateRowGroupingByPath,
-        mapper: React.useCallback<RowGroupingMapper>(
-             (itemOrRow) => {
-                if (typeof itemOrRow === "number") {
-                    return mapRowIndexToPath(itemOrRow, flattenedRowGroups);
-                }
-                const r = mapRowIndexToPath(itemOrRow[1], flattenedRowGroups);
-                return {
-                    ...r,
-                    originalIndex: [itemOrRow[0], r.originalIndex],
-                } as RowGroupingMapperResult<Item>;
-            },
+        mapper: React.useCallback<UseRowGroupingResult["mapper"]>(
+            (itemOrRow) => mapRowIndexToPath(itemOrRow, flattenedRowGroups),
             [flattenedRowGroups]
         ),
     };

--- a/packages/core/src/data-editor/row-grouping-api.ts
+++ b/packages/core/src/data-editor/row-grouping-api.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import type { Item } from "../internal/data-grid/data-grid-types.js";
-import { flattenRowGroups, mapRowIndexToPath, type RowGroup, type RowGroupingOptions } from "./row-grouping.js";
-
+import { flattenRowGroups, mapRowIndexToPath, type FlattenedRowGroup, type RowGroup, type RowGroupingOptions } from "./row-grouping.js";
 
 export interface RowGroupingMapperResult<T> {
     path: readonly number[];
@@ -13,6 +12,20 @@ export interface RowGroupingMapperResult<T> {
 }
 
 export type RowGroupingMapper = (itemOrRow: number | Item) => RowGroupingMapperResult<Item | number>;
+
+export function rowGroupingMapper(itemOrRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[] | undefined): RowGroupingMapperResult<number>;
+export function rowGroupingMapper(itemOrRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[] | undefined): RowGroupingMapperResult<Item>;
+export function rowGroupingMapper(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[] | undefined): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item>;
+export function rowGroupingMapper(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[] | undefined): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
+    if (typeof itemOrRow === "number") {
+        return mapRowIndexToPath(itemOrRow, flattenedRowGroups);
+    }
+    const r = mapRowIndexToPath(itemOrRow[1], flattenedRowGroups);
+    return {
+        ...r,
+        originalIndex: [itemOrRow[0], r.originalIndex],
+    } as RowGroupingMapperResult<Item>;
+};
 
 export interface UseRowGroupingResult {
     readonly mapper: RowGroupingMapper;
@@ -34,21 +47,11 @@ export function useRowGrouping(options: RowGroupingOptions | undefined, rows: nu
         getRowGroupingForPath,
         updateRowGroupingByPath,
         mapper: React.useCallback<UseRowGroupingResult["mapper"]>(
-            (itemOrRow: number | Item) => {
-                if (typeof itemOrRow === "number") {
-                    return mapRowIndexToPath(itemOrRow, flattenedRowGroups);
-                }
-                const r = mapRowIndexToPath(itemOrRow[1], flattenedRowGroups);
-                return {
-                    ...r,
-                    originalIndex: [itemOrRow[0], r.originalIndex],
-                } as RowGroupingMapperResult<Item>;
-            },
+            (itemOrRow: number | Item) => rowGroupingMapper(itemOrRow, flattenedRowGroups),
             [flattenedRowGroups]
         ),
     };
 }
-
 
 export function updateRowGroupingByPath(
     rowGrouping: readonly RowGroup[],

--- a/packages/core/src/data-editor/row-grouping.ts
+++ b/packages/core/src/data-editor/row-grouping.ts
@@ -4,7 +4,6 @@ import type { DataEditorProps } from "./data-editor.js";
 import type { DataGridProps } from "../internal/data-grid/data-grid.js";
 import { whenDefined } from "../common/utils.js";
 import type { RowGroupingMapperResult } from "./row-grouping-api.js";
-import type { Item } from "../internal/data-grid/data-grid-types.js";
 
 type Mutable<T> = {
     -readonly [K in keyof T]: T[K];
@@ -181,13 +180,7 @@ export function flattenRowGroups(rowGrouping: RowGroupingOptions, rows: number):
 
 
 // grid relative index to path and other details
-export function mapRowIndexToPath(itemOrRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
-export function mapRowIndexToPath(itemOrRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
-export function mapRowIndexToPath(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item>;
-export function mapRowIndexToPath(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
-    const row = typeof itemOrRow === "number" ? itemOrRow : itemOrRow[1];
-    const originalIndex = typeof itemOrRow === "number" ? row : itemOrRow[0];
-
+export function mapRowIndexToPath(row: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> {
     if (flattenedRowGroups === undefined || flattenRowGroups.length === 0)
         return {
             path: [row],
@@ -229,7 +222,7 @@ export function mapRowIndexToPath(itemOrRow: number | Item, flattenedRowGroups?:
     // I suppose to eliminate this, you can treat this case as part of the overflow of the last group.
     return {
         path: [row],
-        originalIndex,
+        originalIndex: row,
         isGroupHeader: false,
         groupIndex: row,
         contentIndex: row,

--- a/packages/core/src/data-editor/row-grouping.ts
+++ b/packages/core/src/data-editor/row-grouping.ts
@@ -181,9 +181,10 @@ export function flattenRowGroups(rowGrouping: RowGroupingOptions, rows: number):
 
 
 // grid relative index to path and other details
-function mapRowIndexToPathFn(itemOrRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
-function mapRowIndexToPathFn(itemOrRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
-function mapRowIndexToPathFn(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
+export function mapRowIndexToPath(itemOrRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
+export function mapRowIndexToPath(itemOrRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
+export function mapRowIndexToPath(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item>;
+export function mapRowIndexToPath(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
     const row = typeof itemOrRow === "number" ? itemOrRow : itemOrRow[1];
     const originalIndex = typeof itemOrRow === "number" ? row : itemOrRow[0];
 
@@ -235,8 +236,6 @@ function mapRowIndexToPathFn(itemOrRow: number | Item, flattenedRowGroups?: read
         groupRows: -1,
     };
 }
-
-export const mapRowIndexToPath = (itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]) => typeof itemOrRow === "number" ? mapRowIndexToPathFn(itemOrRow, flattenedRowGroups) : mapRowIndexToPathFn(itemOrRow, flattenedRowGroups);
 
 export interface UseRowGroupingInnerResult {
     readonly rows: number;

--- a/packages/core/src/data-editor/row-grouping.ts
+++ b/packages/core/src/data-editor/row-grouping.ts
@@ -3,6 +3,7 @@ import type { Theme } from "../common/styles.js";
 import type { DataEditorProps } from "./data-editor.js";
 import type { DataGridProps } from "../internal/data-grid/data-grid.js";
 import { whenDefined } from "../common/utils.js";
+import type { RowGroupingMapperResult } from "./row-grouping-api.js";
 
 type Mutable<T> = {
     -readonly [K in keyof T]: T[K];
@@ -177,17 +178,8 @@ export function flattenRowGroups(rowGrouping: RowGroupingOptions, rows: number):
         });
 }
 
-export interface MapResult {
-    readonly path: readonly number[];
-    readonly isGroupHeader: boolean;
-    readonly originalIndex: number;
-    readonly groupIndex: number;
-    readonly groupRows: number;
-    readonly contentIndex: number;
-}
-
 // grid relative index to path and other details
-export function mapRowIndexToPath(row: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): MapResult {
+export function mapRowIndexToPath(row: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> {
     if (flattenedRowGroups === undefined || flattenRowGroups.length === 0)
         return {
             path: [row],

--- a/packages/core/src/data-editor/row-grouping.ts
+++ b/packages/core/src/data-editor/row-grouping.ts
@@ -4,6 +4,7 @@ import type { DataEditorProps } from "./data-editor.js";
 import type { DataGridProps } from "../internal/data-grid/data-grid.js";
 import { whenDefined } from "../common/utils.js";
 import type { RowGroupingMapperResult } from "./row-grouping-api.js";
+import type { Item } from "../internal/data-grid/data-grid-types.js";
 
 type Mutable<T> = {
     -readonly [K in keyof T]: T[K];
@@ -178,8 +179,14 @@ export function flattenRowGroups(rowGrouping: RowGroupingOptions, rows: number):
         });
 }
 
+
 // grid relative index to path and other details
-export function mapRowIndexToPath(row: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> {
+function mapRowIndexToPathFn(itemRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
+function mapRowIndexToPathFn(itemRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
+function mapRowIndexToPathFn(itemRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
+    const row = typeof itemRow === "number" ? itemRow : itemRow[1];
+    const originalIndex = typeof itemRow === "number" ? row : itemRow[0];
+
     if (flattenedRowGroups === undefined || flattenRowGroups.length === 0)
         return {
             path: [row],
@@ -221,13 +228,15 @@ export function mapRowIndexToPath(row: number, flattenedRowGroups?: readonly Fla
     // I suppose to eliminate this, you can treat this case as part of the overflow of the last group.
     return {
         path: [row],
-        originalIndex: row,
+        originalIndex,
         isGroupHeader: false,
         groupIndex: row,
         contentIndex: row,
         groupRows: -1,
     };
 }
+
+export const mapRowIndexToPath = (itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]) => typeof itemOrRow === "number" ? mapRowIndexToPathFn(itemOrRow, flattenedRowGroups) : mapRowIndexToPathFn(itemOrRow, flattenedRowGroups);
 
 export interface UseRowGroupingInnerResult {
     readonly rows: number;

--- a/packages/core/src/data-editor/row-grouping.ts
+++ b/packages/core/src/data-editor/row-grouping.ts
@@ -181,11 +181,11 @@ export function flattenRowGroups(rowGrouping: RowGroupingOptions, rows: number):
 
 
 // grid relative index to path and other details
-function mapRowIndexToPathFn(itemRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
-function mapRowIndexToPathFn(itemRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
-function mapRowIndexToPathFn(itemRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
-    const row = typeof itemRow === "number" ? itemRow : itemRow[1];
-    const originalIndex = typeof itemRow === "number" ? row : itemRow[0];
+function mapRowIndexToPathFn(itemOrRow: number, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number>;
+function mapRowIndexToPathFn(itemOrRow: Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<Item>;
+function mapRowIndexToPathFn(itemOrRow: number | Item, flattenedRowGroups?: readonly FlattenedRowGroup[]): RowGroupingMapperResult<number> | RowGroupingMapperResult<Item> {
+    const row = typeof itemOrRow === "number" ? itemOrRow : itemOrRow[1];
+    const originalIndex = typeof itemOrRow === "number" ? row : itemOrRow[0];
 
     if (flattenedRowGroups === undefined || flattenRowGroups.length === 0)
         return {


### PR DESCRIPTION
Introduced rowGroupingMapper with type overload to make sure when itemOrRow is type of `number` it should return `RowGroupingMapperResult<number>` and when type if `Item` it should return `RowGroupingMapperResult<Item>`