### PR TITLE
Fix homepage links in cells and source packages

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -34,7 +34,7 @@
         "url": "git+https://github.com/glideapps/glide-data-grid.git",
         "directory": "packages/cells"
     },
-    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
+    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/packages/cells",
     "author": "Glide",
     "license": "MIT",
     "keywords": [

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -26,7 +26,7 @@
         "url": "git+https://github.com/glideapps/glide-data-grid.git",
         "directory": "packages/source"
     },
-    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
+    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/packages/source",
     "author": "Glide",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
Seems like the folder structure has changed, so the links gave 404 errors