### PR TITLE
fix: add keyboard support for context menu

### DIFF
--- a/packages/core/src/data-editor/data-editor-keybindings.ts
+++ b/packages/core/src/data-editor/data-editor-keybindings.ts
@@ -67,6 +67,8 @@ export interface ConfigurableKeybinds {
     readonly selectAll: Keybind;
     readonly selectRow: Keybind;
     readonly selectColumn: Keybind;
+
+    readonly contextMenu: Keybind;
 }
 
 export type Keybinds = ConfigurableKeybinds & ForcedKeybinds & Partial<BackCompatKeybinds>;
@@ -118,6 +120,7 @@ export const keybindingDefaults: Keybinds = {
     selectGrowRight: true,
     selectGrowDown: true,
     selectGrowLeft: true,
+    contextMenu: true,
 };
 
 function realizeKeybind(keybind: Keybind, defaultVal: string): string {
@@ -174,6 +177,7 @@ export function realizeKeybinds(keybinds: Keybinds): RealizedKeybinds {
         selectToLastCell: realizeKeybind(keybinds.selectToLastCell, "primary+shift+End"),
         selectToLastColumn: realizeKeybind(keybinds.selectToLastColumn, "primary+shift+ArrowRight"),
         selectToLastRow: realizeKeybind(keybinds.selectToLastRow, "primary+shift+ArrowDown"),
+        contextMenu: realizeKeybind(keybinds.contextMenu, "shift+F10"),
     };
 }
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3263,7 +3263,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
                 }
             }
-            console.log({event, details}, "keys.contextMenu:", keys.contextMenu, overlayOpen )
 
             if (details.didMatch) {
                 cancel();
@@ -3363,6 +3362,34 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     col = Number.MAX_SAFE_INTEGER;
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
+                } else if (isHotkey(keys.contextMenu, event, details) &&
+                  bounds !== undefined &&
+                  event.location !== undefined
+                ) {
+                  const {
+                    location,
+                    ctrlKey,
+                    metaKey,
+                    shiftKey,
+                  } = event;
+
+                  onContextMenu(
+                    {
+                      kind: "cell",
+                      isFillHandle: false,
+                      isTouch: false,
+                      isEdge: false,
+                      button: 0,
+                      scrollEdge: [0, 0],
+                      localEventX: bounds.width / 2,
+                      localEventY: bounds.height / 2,
+                      location,
+                      bounds,
+                      ctrlKey,
+                      metaKey,
+                      shiftKey,
+                      buttons: 0
+                    }, cancel)
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
                   if (isHotkey(keys.selectGrowDown, event, details)) {
                     adjustSelection([0, 1]);
@@ -3380,27 +3407,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     adjustSelection([2, 0]);
                   } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
                     adjustSelection([-2, 0]);
-                  } else if (isHotkey(keys.contextMenu, event, details) &&
-                    event.bounds !== undefined &&
-                    event.location !== undefined
-                  ) {
-                    onContextMenu(
-                      {
-                        kind: "cell",
-                        isFillHandle: false,
-                        isTouch: false,
-                        isEdge: false,
-                        button: 0,
-                        scrollEdge: [0, 0],
-                        localEventX: event.bounds.width / 2,
-                        localEventY: event.bounds.height / 2,
-                        location: [col, row],
-                        bounds: event.bounds,
-                        ctrlKey: false,
-                        metaKey: false,
-                        shiftKey: true,
-                        buttons: 0
-                      }, cancel)
                   }
                 }
                 cancelOnlyOnMove = details.didMatch;

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3185,6 +3185,42 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const overlayOpen = overlay !== undefined;
 
