### PR TITLE
feat(core): add headerCursor override for column headers

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -262,6 +262,7 @@ interface BaseGridColumn {
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;
+    readonly headerCursor?: CSSProperties["cursor"];
     readonly hasMenu?: boolean;
     readonly style?: "normal" | "highlight";
     readonly grow?: number;
@@ -293,6 +294,7 @@ export type GridColumn = SizedGridColumn | AutoGridColumn;
 | group              | The name of the group the column belongs to                                                                                              |
 | icon               | The icon the column belongs to. The icon must be either one of the predefined icons or an icon passed to the `headerIcons` prop          |
 | overlayIcon        | An icon which is painted on top offset bottom right of the `icon`. Must be a predefined icon or an icon passed to the `headerIcons` prop |
+| headerCursor       | Optional cursor to use when hovering the column header. Falls back to pointer/default based on interaction if not provided.            |
 | hasMenu            | Enables/disables the menu dropdown indicator. If not enabled, `onHeaderMenuClick` will not be emitted.                                   |
 | style              | Makes the column use the highlighted theming from the `Theme`. `themeOverride` can be used to perform the same effect.                   |
 | grow               | When set to a number > 0 the column will grow to consume extra available space according to the weight of its grow property.             |

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -150,6 +150,7 @@ export interface BaseGridColumn {
     readonly group?: string;
     readonly icon?: GridColumnIcon | string;
     readonly overlayIcon?: GridColumnIcon | string;
+    readonly headerCursor?: CSSProperties["cursor"];
     readonly menuIcon?: GridColumnMenuIcon | string;
     readonly indicatorIcon?: GridColumnIcon | string;
     readonly hasMenu?: boolean;

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -971,6 +971,9 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         cursorOverride = cell.cursor;
     }
     const canDrag = hoveredOnEdge ?? false;
+    const headerCursorOverride =
+        headerHovered && hCol !== undefined ? mappedColumns[hCol]?.headerCursor : undefined;
+
     const cursor = isDragging
         ? "grabbing"
         : canDrag || isResizing
@@ -979,7 +982,9 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             ? "crosshair"
             : cursorOverride !== undefined
               ? cursorOverride
-              : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
+              : headerCursorOverride !== undefined
+                ? headerCursorOverride
+                : headerHovered || clickableInnerCellHovered || editableBoolHovered || groupHeaderHovered
                 ? "pointer"
                 : "default";
 

--- a/packages/core/src/internal/data-grid/render/data-grid-lib.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-lib.ts
@@ -31,6 +31,7 @@ export function useMappedColumns(
                     grow: c.grow,
                     hasMenu: c.hasMenu,
                     icon: c.icon,
+                    headerCursor: c.headerCursor,
                     id: c.id,
                     menuIcon: c.menuIcon,
                     overlayIcon: c.overlayIcon,


### PR DESCRIPTION
This PR adds a per-column header cursor override.

Why
Allows consumers to customize cursor feedback on header hover (e.g., `help`, `grab`, `context-menu`) without affecting cell cursors.

Notes
- No behavioral change unless `headerCursor` is provided.
- Lints pass locally.

Example
```ts
const columns = [
  { title: "Name", width: 200, headerCursor: "help" },
  { title: "Status", id: "status", headerCursor: "grab" },
];
```