### PR TITLE
Add support for configuring color for range-cell

### DIFF
--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -312,6 +312,7 @@ export const CustomCells: React.VFC = () => {
                                 step: 1,
                                 label: `${Math.round(v * 100)}%`,
                                 measureLabel: "100%",
+                                color: row % 2 === 0 ? "#77c4c4" : undefined,
                             },
                         };
                         return d;

--- a/packages/cells/src/cells/range-cell.tsx
+++ b/packages/cells/src/cells/range-cell.tsx
@@ -31,6 +31,8 @@ interface RangeCellProps {
     readonly step: number;
     readonly label?: string;
     readonly measureLabel?: string;
+    /* The color of the range, fallback to theme.accentColor. */
+    readonly color?: string;
 }
 
 export type RangeCell = CustomCell<RangeCellProps>;
@@ -50,7 +52,7 @@ const renderer: CustomRenderer<RangeCell> = {
     isMatch: (c): c is RangeCell => (c.data as any).kind === "range-cell",
     draw: (args, cell) => {
         const { ctx, theme, rect } = args;
-        const { min, max, value, label, measureLabel } = cell.data;
+        const { min, max, value, label, measureLabel, color } = cell.data;
 
         const x = rect.x + theme.cellHorizontalPadding;
         const yMid = rect.y + rect.height / 2;
@@ -75,8 +77,9 @@ const renderer: CustomRenderer<RangeCell> = {
         if (rangeWidth >= rangeHeight) {
             const gradient = ctx.createLinearGradient(x, yMid, x + rangeWidth, yMid);
 
-            gradient.addColorStop(0, theme.accentColor);
-            gradient.addColorStop(fillRatio, theme.accentColor);
+            const fillColor = color ?? theme.accentColor;
+            gradient.addColorStop(0, fillColor);
+            gradient.addColorStop(fillRatio, fillColor);
             gradient.addColorStop(fillRatio, theme.bgBubble);
             gradient.addColorStop(1, theme.bgBubble);
 


### PR DESCRIPTION
Adds support for configuring individual colors for range-cells similar to sparkline-cell:

<img width="161" height="185" alt="image" src="https://github.com/user-attachments/assets/578671a8-e46c-4254-9332-a741700b72e2" />
