### PR TITLE
allows frozen columns to be editable on keydown

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3516,7 +3516,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             ) {
                 if (
                     (!showTrailingBlankRow || row !== rows) &&
-                    (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width)
+                    (vr.y > row || row > vr.y + vr.height) &&
+                    col >= freezeColumns &&
+                    (vr.x > col || col > vr.x + vr.width)
                 ) {
                     return;
                 }

--- a/packages/core/src/docs/examples/freeze-columns.stories.tsx
+++ b/packages/core/src/docs/examples/freeze-columns.stories.tsx
@@ -20,7 +20,8 @@ export default {
                     description={
                         <Description>
                             Columns at the start of your grid can be frozen in place by settings{" "}
-                            <PropName>freezeColumns</PropName> to a number greater than 0.
+                            <PropName>freezeColumns</PropName> to a number greater than 0. Cells are editable - try
+                            clicking on them!
                         </Description>
                     }>
                     <Story />
@@ -30,8 +31,8 @@ export default {
     ],
 };
 
-export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
-    const { cols, getCellContent } = useMockDataGenerator(100);
+export const FreezeColumns: React.FC<{ freezeColumns: number }> = p => {
+    const { cols, getCellContent, setCellValue } = useMockDataGenerator(100, false);
 
     return (
         <DataEditor
@@ -42,6 +43,7 @@ export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
             columns={cols}
             verticalBorder={false}
             rows={1000}
+            onCellEdited={setCellValue}
         />
     );
 };
@@ -56,4 +58,33 @@ export const FreezeColumns: React.VFC<any> = (p: { freezeColumns: number }) => {
 };
 (FreezeColumns as any).args = {
     freezeColumns: 1,
+};
+
+export const EditableFreezeColumns: React.FC<{ freezeColumns: number }> = p => {
+    const { cols, getCellContent, setCellValue } = useMockDataGenerator(100, false);
+
+    return (
+        <DataEditor
+            {...defaultProps}
+            rowMarkers="both"
+            freezeColumns={p.freezeColumns}
+            getCellContent={getCellContent}
+            columns={cols}
+            verticalBorder={false}
+            rows={1000}
+            onCellEdited={setCellValue}
+        />
+    );
+};
+(EditableFreezeColumns as any).argTypes = {
+    freezeColumns: {
+        control: {
+            type: "range",
+            min: 0,
+            max: 10,
+        },
+    },
+};
+(EditableFreezeColumns as any).args = {
+    freezeColumns: 2,
 };


### PR DESCRIPTION
Issue: When you have frozen columns in the data grid and try to edit a cell by typing a character, the edit portal doesn't open for frozen columns (except sometimes the first one).
Expected Behavior: Frozen columns should always be editable by typing, regardless of scroll position.
Actual Behavior: Frozen columns beyond the first one weren't editable when typing characters.