+    const onContextMenu = React.useCallback(
+      (args: GridMouseEventArgs, preventDefault: () => void) => {
+        const adjustedCol = args.location[0] - rowMarkerOffset;
+        if (args.kind === "header") {
+          onHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
+        }
+
+        if (args.kind === groupHeaderKind) {
+          if (adjustedCol < 0) {
+            return;
+          }
+          onGroupHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
+        }
+
+        if (args.kind === "cell") {
+          const [col, row] = args.location;
+          onCellContextMenu?.([adjustedCol, row], {
+            ...args,
+            preventDefault,
+          });
+
+          if (!gridSelectionHasItem(gridSelection, args.location)) {
+            updateSelectedCell(col, row, false, false);
+          }
+        }
+      },
+      [
+        gridSelection,
+        onCellContextMenu,
+        onGroupHeaderContextMenu,
+        onHeaderContextMenu,
+        rowMarkerOffset,
+        updateSelectedCell,
+      ]
+    );
+
     const handleFixedKeybindings = React.useCallback(
         (event: GridKeyEventArgs): boolean => {
             const cancel = () => {
@@ -3480,6 +3516,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             return didMatch;
         },
         [
+            onContextMenu,
             rowGroupingNavBehavior,
             overlayOpen,
             gridSelection,
@@ -3570,42 +3607,6 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             showTrailingBlankRow,
             onCellActivated,
             reselect,
-        ]
-    );
-
-    const onContextMenu = React.useCallback(
-        (args: GridMouseEventArgs, preventDefault: () => void) => {
-            const adjustedCol = args.location[0] - rowMarkerOffset;
-            if (args.kind === "header") {
-                onHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
-            }
-
-            if (args.kind === groupHeaderKind) {
-                if (adjustedCol < 0) {
-                    return;
-                }
-                onGroupHeaderContextMenu?.(adjustedCol, { ...args, preventDefault });
-            }
-
-            if (args.kind === "cell") {
-                const [col, row] = args.location;
-                onCellContextMenu?.([adjustedCol, row], {
-                    ...args,
-                    preventDefault,
-                });
-
-                if (!gridSelectionHasItem(gridSelection, args.location)) {
-                    updateSelectedCell(col, row, false, false);
-                }
-            }
-        },
-        [
-            gridSelection,
-            onCellContextMenu,
-            onGroupHeaderContextMenu,
-            onHeaderContextMenu,
-            rowMarkerOffset,
-            updateSelectedCell,
         ]
     );
 

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3362,52 +3362,53 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     col = Number.MAX_SAFE_INTEGER;
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
-                } else if (isHotkey(keys.contextMenu, event, details) &&
-                  bounds !== undefined &&
-                  event.location !== undefined
+                } else if (
+                    isHotkey(keys.contextMenu, event, details) &&
+                    bounds !== undefined &&
+                    event.location !== undefined
                 ) {
-                  const {
-                    location,
-                    ctrlKey,
-                    metaKey,
-                    shiftKey,
-                  } = event;
-
-                  onContextMenu(
-                    {
-                      kind: "cell",
-                      isFillHandle: false,
-                      isTouch: false,
-                      isEdge: false,
-                      button: 0,
-                      scrollEdge: [0, 0],
-                      localEventX: bounds.width / 2,
-                      localEventY: bounds.height / 2,
+                    const {
                       location,
-                      bounds,
                       ctrlKey,
                       metaKey,
                       shiftKey,
-                      buttons: 0
-                    }, cancel)
+                    } = event;
+
+                    onContextMenu(
+                      {
+                        kind: "cell",
+                        isFillHandle: false,
+                        isTouch: false,
+                        isEdge: false,
+                        button: 0,
+                        scrollEdge: [0, 0],
+                        localEventX: bounds.width / 2,
+                        localEventY: bounds.height / 2,
+                        location,
+                        bounds,
+                        ctrlKey,
+                        metaKey,
+                        shiftKey,
+                        buttons: 0
+                      }, cancel)
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
-                  if (isHotkey(keys.selectGrowDown, event, details)) {
-                    adjustSelection([0, 1]);
-                  } else if (isHotkey(keys.selectGrowUp, event, details)) {
-                    adjustSelection([0, -1]);
-                  } else if (isHotkey(keys.selectGrowRight, event, details)) {
-                    adjustSelection([1, 0]);
-                  } else if (isHotkey(keys.selectGrowLeft, event, details)) {
-                    adjustSelection([-1, 0]);
-                  } else if (isHotkey(keys.selectToLastRow, event, details)) {
-                    adjustSelection([0, 2]);
-                  } else if (isHotkey(keys.selectToFirstRow, event, details)) {
-                    adjustSelection([0, -2]);
-                  } else if (isHotkey(keys.selectToLastColumn, event, details)) {
-                    adjustSelection([2, 0]);
-                  } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
-                    adjustSelection([-2, 0]);
-                  }
+                    if (isHotkey(keys.selectGrowDown, event, details)) {
+                        adjustSelection([0, 1]);
+                    } else if (isHotkey(keys.selectGrowUp, event, details)) {
+                        adjustSelection([0, -1]);
+                    } else if (isHotkey(keys.selectGrowRight, event, details)) {
+                        adjustSelection([1, 0]);
+                    } else if (isHotkey(keys.selectGrowLeft, event, details)) {
+                        adjustSelection([-1, 0]);
+                    } else if (isHotkey(keys.selectToLastRow, event, details)) {
+                        adjustSelection([0, 2]);
+                    } else if (isHotkey(keys.selectToFirstRow, event, details)) {
+                        adjustSelection([0, -2]);
+                    } else if (isHotkey(keys.selectToLastColumn, event, details)) {
+                        adjustSelection([2, 0]);
+                    } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
+                        adjustSelection([-2, 0]);
+                    }
                 }
                 cancelOnlyOnMove = details.didMatch;
             } else {

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3263,6 +3263,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
                 }
             }
