### PR TITLE
fix: enable autoscroll during row reordering

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -4311,6 +4311,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     gridRef={gridRef}
                     getCellRenderer={getCellRenderer}
                     resizeIndicator={resizeIndicator}
+                    setScrollDir={setScrollDir}
                 />
                 {renameGroupNode}
                 {overlay !== undefined && (

--- a/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
@@ -76,6 +76,7 @@ export interface DataGridDndProps extends Props {
     readonly maxColumnWidth: number;
     readonly minColumnWidth: number;
     readonly lockColumns: number;
+    readonly setScrollDir: (dir: GridMouseEventArgs["scrollEdge"] | undefined) => void;
 }
 
 // Dear Past Jason,
@@ -118,6 +119,7 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
         onItemHovered,
         onDragStart,
         canvasRef,
+        setScrollDir
     } = p;
 
     const canResize = (onColumnResize ?? onColumnResizeEnd ?? onColumnResizeStart) !== undefined;
@@ -134,12 +136,13 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             } else if (dragRow !== undefined && row !== undefined) {
                 setDragRowActive(true);
                 setDropRow(Math.max(0, row));
+                setScrollDir(args.scrollEdge);
                 // Don't emit onItemHovered if resizing or reordering a column or row.
             } else if (resizeCol === undefined && !dragColActive && !dragRowActive) {
                 onItemHovered?.(args);
             }
         },
-        [dragCol, dragRow, dropCol, onItemHovered, lockColumns, resizeCol, dragColActive, dragRowActive]
+        [dragCol, dragRow, dropCol, onItemHovered, lockColumns, resizeCol, dragColActive, dragRowActive, setScrollDir]
     );
 
     const canDragCol = onColumnMoved !== undefined;

--- a/packages/core/src/internal/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/internal/data-grid-search/data-grid-search.tsx
@@ -567,6 +567,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                 smoothScrollX={p.smoothScrollX}
                 smoothScrollY={p.smoothScrollY}
                 resizeIndicator={p.resizeIndicator}
+                setScrollDir={p.setScrollDir}
             />
             {searchbox}
         </>

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -339,6 +339,7 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 smoothScrollX={p.smoothScrollX}
                 smoothScrollY={p.smoothScrollY}
                 resizeIndicator={p.resizeIndicator}
+                setScrollDir={p.setScrollDir}
             />
         </InfiniteScroller>
     );


### PR DESCRIPTION
#### Enables autoscroll when dragging rows near viewport edges during row reordering operations. 
#### Connects the row drag operation to the existing autoscroll mechanism by updating scroll direction state during row hover events.

Fixes #1143

https://github.com/user-attachments/assets/fa737919-d626-4ed0-90c0-913916e7d480

