### PR TITLE
feat: add onKeyDown event on custom cell renderer

### DIFF
--- a/packages/core/src/cells/cell-types.ts
+++ b/packages/core/src/cells/cell-types.ts
@@ -91,6 +91,22 @@ interface BaseCellRenderer<T extends InnerGridCell> {
         } & BaseGridMouseEventArgs
     ) => void;
     readonly onDelete?: (cell: T) => T | undefined;
+
+    readonly onKeyDown?: (
+        args: {
+            readonly cell: T;
+            readonly bounds: Rectangle;
+            readonly location: Item;
+            readonly theme: FullTheme;
+            readonly preventDefault: () => void;
+            readonly key: string;
+            readonly keyCode: number;
+            readonly altKey: boolean;
+            readonly shiftKey: boolean;
+            readonly ctrlKey: boolean;
+            readonly metaKey: boolean;
+        }
+    ) => T | undefined;
 }
 
 /** @category Renderers */

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3507,6 +3507,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     let prevented = false;
                     const newVal = renderer.onKeyDown({
                         ...event,
+                        bounds: event.bounds,
                         cell,
                         location: [col - rowMarkerOffset, row],
                         theme: themeForCell(cell, event.location),

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3506,19 +3506,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 if (renderer?.onKeyDown !== undefined) {
                     let prevented = false;
                     const newVal = renderer.onKeyDown({
+                        ...event,
                         cell,
-                        bounds: event.bounds,
                         location: [col - rowMarkerOffset, row],
                         theme: themeForCell(cell, event.location),
                         preventDefault: () => {
                             prevented = true;
                         },
-                        key: event.key,
-                        keyCode: event.keyCode,
-                        altKey: event.altKey,
-                        shiftKey: event.shiftKey,
-                        ctrlKey: event.ctrlKey,
-                        metaKey: event.metaKey,
                     });
 
                     if (prevented) {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3525,6 +3525,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         newVal !== undefined &&
                         !isInnerOnlyCell(newVal) &&
                         isEditableGridCell(newVal) &&
+                        !isInnerOnlyCell(cell) &&
                         isEditableGridCell(cell) &&
                         cell.readonly !== true
                     ) {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3521,7 +3521,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         event.stopPropagation();
                     }
 
-                    if (newVal !== undefined && !isInnerOnlyCell(newVal) && isEditableGridCell(newVal) && newVal.readonly !== true) {
+                    if (
+                        newVal !== undefined &&
+                        !isInnerOnlyCell(newVal) &&
+                        isEditableGridCell(newVal) &&
+                        isEditableGridCell(cell) &&
+                        cell.readonly !== true
+                    ) {
                         mangledOnCellsEdited([{ location: event.location, value: newVal }]);
                         gridRef.current?.damage([{ cell: event.location }]);
                     }

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -5065,8 +5065,8 @@ describe("data-editor", () => {
         const mockStopPropagation = vi.fn();
 
         const evt = createEvent.keyDown(canvas, { key: 'ArrowDown', code: 'ArrowDown' });
-        evt.preventDefault = mockPreventDefault
-        evt.stopPropagation = mockStopPropagation
+        evt.preventDefault = mockPreventDefault;
+        evt.stopPropagation = mockStopPropagation;
         fireEvent(canvas, evt);
 
         // Renderer's onKeyDown should have been called
@@ -5405,8 +5405,8 @@ describe("data-editor", () => {
         const mockStopPropagation = vi.fn();
 
         const evt = createEvent.keyDown(canvas, { key: 'x' });
-        evt.preventDefault = mockPreventDefault
-        evt.stopPropagation = mockStopPropagation
+        evt.preventDefault = mockPreventDefault;
+        evt.stopPropagation = mockStopPropagation;
         fireEvent(canvas, evt);
 
         act(() => {
@@ -5417,5 +5417,64 @@ describe("data-editor", () => {
         expect(mockOnCellsEdited).toHaveBeenCalled();
         expect(mockPreventDefault).toHaveBeenCalled();
         expect(mockStopPropagation).toHaveBeenCalled();
+    });
+
+    test("Cell renderer onKeyDown location should be adjusted when row markers are enabled", async () => {
+        const mockOnKeyDown = vi.fn();
+        const customRenderer = {
+            kind: GridCellKind.Custom,
+            isMatch: (c: GridCell): c is CustomCell => c.kind === GridCellKind.Custom,
+            draw: () => true,
+            onKeyDown: mockOnKeyDown,
+        };
+
+        vi.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                rowMarkers="both"
+                customRenderers={[customRenderer]}
+                getCellContent={() => {
+                    return {
+                        kind: GridCellKind.Custom,
+                        allowOverlay: false,
+                        copyData: "",
+                        data: { value: "custom-cell" },
+                    };
+                }}
+            />,
+            { wrapper: Context }
+        );
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        // Click on cell at visual position [2, 1] (which is col B when row markers are enabled)
+        // With row markers, column 0 is the row marker, so visual col 2 is data col 1
+        sendClick(canvas, {
+            clientX: 320, // Adjusted for row marker width
+            clientY: 36 + 32 + 16, // Row 1
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        // Press a key
+        fireEvent.keyDown(canvas, {
+            key: "a",
+            keyCode: 65,
+        });
+
+        // The location should be adjusted: internal grid col 2 minus rowMarkerOffset (1) = [1, 1]
+        expect(mockOnKeyDown).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cell: expect.objectContaining({
+                    kind: GridCellKind.Custom,
+                }),
+                location: [1, 1], // Adjusted for row marker offset
+                key: "a",
+            })
+        );
     });
 });


### PR DESCRIPTION
### Summary
This PR adds support for cell renderers to handle keyboard events directly, allowing custom cells to intercept and respond to key presses before default grid behavior.

### Motivation
Currently, cell renderers can respond to mouse events (onClick, onSelect) and deletion (onDelete), but have no way to handle keyboard input. This limitation prevents common use cases such as:
- Custom keyboard shortcuts for specific cell types
- In-cell interactions without opening the overlay editor
- Preventing certain keys from triggering default grid navigation

This feature bridges that gap by providing renderers with keyboard event access, similar to existing mouse event handlers.

### Implementation Details
- Added onKeyDown method to cell renderer interface that receives keyboard event details (key, modifiers) along with cell context (data, bounds, location, theme)
- Integrated keyboard handler into the data editor's event flow, calling the renderer's onKeyDown when a cell has focus and no overlay is open
- Handler can optionally return a modified cell value to trigger immediate save, or call preventDefault() to block default keybindings
- Includes proper validation of returned values (checking for read-only status, editable types) and coordinate system transformations

### Breaking Changes
None

Fixes: #1157