+            console.log({event, details}, "keys.contextMenu:", keys.contextMenu, overlayOpen )
 
             if (details.didMatch) {
                 cancel();
@@ -3363,23 +3364,44 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 } else if (isHotkey(keys.goToFirstColumn, event, details)) {
                     col = Number.MIN_SAFE_INTEGER;
                 } else if (rangeSelect === "rect" || rangeSelect === "multi-rect") {
-                    if (isHotkey(keys.selectGrowDown, event, details)) {
-                        adjustSelection([0, 1]);
-                    } else if (isHotkey(keys.selectGrowUp, event, details)) {
-                        adjustSelection([0, -1]);
-                    } else if (isHotkey(keys.selectGrowRight, event, details)) {
-                        adjustSelection([1, 0]);
-                    } else if (isHotkey(keys.selectGrowLeft, event, details)) {
-                        adjustSelection([-1, 0]);
-                    } else if (isHotkey(keys.selectToLastRow, event, details)) {
-                        adjustSelection([0, 2]);
-                    } else if (isHotkey(keys.selectToFirstRow, event, details)) {
-                        adjustSelection([0, -2]);
-                    } else if (isHotkey(keys.selectToLastColumn, event, details)) {
-                        adjustSelection([2, 0]);
-                    } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
-                        adjustSelection([-2, 0]);
-                    }
+                  if (isHotkey(keys.selectGrowDown, event, details)) {
+                    adjustSelection([0, 1]);
+                  } else if (isHotkey(keys.selectGrowUp, event, details)) {
+                    adjustSelection([0, -1]);
+                  } else if (isHotkey(keys.selectGrowRight, event, details)) {
+                    adjustSelection([1, 0]);
+                  } else if (isHotkey(keys.selectGrowLeft, event, details)) {
+                    adjustSelection([-1, 0]);
+                  } else if (isHotkey(keys.selectToLastRow, event, details)) {
+                    adjustSelection([0, 2]);
+                  } else if (isHotkey(keys.selectToFirstRow, event, details)) {
+                    adjustSelection([0, -2]);
+                  } else if (isHotkey(keys.selectToLastColumn, event, details)) {
+                    adjustSelection([2, 0]);
+                  } else if (isHotkey(keys.selectToFirstColumn, event, details)) {
+                    adjustSelection([-2, 0]);
+                  } else if (isHotkey(keys.contextMenu, event, details) &&
+                    event.bounds !== undefined &&
+                    event.location !== undefined
+                  ) {
+                    onContextMenu(
+                      {
+                        kind: "cell",
+                        isFillHandle: false,
+                        isTouch: false,
+                        isEdge: false,
+                        button: 0,
+                        scrollEdge: [0, 0],
+                        localEventX: event.bounds.width / 2,
+                        localEventY: event.bounds.height / 2,
+                        location: [col, row],
+                        bounds: event.bounds,
+                        ctrlKey: false,
+                        metaKey: false,
+                        shiftKey: true,
+                        buttons: 0
+                      }, cancel)
+                  }
                 }
                 cancelOnlyOnMove = details.didMatch;
             } else {

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -1263,6 +1263,25 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     );
     useEventListener("contextmenu", onContextMenuImpl, eventTargetRef?.current ?? null, false);
 
