### PR TITLE
feat(data-editor): add keepFocusOnEnterAccept prop

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -581,6 +581,16 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
     readonly editOnType?: boolean;
 
     /**
+     * When true, pressing Enter to commit an overlay edit keeps the cursor on the edited cell instead
+     * of moving it down. Tab / Shift+Tab / Shift+Enter still move horizontally / upward as usual —
+     * only the [0, 1] (Enter → down) movement is neutralized.
+     *
+     * Default: `false` (preserves the historical "Enter moves down" behavior).
+     * @group Editing
+     */
+    readonly keepFocusOnEnterAccept?: boolean;
+
+    /**
      * Used to fetch large amounts of cells at once. Used for copy/paste, if unset copy will not work.
      *
      * `getCellsForSelection` is called when the user copies a selection to the clipboard or the data editor needs to
@@ -828,6 +838,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         onKeyUp: onKeyUpIn,
         keybindings: keybindingsIn,
         editOnType = true,
+        keepFocusOnEnterAccept = false,
         onRowAppended,
         onColumnAppended,
         onColumnMoved,
@@ -3096,6 +3107,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             focus(true);
             setOverlay(undefined);
 
+            // When keepFocusOnEnterAccept is enabled, only the Enter (down) movement is neutralized so
+            // pressing Enter commits without dropping a row. Tab / Shift+Tab / Shift+Enter keep
+            // their default direction-of-travel behavior.
+            if (keepFocusOnEnterAccept && movement[0] === 0 && movement[1] === 1) {
+                movement = [0, 0];
+            }
+
             const [movX, movY] = movement;
             if (gridSelection.current !== undefined && (movX !== 0 || movY !== 0)) {
                 const isEditingLastRow = gridSelection.current.cell[1] === mangledRows - 1 && newValue !== undefined;
@@ -3138,6 +3156,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             onRowAppended,
             onColumnAppended,
             getCustomNewRowTargetColumn,
+            keepFocusOnEnterAccept,
         ]
     );
 


### PR DESCRIPTION
## Summary

Adds a new `keepFocusOnEnterAccept` boolean prop to `DataEditor`. When enabled, pressing **Enter** to commit an overlay edit keeps the cursor on the edited cell instead of moving it down by one row.

The other accept directions are unaffected: **Tab**, **Shift+Tab**, and **Shift+Enter** continue to move horizontally / upward as usual. Only the `[0, 1]` (Enter → down) movement is neutralized.

## Motivation

In spreadsheet-style data editors backing real databases, a deliberate Enter generally means "commit this edit" - not "move the cursor down". The default Enter-moves-down behavior makes single-cell edits feel like the cursor is being yanked away after every commit, and it interferes with subsequent arrow-key navigation. This is also the behavior most native editors (Excel-style or otherwise) expose as a configuration option.

## Implementation

The change is localized to `onFinishEditing` in `packages/core/src/data-editor/data-editor.tsx`. When `keepFocusOnEnterAccept` is `true` and the incoming `movement` is exactly `[0, 1]`, we replace it with `[0, 0]` before the rest of the handler runs - so `updateSelectedCell` is never invoked for the Enter case and the cursor / scroll stay put. All other movement vectors flow through unchanged.

```diff
+ if (keepFocusOnEnterAccept && movement[0] === 0 && movement[1] === 1) {
+     movement = [0, 0];
+ }
  const [movX, movY] = movement;
  if (gridSelection.current !== undefined && (movX !== 0 || movY !== 0)) {
      ...
      updateSelectedCell(...);
  }
```

## Backwards compatibility

Default is `false`, so existing consumers see no behavior change. Opt-in only.

## Test plan

- [ ] Verify Enter on an open overlay still commits the value when `keepFocusOnEnterAccept={true}`.
- [ ] Verify the cursor stays on the edited cell after Enter.
- [ ] Verify Tab / Shift+Tab / Shift+Enter still move in their respective directions.
- [ ] Verify Escape still cancels without movement.
- [ ] Verify default behavior (`keepFocusOnEnterAccept` unset or `false`) is identical to today's.