+    const onContextMenuWithKeyboardImpl = React.useCallback(
+      (ev: MouseEvent) => {
+        const canvas = ref.current;
+        const currentSelectedCell = selectionRef.current.current?.cell
+        if (canvas === null || onContextMenu === undefined || currentSelectedCell === undefined)
+          return;
+        const bounds = getBoundsForItem(canvas, ...currentSelectedCell);
+        if (bounds) {
+          const args = getMouseArgsForPosition(canvas, bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, ev);
+          onContextMenu(args, () => {
+          if (ev.cancelable) ev.preventDefault();
+          });
+        }
+      },
+      [getMouseArgsForPosition, onContextMenu, getBoundsForItem]
+   );
+
+    useEventListener("contextmenu", onContextMenuWithKeyboardImpl, ref?.current ?? null, false);
+
     const onAnimationFrame = React.useCallback<StepCallback>(values => {
         damageRegion.current = new CellSet(values.map(x => x.item));
         hoverValues.current = values;

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -1263,25 +1263,6 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
     );
     useEventListener("contextmenu", onContextMenuImpl, eventTargetRef?.current ?? null, false);
 
-    const onContextMenuWithKeyboardImpl = React.useCallback(
-      (ev: MouseEvent) => {
-        const canvas = ref.current;
-        const currentSelectedCell = selectionRef.current.current?.cell
-        if (canvas === null || onContextMenu === undefined || currentSelectedCell === undefined)
-          return;
-        const bounds = getBoundsForItem(canvas, ...currentSelectedCell);
-        if (bounds) {
-          const args = getMouseArgsForPosition(canvas, bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, ev);
-          onContextMenu(args, () => {
-          if (ev.cancelable) ev.preventDefault();
-          });
-        }
-      },
-      [getMouseArgsForPosition, onContextMenu, getBoundsForItem]
-   );
-
-    useEventListener("contextmenu", onContextMenuWithKeyboardImpl, ref?.current ?? null, false);
-
     const onAnimationFrame = React.useCallback<StepCallback>(values => {
         damageRegion.current = new CellSet(values.map(x => x.item));
         hoverValues.current = values;

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -196,6 +196,53 @@ describe("data-editor", () => {
         expect(spySelection).not.toHaveBeenCalled();
     });
 
+    test("opens contextmenu at selected cell position when fired on canvas", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor
+        {...basicProps}
+        gridSelection={{
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.empty(),
+          current: {
+            cell: [1, 1],
+            range: { x: 1, y: 1, width: 1, height: 1 },
+            rangeStack: [],
+          },
+        }}
+        onCellContextMenu={spy}
+      />, { wrapper: Context });
+
+      prep();
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+
+      fireEvent.contextMenu(canvas);
+
+      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+    });
+
+    test("does not open contextmenu when no cell selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor
+        {...basicProps}
+        gridSelection={{
+          columns: CompactSelection.empty(),
+          rows: CompactSelection.empty(),
+        }}
+        onCellContextMenu={spy}
+      />, { wrapper: Context });
+
+      prep();
+      const canvas = screen.getByTestId("data-grid-canvas");
+      fireEvent.contextMenu(canvas);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     test("middle click does not change selection", async () => {
         const spySelection = vi.fn();
 

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -1183,10 +1183,10 @@ describe("data-editor", () => {
           width: expect.any(Number),
           height: expect.any(Number),
         }),
+        localEventX: eventArgs.bounds.width / 2,
+        localEventY: eventArgs.bounds.height / 2,
       });
 
-      expect(eventArgs.localEventX).toBe(eventArgs.bounds.width / 2);
-      expect(eventArgs.localEventY).toBe(eventArgs.bounds.height / 2);
     });
 
     test("does not open context menu with Shift+F10 when no cells are selected", async () => {
@@ -1211,6 +1211,7 @@ describe("data-editor", () => {
 
       const canvas = screen.getByTestId("data-grid-canvas");
 
+      // Press Shift+F10 without selecting any cell
       fireEvent.keyDown(canvas, {
         key: "F10",
         keyCode: 121,

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -196,53 +196,6 @@ describe("data-editor", () => {
         expect(spySelection).not.toHaveBeenCalled();
     });
 
-    test("opens contextmenu at selected cell position when fired on canvas", async () => {
-      const spy = vi.fn();
-
-      vi.useFakeTimers();
-      render(<DataEditor
-        {...basicProps}
-        gridSelection={{
-          columns: CompactSelection.empty(),
-          rows: CompactSelection.empty(),
-          current: {
-            cell: [1, 1],
-            range: { x: 1, y: 1, width: 1, height: 1 },
-            rangeStack: [],
-          },
-        }}
-        onCellContextMenu={spy}
-      />, { wrapper: Context });
-
-      prep();
-
-      const canvas = screen.getByTestId("data-grid-canvas");
-
-      fireEvent.contextMenu(canvas);
-
-      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
-    });
-
-    test("does not open contextmenu when no cell selected", async () => {
-      const spy = vi.fn();
-
-      vi.useFakeTimers();
-      render(<DataEditor
-        {...basicProps}
-        gridSelection={{
-          columns: CompactSelection.empty(),
-          rows: CompactSelection.empty(),
-        }}
-        onCellContextMenu={spy}
-      />, { wrapper: Context });
-
-      prep();
-      const canvas = screen.getByTestId("data-grid-canvas");
-      fireEvent.contextMenu(canvas);
-
-      expect(spy).not.toHaveBeenCalled();
-    });
-
     test("middle click does not change selection", async () => {
         const spySelection = vi.fn();
 
@@ -1194,6 +1147,77 @@ describe("data-editor", () => {
 
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith(expect.objectContaining({ location: [1, 1] }));
+    });
+
+    test("opens context menu with Shift+F10 when cell is selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(<DataEditor {...basicProps} onCellContextMenu={spy} />, {
+        wrapper: Context,
+      });
+      prep(false);
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+      sendClick(canvas, {
+        clientX: 300,
+        clientY: 84,
+      });
+
+      fireEvent.keyDown(canvas, {
+        key: "F10",
+        keyCode: 121,
+        shiftKey: true,
+      });
+
+      expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+
+      const eventArgs = spy.mock.calls[0][1];
+      expect(eventArgs).toMatchObject({
+        kind: "cell",
+        shiftKey: true,
+        location: [1, 1],
+        bounds: expect.objectContaining({
+          x: expect.any(Number),
+          y: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        }),
+      });
+
+      expect(eventArgs.localEventX).toBe(eventArgs.bounds.width / 2);
+      expect(eventArgs.localEventY).toBe(eventArgs.bounds.height / 2);
+    });
+
+    test("does not open context menu with Shift+F10 when no cells are selected", async () => {
+      const spy = vi.fn();
+
+      vi.useFakeTimers();
+      render(
+        <DataEditor
+          {...basicProps}
+          onCellContextMenu={spy}
+          gridSelection={{
+            columns: CompactSelection.empty(),
+            rows: CompactSelection.empty(),
+            current: undefined,
+          }}
+        />,
+        {
+          wrapper: Context,
+        }
+      );
+      prep(false);
+
+      const canvas = screen.getByTestId("data-grid-canvas");
+
+      fireEvent.keyDown(canvas, {
+        key: "F10",
+        keyCode: 121,
+        shiftKey: true,
+      });
+
+      expect(spy).not.toHaveBeenCalled();
     });
 
     test("Delete cell", async () => {


### PR DESCRIPTION
## Problem Statement
The data grid previously supported opening context menus only via mouse right-click.
Keyboard users were unable to open context menus using standard shortcuts.

At first glance, handling the contextmenu event appears sufficient. However, this assumption breaks down on macOS, where keyboard shortcuts do not fire a contextmenu event.

## Root Cause
The issue has two contributing factors:

Split event handling architecture
- Keyboard events are handled on the canvas element
- Context menu events are handled on the scroller div
- Keyboard-triggered context menu events would target the canvas, which had no listener

Platform limitation on macOS
- macOS does not fire contextmenu events from keyboard shortcuts

Relying solely on contextmenu listeners is insufficient

## Changes
- Added a Shift + F10 keybinding to explicitly open the context menu
- The handler Invokes the existing onContextMenu callback with event args
- Added unit tests to verify changes
