### PR TITLE
Sections - visually grouping rows with a section header 

### DIFF
--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -178,6 +178,8 @@ Most data grids will want to set the majority of these props one way or another.
 | [onCellActivated](#oncellactivated)                   | Emitted when a cell is activated, such as by pressing Enter, Space, double clicking, or typing.                                                                                     |
 | [onCellClicked](#oncellclicked)                       | Emitted when a cell is clicked.                                                                                                                                                     |
 | [onCellContextMenu](#oncellcontextmenu)               | Emitted when a cell should show a context menu. Usually right click.                                                                                                                |
+| [onSectionHeaderClicked](#onsectionheaderclicked)     | Emitted when a section header is clicked.                                                                                                                                           |
+| [onSectionHeaderContextMenu](#onsectionheadercontextmenu) | Emitted when a section header should show a context menu. Usually right click.                                                                                                  |
 | [onColumnMoved](#oncolumnmoved)                       | Emitted when a column has been dragged to a new location.                                                                                                                           |
 | [onColumnResize](#oncolumnresize)                     | Emitted when a column has been resized to a new size.                                                                                                                               |
 | [onColumnResizeEnd](#oncolumnresize)                  | Emitted when a column has been resized to a new size and the user has stopped interacting wtih the resize handle.                                                                   |
@@ -1292,6 +1294,32 @@ The `event` parameter is one of:
 ---
 
 ## onCellContextMenu
+
+```ts
+onCellContextMenu?: (cell: Item, event: CellClickedEventArgs) => void;
+```
+
+`onCellContextMenu` is called whenever a cell context menu should be presented, usually right click.
+
+---
+
+## onSectionHeaderClicked
+
+```ts
+onSectionHeaderClicked?: (section: RowSection, event: CellClickedEventArgs) => void;
+```
+
+`onSectionHeaderClicked` is called whenever the user clicks a section header. Section header events use the section's data row as `event.location[1]`; `event.location[0]` is the clicked column when the section is rendered in the grid, or `0` when the sticky section header is clicked.
+
+---
+
+## onSectionHeaderContextMenu
+
+```ts
+onSectionHeaderContextMenu?: (section: RowSection, event: CellClickedEventArgs) => void;
+```
+
+`onSectionHeaderContextMenu` is called whenever a section header context menu should be presented, usually right click. Section headers remain non-selectable when this callback fires.
 
 ---
 

--- a/packages/core/API.md
+++ b/packages/core/API.md
@@ -98,6 +98,7 @@ Most data grids will want to set the majority of these props one way or another.
 | [portalElementRef](#portalelementref)             | A ref to the portal element to use for the overlay editor.                                                                                                                                                                                                          |
 | [rowHeight](#rowheight)                           | Callback or number used to specify the height of a given row.                                                                                                                                                                                                       |
 | [rowMarkers](#rowmarkers)                         | Enable/disable row marker column on the left. Can show row numbers, selection boxes, or both.                                                                                                                                                                       |
+| [sections](#sections)                             | Adds non-selectable full-width section rows before the provided row indexes.                                                                                                                                                                                        |
 | [smoothScrollX](#smoothscroll)                    | Enable/disable smooth scrolling on the X axis.                                                                                                                                                                                                                      |
 | [smoothScrollY](#smoothscroll)                    | Enable/disable smooth scrolling on the Y axis.                                                                                                                                                                                                                      |
 
@@ -659,6 +660,30 @@ rowMarkers?: "checkbox" | "number" | "both" | "none";
 ```
 
 `rowMarkers` determines whether to display the marker column on the very left. It defaults to `none`. Note that this column doesn't count as a table column, i.e. it has no index, and doesn't change column indexes.
+
+---
+
+## sections
+
+```ts
+interface RowSection {
+    row: number;
+    title: string;
+    height?: number;
+    sticky?: boolean;
+    stickyStyle?: "solid" | "frosted";
+    themeOverride?: Partial<Theme>;
+}
+
+sections?: readonly RowSection[];
+sectionHeight?: number;
+```
+
+`sections` inserts non-selectable full-width section rows before the provided row indexes. Section rows render with a title and are skipped by row marker selection and keyboard navigation. `sectionHeight` controls the default section row height and defaults to `44`. Set `sticky` on a section to keep it pinned at the top of the visible rows until the next section pushes it away.
+
+`stickyStyle` controls the pinned section header. Use `"solid"` for an opaque sticky header or `"frosted"` for a translucent sticky header with backdrop blur. It defaults to `"solid"`.
+
+Use `themeOverride` to style individual section rows. Section rendering uses `bgGroupHeader` and `textGroupHeader` when provided, falling back to the standard header theme.
 
 ---
 

--- a/packages/core/src/cells/index.ts
+++ b/packages/core/src/cells/index.ts
@@ -11,12 +11,14 @@ import { newRowCellRenderer } from "./new-row-cell.js";
 import { numberCellRenderer } from "./number-cell.js";
 import { protectedCellRenderer } from "./protected-cell.js";
 import { rowIDCellRenderer } from "./row-id-cell.js";
+import { sectionCellRenderer } from "./section-cell.js";
 import { textCellRenderer } from "./text-cell.js";
 import { uriCellRenderer } from "./uri-cell.js";
 
 export const AllCellRenderers = [
     markerCellRenderer,
     newRowCellRenderer,
+    sectionCellRenderer,
     booleanCellRenderer,
     bubbleCellRenderer,
     drilldownCellRenderer,

--- a/packages/core/src/cells/section-cell.tsx
+++ b/packages/core/src/cells/section-cell.tsx
@@ -2,6 +2,10 @@ import { getMiddleCenterBias } from "../internal/data-grid/render/data-grid-lib.
 import { InnerGridCellKind, type SectionCell } from "../internal/data-grid/data-grid-types.js";
 import type { BaseDrawArgs, InternalCellRenderer, PrepResult } from "./cell-types.js";
 
+type SectionCellDrawData = SectionCell & {
+    readonly titleOffset?: number;
+};
+
 export const sectionCellRenderer: InternalCellRenderer<SectionCell> = {
     getAccessibilityString: c => c.title,
     kind: InnerGridCellKind.Section,
@@ -11,6 +15,7 @@ export const sectionCellRenderer: InternalCellRenderer<SectionCell> = {
     measure: () => 120,
     draw: a => {
         const { ctx, rect, theme, cell } = a;
+        const titleOffset = (cell as SectionCellDrawData).titleOffset ?? 0;
         const { x, y, width, height } = rect;
 
         ctx.fillStyle = theme.bgGroupHeader ?? theme.bgHeader;
@@ -26,7 +31,7 @@ export const sectionCellRenderer: InternalCellRenderer<SectionCell> = {
         ctx.font = theme.headerFontFull;
         ctx.fillText(
             cell.title,
-            x + theme.cellHorizontalPadding * 2,
+            x + titleOffset + theme.cellHorizontalPadding * 2,
             y + height / 2 + getMiddleCenterBias(ctx, ctx.font)
         );
     },

--- a/packages/core/src/cells/section-cell.tsx
+++ b/packages/core/src/cells/section-cell.tsx
@@ -27,13 +27,15 @@ export const sectionCellRenderer: InternalCellRenderer<SectionCell> = {
         ctx.lineTo(x + width, y + height - 0.5);
         ctx.stroke();
 
-        ctx.fillStyle = theme.textGroupHeader ?? theme.textDark;
-        ctx.font = theme.headerFontFull;
-        ctx.fillText(
-            cell.title,
-            x + titleOffset + theme.cellHorizontalPadding * 2,
-            y + height / 2 + getMiddleCenterBias(ctx, ctx.font)
-        );
+        if (cell.title !== "") {
+            ctx.fillStyle = theme.textGroupHeader ?? theme.textDark;
+            ctx.font = theme.headerFontFull;
+            ctx.fillText(
+                cell.title,
+                x + titleOffset + theme.cellHorizontalPadding * 2,
+                y + height / 2 + getMiddleCenterBias(ctx, ctx.font)
+            );
+        }
     },
     onPaste: () => undefined,
 };

--- a/packages/core/src/cells/section-cell.tsx
+++ b/packages/core/src/cells/section-cell.tsx
@@ -1,0 +1,47 @@
+import { getMiddleCenterBias } from "../internal/data-grid/render/data-grid-lib.js";
+import { InnerGridCellKind, type SectionCell } from "../internal/data-grid/data-grid-types.js";
+import type { BaseDrawArgs, InternalCellRenderer, PrepResult } from "./cell-types.js";
+
+export const sectionCellRenderer: InternalCellRenderer<SectionCell> = {
+    getAccessibilityString: c => c.title,
+    kind: InnerGridCellKind.Section,
+    needsHover: false,
+    needsHoverPosition: false,
+    drawPrep: prepSectionCell,
+    measure: () => 120,
+    draw: a => {
+        const { ctx, rect, theme, cell } = a;
+        const { x, y, width, height } = rect;
+
+        ctx.fillStyle = theme.bgGroupHeader ?? theme.bgHeader;
+        ctx.fillRect(x, y, width, height);
+
+        ctx.strokeStyle = theme.borderColor;
+        ctx.beginPath();
+        ctx.moveTo(x, y + height - 0.5);
+        ctx.lineTo(x + width, y + height - 0.5);
+        ctx.stroke();
+
+        ctx.fillStyle = theme.textGroupHeader ?? theme.textDark;
+        ctx.font = theme.headerFontFull;
+        ctx.fillText(
+            cell.title,
+            x + theme.cellHorizontalPadding * 2,
+            y + height / 2 + getMiddleCenterBias(ctx, ctx.font)
+        );
+    },
+    onPaste: () => undefined,
+};
+
+function prepSectionCell(args: BaseDrawArgs, lastPrep: PrepResult | undefined): Partial<PrepResult> {
+    const { ctx } = args;
+    const result: Partial<PrepResult> = lastPrep ?? {};
+    ctx.textAlign = "left";
+    result.deprep = deprepSectionCell;
+    return result;
+}
+
+function deprepSectionCell(args: Pick<BaseDrawArgs, "ctx">) {
+    const { ctx } = args;
+    ctx.textAlign = "start";
+}

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -85,6 +85,7 @@ import type { Highlight } from "../internal/data-grid/render/data-grid-render.ce
 import { useRowGroupingInner, type RowGroupingOptions } from "./row-grouping.js";
 import { useRowGrouping } from "./row-grouping-api.js";
 import { useInitialScrollOffset } from "./use-initial-scroll-offset.js";
+import { useRowSections } from "./row-sections.js";
 import type { VisibleRegion } from "./visible-region.js";
 
 const DataGridOverlayEditor = React.lazy(
@@ -103,6 +104,15 @@ export interface RowMarkerOptions {
     headerTheme?: Partial<Theme>;
     headerAlwaysVisible?: boolean;
     headerDisabled?: boolean;
+}
+
+export interface RowSection {
+    readonly row: number;
+    readonly title: string;
+    readonly height?: number;
+    readonly sticky?: boolean;
+    readonly stickyStyle?: "solid" | "frosted";
+    readonly themeOverride?: Partial<Theme>;
 }
 
 interface MouseState {
@@ -624,6 +634,19 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
     readonly rowGrouping?: RowGroupingOptions;
 
     /**
+     * Adds non-selectable section rows before the provided row indexes.
+     * @group Rows
+     */
+    readonly sections?: readonly RowSection[];
+
+    /**
+     * The default height of section rows.
+     * @defaultValue `44`
+     * @group Rows
+     */
+    readonly sectionHeight?: number;
+
+    /**
      * Called when data is pasted into the grid. If left undefined, the `DataEditor` will operate in a
      * fallback mode and attempt to paste the text buffer into the current cell assuming the current cell is not
      * readonly and can accept the data type. If `onPaste` is set to false or the function returns false, the grid will
@@ -852,6 +875,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         onHeaderIndicatorClick,
         getGroupDetails,
         rowGrouping,
+        sections,
+        sectionHeight = 44,
         onSearchClose: onSearchCloseIn,
         onItemHovered,
         onSelectionCleared,
@@ -929,11 +954,45 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     }, []);
 
     const {
-        rows,
-        rowNumberMapper,
+        rows: rowsPostGrouping,
+        rowNumberMapper: rowNumberMapperPostGrouping,
         rowHeight: rowHeightPostGrouping,
         getRowThemeOverride,
     } = useRowGroupingInner(rowGrouping, rowsIn, rowHeightIn, getRowThemeOverrideIn);
+
+    const {
+        dataRowToVisualRow,
+        dataSelectionToVisualSelection,
+        getSectionForRow,
+        getVisualRowSelection,
+        isDataRow,
+        sectionRows,
+        visualRectToDataRect,
+        visualRowCount: rows,
+        visualRowToDataRow,
+        visualSelectionToDataSelection,
+    } = useRowSections(sections, rowsPostGrouping);
+
+    const rowNumberMapper = React.useCallback(
+        (row: number): number | undefined => {
+            const dataRow = visualRowToDataRow(row);
+            if (dataRow === undefined) return undefined;
+            return rowNumberMapperPostGrouping(dataRow);
+        },
+        [rowNumberMapperPostGrouping, visualRowToDataRow]
+    );
+
+    const rowHeightPostSections = React.useMemo(() => {
+        if (sectionRows.length === 0) return rowHeightPostGrouping;
+        return (row: number) => {
+            const section = getSectionForRow(row);
+            if (section !== undefined) return section.height ?? sectionHeight;
+
+            const dataRow = visualRowToDataRow(row);
+            if (dataRow === undefined) return sectionHeight;
+            return typeof rowHeightPostGrouping === "number" ? rowHeightPostGrouping : rowHeightPostGrouping(dataRow);
+        };
+    }, [getSectionForRow, sectionRows.length, rowHeightPostGrouping, sectionHeight, visualRowToDataRow]);
 
     const remSize = React.useMemo(() => Number.parseFloat(docStyle.fontSize), [docStyle]);
     const { rowHeight, headerHeight, groupHeaderHeight, theme, overscrollX, overscrollY } = useRemAdjuster({
@@ -942,7 +1001,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         overscrollX: overscrollXIn,
         overscrollY: overscrollYIn,
         remSize,
-        rowHeight: rowHeightPostGrouping,
+        rowHeight: rowHeightPostSections,
         scaleToRem,
         theme: themeIn,
     });
@@ -967,8 +1026,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     }, [onSearchCloseIn]);
 
     const gridSelectionOuterMangled: GridSelection | undefined = React.useMemo((): GridSelection | undefined => {
-        return gridSelectionOuter === undefined ? undefined : shiftSelection(gridSelectionOuter, rowMarkerOffset);
-    }, [gridSelectionOuter, rowMarkerOffset]);
+        if (gridSelectionOuter === undefined) return undefined;
+        return dataSelectionToVisualSelection(shiftSelection(gridSelectionOuter, rowMarkerOffset));
+    }, [dataSelectionToVisualSelection, gridSelectionOuter, rowMarkerOffset]);
     const gridSelection = gridSelectionOuterMangled ?? gridSelectionInner;
 
     const abortControllerRef = React.useRef() as React.MutableRefObject<AbortController>;
@@ -981,16 +1041,42 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         getCellContent,
         rowMarkerOffset,
         abortControllerRef.current,
-        rows
+        rowsPostGrouping,
+        visualRectToDataRect
     );
 
     const validateCell = React.useCallback<NonNullable<typeof validateCellIn>>(
         (cell, newValue, prevValue) => {
             if (validateCellIn === undefined) return true;
-            const item: Item = [cell[0] - rowMarkerOffset, cell[1]];
+            const dataRow = visualRowToDataRow(cell[1]);
+            if (dataRow === undefined) return false;
+            const item: Item = [cell[0] - rowMarkerOffset, dataRow];
             return validateCellIn?.(item, newValue, prevValue);
         },
-        [rowMarkerOffset, validateCellIn]
+        [rowMarkerOffset, validateCellIn, visualRowToDataRow]
+    );
+
+    const toPublicCell = React.useCallback(
+        (cell: Item): Item | undefined => {
+            const dataRow = visualRowToDataRow(cell[1]);
+            if (dataRow === undefined) return undefined;
+            return [cell[0] - rowMarkerOffset, dataRow];
+        },
+        [rowMarkerOffset, visualRowToDataRow]
+    );
+
+    const toPublicMouseArgs = React.useCallback(
+        <T extends GridMouseEventArgs>(args: T): T | undefined => {
+            const [col, row] = args.location;
+            const adjustedCol = col - rowMarkerOffset;
+            if (args.kind === "cell") {
+                const dataRow = visualRowToDataRow(row);
+                if (dataRow === undefined) return undefined;
+                return { ...args, location: [adjustedCol, dataRow] as any };
+            }
+            return { ...args, location: [adjustedCol, row] as any };
+        },
+        [rowMarkerOffset, visualRowToDataRow]
     );
 
     const expectedExternalGridSelection = React.useRef<GridSelection | undefined>(gridSelectionOuter);
@@ -1006,13 +1092,22 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 );
             }
             if (onGridSelectionChange !== undefined) {
-                expectedExternalGridSelection.current = shiftSelection(newVal, -rowMarkerOffset);
+                expectedExternalGridSelection.current = shiftSelection(
+                    visualSelectionToDataSelection(newVal),
+                    -rowMarkerOffset
+                );
                 onGridSelectionChange(expectedExternalGridSelection.current);
             } else {
                 setGridSelectionInner(newVal);
             }
         },
-        [onGridSelectionChange, getCellsForSelection, rowMarkerOffset, spanRangeBehavior]
+        [
+            onGridSelectionChange,
+            getCellsForSelection,
+            rowMarkerOffset,
+            spanRangeBehavior,
+            visualSelectionToDataSelection,
+        ]
     );
 
     const onColumnResize = whenDefined(
@@ -1059,24 +1154,29 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         drawCellIn,
         React.useCallback<NonNullable<typeof drawCellIn>>(
             (args, draw) => {
-                return drawCellIn?.({ ...args, col: args.col - rowMarkerOffset }, draw) ?? false;
+                return (
+                    drawCellIn?.(
+                        { ...args, col: args.col - rowMarkerOffset, row: visualRowToDataRow(args.row) ?? args.row },
+                        draw
+                    ) ?? false
+                );
             },
-            [drawCellIn, rowMarkerOffset]
+            [drawCellIn, rowMarkerOffset, visualRowToDataRow]
         )
     );
 
     const onDelete = React.useCallback<NonNullable<DataEditorProps["onDelete"]>>(
         sel => {
             if (onDeleteIn !== undefined) {
-                const result = onDeleteIn(shiftSelection(sel, -rowMarkerOffset));
+                const result = onDeleteIn(shiftSelection(visualSelectionToDataSelection(sel), -rowMarkerOffset));
                 if (typeof result === "boolean") {
                     return result;
                 }
-                return shiftSelection(result, rowMarkerOffset);
+                return dataSelectionToVisualSelection(shiftSelection(result, rowMarkerOffset));
             }
             return true;
         },
-        [onDeleteIn, rowMarkerOffset]
+        [dataSelectionToVisualSelection, onDeleteIn, rowMarkerOffset, visualSelectionToDataSelection]
     );
 
     const [setCurrent, setSelectedRows, setSelectedColumns] = useSelectionBehavior(
@@ -1117,7 +1217,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     // eslint-disable-next-line prefer-const
     let { sizedColumns: columns, nonGrowWidth } = useColumnSizer(
         columnsIn,
-        rows,
+        rowsPostGrouping,
         getCellsForSeletionDirect,
         clientSize[0] - (rowMarkerOffset === 0 ? 0 : rowMarkerWidth) - clientSize[2],
         minColumnWidth,
@@ -1135,8 +1235,22 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const totalHeaderHeight = enableGroups ? headerHeight + groupHeaderHeight : headerHeight;
 
     const numSelectedRows = gridSelection.rows.length;
-    const rowMarkerChecked =
-        rowMarkers === "none" ? undefined : numSelectedRows === 0 ? false : numSelectedRows === rows ? true : undefined;
+    const allSelectableRows = React.useMemo(() => {
+        if (rowMarkers === "none" || sectionRows.length === 0) {
+            return undefined;
+        }
+        return getVisualRowSelection([0, rows]);
+    }, [getVisualRowSelection, sectionRows.length, rowMarkers, rows]);
+    let rowMarkerChecked: boolean | undefined;
+    if (rowMarkers !== "none") {
+        if (numSelectedRows === 0) {
+            rowMarkerChecked = false;
+        } else if (allSelectableRows !== undefined) {
+            rowMarkerChecked = gridSelection.rows.equals(allSelectableRows) ? true : undefined;
+        } else {
+            rowMarkerChecked = numSelectedRows === rows ? true : undefined;
+        }
+    }
 
     const mangledCols = React.useMemo(() => {
         if (rowMarkers === "none") return columns;
@@ -1189,6 +1303,117 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const cellXOffset = visibleRegion.x + rowMarkerOffset;
     const cellYOffset = visibleRegion.y;
+    const rightElementWidth = clientSize[2];
+
+    const stickySection = React.useMemo(() => {
+        if (sectionRows.length === 0) return undefined;
+
+        const translateY = visibleRegion.ty ?? 0;
+        let activeIndex = -1;
+        let sectionIndex = 0;
+        for (const { row: sectionRow } of sectionRows) {
+            if (sectionRow < cellYOffset || (sectionRow === cellYOffset && translateY <= 0)) {
+                activeIndex = sectionIndex;
+            } else {
+                break;
+            }
+            sectionIndex++;
+        }
+
+        if (activeIndex === -1) return undefined;
+
+        const activeSectionRow = sectionRows[activeIndex];
+        if (activeSectionRow.section.sticky !== true) return undefined;
+        if (activeSectionRow.row === cellYOffset && translateY === 0) return undefined;
+
+        const getRowHeight = typeof rowHeight === "number" ? () => rowHeight : rowHeight;
+        const sectionRowHeight = getRowHeight(activeSectionRow.row);
+        const nextSectionRow = sectionRows[activeIndex + 1];
+
+        let offset = 0;
+        if (nextSectionRow !== undefined) {
+            let nextSectionTop = translateY;
+            let row = cellYOffset;
+            while (row < nextSectionRow.row) {
+                nextSectionTop += getRowHeight(row);
+                row++;
+            }
+            offset = Math.min(0, nextSectionTop - sectionRowHeight);
+        }
+
+        const sectionTheme = mergeAndRealizeTheme(mergedTheme, activeSectionRow.section.themeOverride);
+        const stickyStyle = activeSectionRow.section.stickyStyle ?? "solid";
+        const sectionBackground = sectionTheme.bgGroupHeader ?? sectionTheme.bgHeader;
+        const sectionBorder = sectionTheme.borderColor;
+        const clipStyle: React.CSSProperties = {
+            position: "absolute",
+            top: totalHeaderHeight,
+            left: 0,
+            right: rightElementWidth,
+            bottom: 0,
+            overflow: "hidden",
+            pointerEvents: "none",
+            zIndex: 3,
+        };
+        const sectionStyle: React.CSSProperties = {
+            height: sectionRowHeight,
+            boxSizing: "border-box",
+            display: "flex",
+            alignItems: "center",
+            paddingLeft:
+                rowMarkerOffset === 0
+                    ? sectionTheme.cellHorizontalPadding * 2
+                    : rowMarkerWidth + sectionTheme.cellHorizontalPadding * 2,
+            paddingRight: sectionTheme.cellHorizontalPadding * 2,
+            backgroundColor: stickyStyle === "frosted" ? withAlpha(sectionBackground, 0.74) : sectionBackground,
+            backdropFilter: stickyStyle === "frosted" ? "saturate(180%) blur(14px)" : undefined,
+            WebkitBackdropFilter: stickyStyle === "frosted" ? "saturate(180%) blur(14px)" : undefined,
+            borderBottom: `1px solid ${stickyStyle === "frosted" ? withAlpha(sectionBorder, 0.72) : sectionBorder}`,
+            color: sectionTheme.textGroupHeader ?? sectionTheme.textDark,
+            font: sectionTheme.headerFontFull,
+            overflow: "hidden",
+            pointerEvents: "auto",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            transform: `translateY(${offset}px)`,
+        };
+
+        return {
+            clipStyle,
+            sectionStyle,
+            title: activeSectionRow.section.title,
+        };
+    }, [
+        cellYOffset,
+        mergedTheme,
+        rightElementWidth,
+        rowHeight,
+        rowMarkerOffset,
+        rowMarkerWidth,
+        sectionRows,
+        totalHeaderHeight,
+        visibleRegion.ty,
+    ]);
+
+    const stopStickySectionEvent = React.useCallback((event: React.SyntheticEvent) => {
+        event.preventDefault();
+        event.stopPropagation();
+    }, []);
+
+    const onStickySectionWheel = React.useCallback(
+        (event: React.WheelEvent) => {
+            const scroller = scrollRef.current;
+            if (scroller === null) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            scroller.scrollBy({
+                left: event.deltaX,
+                top: event.deltaY,
+            });
+        },
+        [scrollRef]
+    );
 
     const gridRef = React.useRef<DataGridRef | null>(null);
 
@@ -1206,13 +1431,17 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const mangledOnCellsEdited = React.useCallback<NonNullable<typeof onCellsEdited>>(
         (items: readonly EditListItem[]) => {
-            const mangledItems =
-                rowMarkerOffset === 0
-                    ? items
-                    : items.map(x => ({
-                          ...x,
-                          location: [x.location[0] - rowMarkerOffset, x.location[1]] as const,
-                      }));
+            const mangledItems = items.flatMap(x => {
+                const dataRow = visualRowToDataRow(x.location[1]);
+                if (dataRow === undefined) return [];
+                return [
+                    {
+                        ...x,
+                        location: [x.location[0] - rowMarkerOffset, dataRow] as const,
+                    },
+                ];
+            });
+            if (mangledItems.length === 0) return false;
             const r = onCellsEdited?.(mangledItems);
 
             if (r !== true) {
@@ -1221,7 +1450,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
             return r;
         },
-        [onCellEdited, onCellsEdited, rowMarkerOffset]
+        [onCellEdited, onCellsEdited, rowMarkerOffset, visualRowToDataRow]
     );
 
     const [fillHighlightRegion, setFillHighlightRegion] = React.useState<Rectangle | undefined>();
@@ -1309,6 +1538,17 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const getMangledCellContent = React.useCallback(
         ([col, row]: Item, forceStrict: boolean = false): InnerGridCell => {
             const isTrailing = showTrailingBlankRow && row === mangledRows - 1;
+            const section = getSectionForRow(row);
+            if (section !== undefined) {
+                const spanStart = hasRowMarkers ? rowMarkerOffset : 0;
+                return {
+                    kind: InnerGridCellKind.Section,
+                    allowOverlay: false,
+                    title: col < spanStart ? "" : section.title,
+                    span: col < spanStart ? undefined : [spanStart, mangledColsRef.current.length - 1],
+                    themeOverride: section.themeOverride,
+                };
+            }
             const isRowMarkerCol = col === 0 && hasRowMarkers;
             if (isRowMarkerCol) {
                 if (isTrailing) {
@@ -1347,6 +1587,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
             } else {
                 const outerCol = col - rowMarkerOffset;
+                const dataRow = visualRowToDataRow(row);
+                if (dataRow === undefined) return loadingCell;
                 if (forceStrict || experimental?.strict === true) {
                     const vr = visibleRegionRef.current;
                     const isOutsideMainArea =
@@ -1370,7 +1612,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         return loadingCell;
                     }
                 }
-                let result = getCellContent([outerCol, row]);
+                let result = getCellContent([outerCol, dataRow]);
                 if (rowMarkerOffset !== 0 && result.span !== undefined) {
                     result = {
                         ...result,
@@ -1383,18 +1625,20 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         [
             showTrailingBlankRow,
             mangledRows,
+            getSectionForRow,
             hasRowMarkers,
+            rowMarkerOffset,
             rowNumberMapper,
             rowMarkerCheckboxStyle,
             gridSelection?.rows,
             rowMarkers,
             rowMarkerStartIndex,
             onRowMoved,
-            rowMarkerOffset,
             trailingRowOptions?.hint,
             trailingRowOptions?.addIcon,
             experimental?.strict,
             getCellContent,
+            visualRowToDataRow,
         ]
     );
 
@@ -1710,7 +1954,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     return;
                 }
 
-                const row = typeof r === "number" ? r : bottom ? rows : 0;
+                const dataRow = typeof r === "number" ? r : bottom ? rowsPostGrouping : 0;
+                const row = dataRowToVisualRow(dataRow);
                 scrollToRef.current(col - rowMarkerOffset, row, "both", 0, 0, behavior ? { behavior } : undefined);
                 setCurrent(
                     {
@@ -1727,7 +1972,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     "edit"
                 );
 
-                const cell = getCellContentRef.current([col - rowMarkerOffset, row]);
+                const cell = getCellContentRef.current([col - rowMarkerOffset, dataRow]);
                 if (cell.allowOverlay && isReadWriteCell(cell) && cell.readonly !== true && openOverlay) {
                     // wait for scroll to have a chance to process
                     window.setTimeout(() => {
@@ -1738,7 +1983,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             // Queue up to allow the consumer to react to the event and let us check if they did
             doFocus();
         },
-        [mangledCols, onRowAppended, rowMarkerOffset, rows, setCurrent]
+        [dataRowToVisualRow, mangledCols, onRowAppended, rowMarkerOffset, rows, rowsPostGrouping, setCurrent]
     );
 
     const appendColumn = React.useCallback(
@@ -1764,6 +2009,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
 
                 const col = typeof r === "number" ? r : right ? mangledCols.length : 0;
+                const dataRow = visualRowToDataRow(row);
+                if (dataRow === undefined) return;
                 scrollTo(col - rowMarkerOffset, row);
                 setCurrent(
                     {
@@ -1780,7 +2027,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     "edit"
                 );
 
-                const cell = getCellContentRef.current([col - rowMarkerOffset, row]);
+                const cell = getCellContentRef.current([col - rowMarkerOffset, dataRow]);
                 if (cell.allowOverlay && isReadWriteCell(cell) && cell.readonly !== true && openOverlay) {
                     window.setTimeout(() => {
                         focusCallback.current(col, row);
@@ -1789,7 +2036,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             };
             doFocus();
         },
-        [mangledCols, onColumnAppended, rowMarkerOffset, scrollTo, setCurrent]
+        [mangledCols, onColumnAppended, rowMarkerOffset, scrollTo, setCurrent, visualRowToDataRow]
     );
 
     const getCustomNewRowTargetColumn = React.useCallback(
@@ -1849,6 +2096,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 lastSelectedColRef.current = undefined;
 
                 lastMouseSelectLocation.current = [col, row];
+                if (getSectionForRow(row) !== undefined) {
+                    return;
+                }
 
                 if (col === 0 && hasRowMarkers) {
                     if (
@@ -1890,11 +2140,16 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         selectedRows.hasIndex(lastHighlighted)
                     ) {
                         const newSlice: Slice = [Math.min(lastHighlighted, row), Math.max(lastHighlighted, row) + 1];
+                        const newRows = getVisualRowSelection(newSlice);
 
                         if (isMultiRow || rowSelectionMode === "multi") {
-                            setSelectedRows(undefined, newSlice, true);
+                            setSelectedRows(
+                                CompactSelection.create([...selectedRows.items, ...newRows.items]),
+                                undefined,
+                                true
+                            );
                         } else {
-                            setSelectedRows(CompactSelection.fromSingleSelection(newSlice), undefined, isMultiRow);
+                            setSelectedRows(newRows, undefined, isMultiRow);
                         }
                     } else if (rowSelect === "multi" && (isMultiRow || args.isTouch || rowSelectionMode === "multi")) {
                         if (isSelected) {
@@ -1906,7 +2161,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     } else if (isSelected && selectedRows.length === 1) {
                         setSelectedRows(CompactSelection.empty(), undefined, isMultiKey);
                     } else {
-                        setSelectedRows(CompactSelection.fromSingleSelection(row), undefined, isMultiKey);
+                        setSelectedRows(getVisualRowSelection(row), undefined, isMultiKey);
                         lastSelectedRowRef.current = row;
                     }
                 } else if (col >= rowMarkerOffset && showTrailingBlankRow && row === rows) {
@@ -1998,8 +2253,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     lastSelectedRowRef.current = undefined;
                     lastSelectedColRef.current = undefined;
                     if (!headerRowMarkerDisabled && rowSelect === "multi") {
-                        if (selectedRows.length !== rows) {
-                            setSelectedRows(CompactSelection.fromSingleSelection([0, rows]), undefined, isMultiKey);
+                        const allRows = allSelectableRows ?? getVisualRowSelection([0, rows]);
+                        if (!selectedRows.equals(allRows)) {
+                            setSelectedRows(allRows, undefined, isMultiKey);
                         } else {
                             setSelectedRows(CompactSelection.empty(), undefined, isMultiKey);
                         }
@@ -2064,6 +2320,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rowMarkerOffset,
             showTrailingBlankRow,
             rows,
+            allSelectableRows,
             rowMarkers,
             getMangledCellContent,
             onRowMoved,
@@ -2074,6 +2331,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             themeForCell,
             setSelectedRows,
             getCustomNewRowTargetColumn,
+            getSectionForRow,
+            getVisualRowSelection,
             appendRow,
             rowGroupingNavBehavior,
             mapper,
@@ -2367,10 +2626,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             const handleMaybeClick = (a: GridMouseCellEventArgs): boolean => {
                 const isValidClick = a.isTouch || (lastMouseDownCol === col && lastMouseDownRow === row);
                 if (isValidClick) {
-                    onCellClicked?.([col - rowMarkerOffset, row], {
-                        ...a,
-                        preventDefault,
-                    });
+                    const publicCell = toPublicCell([col, row]);
+                    const publicArgs = toPublicMouseArgs(a);
+                    if (publicCell !== undefined && publicArgs !== undefined) {
+                        onCellClicked?.(publicCell, {
+                            ...publicArgs,
+                            preventDefault,
+                        });
+                    }
                 }
                 if (a.button === 1) return !isPrevented.current;
                 if (!isPrevented.current) {
@@ -2417,6 +2680,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         }
                     }
                     if (shouldActivate) {
+                        const publicCell = toPublicCell([col, row]);
+                        if (publicCell === undefined) return false;
                         const act =
                             a.isDoubleClick === true
                                 ? "double-click"
@@ -2426,7 +2691,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                             pointerActivation: act,
                             pointerType: a.isTouch ? "touch" : "mouse",
                         };
-                        onCellActivated?.([col - rowMarkerOffset, row], activationEvent);
+                        onCellActivated?.(publicCell, activationEvent);
                         reselect(a.bounds, activationEvent);
                         return true;
                     }
@@ -2445,10 +2710,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 // take care of context menus first if long pressed item is already selected
                 if (args.isLongTouch === true) {
                     if (args.kind === "cell" && itemsAreEqual(gridSelection.current?.cell, args.location)) {
-                        onCellContextMenu?.([clickLocation, args.location[1]], {
-                            ...args,
-                            preventDefault,
-                        });
+                        const publicCell = toPublicCell(args.location);
+                        const publicArgs = toPublicMouseArgs(args);
+                        if (publicCell !== undefined && publicArgs !== undefined) {
+                            onCellContextMenu?.(publicCell, {
+                                ...publicArgs,
+                                preventDefault,
+                            });
+                        }
                         return;
                     } else if (args.kind === "header" && gridSelection.columns.hasIndex(col)) {
                         onHeaderContextMenu?.(clickLocation, { ...args, preventDefault });
@@ -2522,6 +2791,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             fillPattern,
             setGridSelection,
             onCellClicked,
+            toPublicCell,
+            toPublicMouseArgs,
             getMangledCellContent,
             getCellRenderer,
             cellActivationBehavior,
@@ -2542,11 +2813,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const onMouseMoveImpl = React.useCallback(
         (args: GridMouseEventArgs) => {
-            const a: GridMouseEventArgs = {
-                ...args,
-                location: [args.location[0] - rowMarkerOffset, args.location[1]] as any,
-            };
-            onMouseMove?.(a);
+            const publicArgs = toPublicMouseArgs(args);
+            if (publicArgs !== undefined) {
+                onMouseMove?.(publicArgs);
+            }
 
             if (mouseState !== undefined && args.buttons === 0) {
                 setMouseState(undefined);
@@ -2563,7 +2833,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     : args.scrollEdge;
             });
         },
-        [mouseState, onMouseMove, rowMarkerOffset]
+        [mouseState, onMouseMove, rowMarkerOffset, toPublicMouseArgs]
     );
 
     const onHeaderMenuClickInner = React.useCallback(
@@ -2595,6 +2865,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             if (selected !== undefined) {
                 selected = [selected[0] - rowMarkerOffset, selected[1]];
             }
+            const publicSelected = currentCell === undefined ? undefined : toPublicCell(currentCell);
 
             const freezeRegion =
                 freezeColumns === 0
@@ -2642,7 +2913,26 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             visibleRegionRef.current = newRegion;
             setVisibleRegion(newRegion);
             setClientSize([clientWidth, clientHeight, rightElWidth]);
-            onVisibleRegionChanged?.(newRegion, newRegion.tx, newRegion.ty, newRegion.extras);
+            if (onVisibleRegionChanged !== undefined) {
+                const mapRegion = (rect: Rectangle | undefined): Rectangle | undefined => {
+                    if (rect === undefined) return undefined;
+                    return visualRectToDataRect(rect) ?? { ...rect, height: 0 };
+                };
+                const publicExtras = {
+                    selected: publicSelected,
+                    freezeRegion: mapRegion(freezeRegion),
+                    freezeRegions: freezeRegions.flatMap(rect => {
+                        const publicRect = mapRegion(rect);
+                        return publicRect === undefined ? [] : [publicRect];
+                    }),
+                };
+                const publicRegion = {
+                    ...newRegion,
+                    ...(mapRegion(newRegion) ?? { height: 0 }),
+                    extras: publicExtras,
+                };
+                onVisibleRegionChanged?.(publicRegion, publicRegion.tx, publicRegion.ty, publicExtras);
+            }
         },
         [
             currentCell,
@@ -2653,6 +2943,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             freezeTrailingRows,
             setVisibleRegion,
             onVisibleRegionChanged,
+            toPublicCell,
+            visualRectToDataRect,
         ]
     );
 
@@ -2686,17 +2978,19 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 args.preventDefault();
                 return;
             }
-            onDragStart?.({
-                ...args,
-                location: [args.location[0] - rowMarkerOffset, args.location[1]] as any,
-            });
+            const publicArgs = toPublicMouseArgs(args);
+            if (publicArgs === undefined) {
+                args.preventDefault();
+                return;
+            }
+            onDragStart?.(publicArgs);
 
             if (!args.defaultPrevented()) {
                 isActivelyDragging.current = true;
             }
             setMouseState(undefined);
         },
-        [onDragStart, rowMarkerOffset]
+        [onDragStart, rowMarkerOffset, toPublicMouseArgs]
     );
 
     const onDragEnd = React.useCallback(() => {
@@ -2743,7 +3037,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             ) {
                 const start = Math.min(mouseDownData.current.location[1], args.location[1]);
                 const end = Math.max(mouseDownData.current.location[1], args.location[1]) + 1;
-                setSelectedRows(CompactSelection.fromSingleSelection([start, end]), undefined, false);
+                setSelectedRows(getVisualRowSelection([start, end]), undefined, false);
             }
             // Only handle rect selection if not already processed by row selection:
             else if (
@@ -2805,7 +3099,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
             }
 
-            onItemHovered?.({ ...args, location: [args.location[0] - rowMarkerOffset, args.location[1]] as any });
+            const publicArgs = toPublicMouseArgs(args);
+            if (publicArgs !== undefined) {
+                onItemHovered?.(publicArgs);
+            }
         },
         [
             mouseState,
@@ -2814,11 +3111,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             gridSelection,
             rangeSelect,
             onItemHovered,
+            toPublicMouseArgs,
             setSelectedRows,
             showTrailingBlankRow,
             rows,
             allowedFillDirections,
             getSelectionRowLimits,
+            getVisualRowSelection,
             setCurrent,
         ]
     );
@@ -3151,14 +3450,16 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             const editList: EditListItem[] = [];
             for (let x = r.x; x < r.x + r.width; x++) {
                 for (let y = r.y; y < r.y + r.height; y++) {
-                    const cellValue = getCellContent([x - rowMarkerOffset, y]);
+                    const dataRow = visualRowToDataRow(y);
+                    if (dataRow === undefined) continue;
+                    const cellValue = getCellContent([x - rowMarkerOffset, dataRow]);
                     if (!cellValue.allowOverlay && cellValue.kind !== GridCellKind.Boolean) continue;
                     let newVal: InnerGridCell | undefined = undefined;
                     if (cellValue.kind === GridCellKind.Custom) {
                         const toDelete = getCellRenderer(cellValue);
                         const editor = toDelete?.provideEditor?.({
                             ...cellValue,
-                            location: [x - rowMarkerOffset, y],
+                            location: [x - rowMarkerOffset, dataRow],
                         });
                         if (toDelete?.onDelete !== undefined) {
                             newVal = toDelete.onDelete(cellValue);
@@ -3180,7 +3481,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             mangledOnCellsEdited(editList);
             gridRef.current?.damage(editList.map(x => ({ cell: x.location })));
         },
-        [focus, getCellContent, getCellRenderer, mangledOnCellsEdited, rowMarkerOffset]
+        [focus, getCellContent, getCellRenderer, mangledOnCellsEdited, rowMarkerOffset, visualRowToDataRow]
     );
 
     const overlayOpen = overlay !== undefined;
@@ -3288,13 +3589,15 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
                 }
             } else if (rowSelect !== "none" && isHotkey(keys.selectRow, event, details)) {
-                if (selectedRows.hasIndex(row)) {
-                    setSelectedRows(selectedRows.remove(row), undefined, true);
-                } else {
-                    if (rowSelect === "single") {
-                        setSelectedRows(CompactSelection.fromSingleSelection(row), undefined, true);
+                if (isDataRow(row)) {
+                    if (selectedRows.hasIndex(row)) {
+                        setSelectedRows(selectedRows.remove(row), undefined, true);
                     } else {
-                        setSelectedRows(undefined, row, true);
+                        if (rowSelect === "single") {
+                            setSelectedRows(getVisualRowSelection(row), undefined, true);
+                        } else {
+                            setSelectedRows(undefined, row, true);
+                        }
                     }
                 }
             } else if (!overlayOpen && bounds !== undefined && isHotkey(keys.activateCell, event, details)) {
@@ -3308,7 +3611,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         inputType: "keyboard",
                         key: event.key,
                     };
-                    onCellActivated?.([col - rowMarkerOffset, row], activationEvent);
+                    const publicCell = toPublicCell([col, row]);
+                    if (publicCell !== undefined) {
+                        onCellActivated?.(publicCell, activationEvent);
+                    }
                     reselect(bounds, activationEvent);
                 }
             } else if (gridSelection.current.range.height > 1 && isHotkey(keys.downFill, event, details)) {
@@ -3409,20 +3715,23 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             }
             // #endregion
 
-            const mustRestrictRow = rowGroupingNavBehavior !== undefined && rowGroupingNavBehavior !== "normal";
+            const mustRestrictRow =
+                sectionRows.length > 0 || (rowGroupingNavBehavior !== undefined && rowGroupingNavBehavior !== "normal");
 
             if (mustRestrictRow && row !== startRow) {
                 const skipUp =
+                    sectionRows.length > 0 ||
                     rowGroupingNavBehavior === "skip-up" ||
                     rowGroupingNavBehavior === "skip" ||
                     rowGroupingNavBehavior === "block";
                 const skipDown =
+                    sectionRows.length > 0 ||
                     rowGroupingNavBehavior === "skip-down" ||
                     rowGroupingNavBehavior === "skip" ||
                     rowGroupingNavBehavior === "block";
                 const didMoveUp = row < startRow;
                 if (didMoveUp && skipUp) {
-                    while (row >= 0 && mapper(row).isGroupHeader) {
+                    while (row >= 0 && (getSectionForRow(row) !== undefined || mapper(row).isGroupHeader)) {
                         row--;
                     }
 
@@ -3430,7 +3739,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         row = startRow;
                     }
                 } else if (!didMoveUp && skipDown) {
-                    while (row < rows && mapper(row).isGroupHeader) {
+                    while (row < rows && (getSectionForRow(row) !== undefined || mapper(row).isGroupHeader)) {
                         row++;
                     }
 
@@ -3472,8 +3781,13 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             setSelectedRows,
             showTrailingBlankRow,
             getCustomNewRowTargetColumn,
+            getSectionForRow,
+            getVisualRowSelection,
             appendRow,
             onCellActivated,
+            toPublicCell,
+            sectionRows.length,
+            isDataRow,
             reselect,
             fillDown,
             fillRight,
@@ -3485,15 +3799,18 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         (event: GridKeyEventArgs) => {
             let cancelled = false;
             if (onKeyDownIn !== undefined) {
-                onKeyDownIn({
-                    ...event,
-                    ...(event.location && {
-                        location: [event.location[0] - rowMarkerOffset, event.location[1]] as any,
-                    }),
-                    cancel: () => {
-                        cancelled = true;
-                    },
-                });
+                const publicCell = event.location === undefined ? undefined : toPublicCell(event.location);
+                if (event.location === undefined || publicCell !== undefined) {
+                    onKeyDownIn({
+                        ...event,
+                        ...(publicCell !== undefined && {
+                            location: publicCell as any,
+                        }),
+                        cancel: () => {
+                            cancelled = true;
+                        },
+                    });
+                }
             }
 
             if (cancelled) return;
@@ -3503,6 +3820,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             if (gridSelection.current === undefined) return;
             const [col, row] = gridSelection.current.cell;
             const vr = visibleRegionRef.current;
+            const editDataRow = visualRowToDataRow(Math.max(0, Math.min(row, rows - 1)));
 
             if (
                 editOnType &&
@@ -3512,7 +3830,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 event.key.length === 1 &&
                 /[\p{L}\p{M}\p{N}\p{S}\p{P}]/u.test(event.key) &&
                 event.bounds !== undefined &&
-                isReadWriteCell(getCellContent([col - rowMarkerOffset, Math.max(0, Math.min(row, rows - 1))]))
+                editDataRow !== undefined &&
+                isReadWriteCell(getCellContent([col - rowMarkerOffset, editDataRow]))
             ) {
                 if (
                     (!showTrailingBlankRow || row !== rows) &&
@@ -3524,7 +3843,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     inputType: "keyboard",
                     key: event.key,
                 };
-                onCellActivated?.([col - rowMarkerOffset, row], activationEvent);
+                const publicCell = toPublicCell([col, row]);
+                if (publicCell !== undefined) {
+                    onCellActivated?.(publicCell, activationEvent);
+                }
                 reselect(event.bounds, activationEvent, event.key);
                 event.stopPropagation();
                 event.preventDefault();
@@ -3540,6 +3862,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             rows,
             showTrailingBlankRow,
             onCellActivated,
+            toPublicCell,
+            visualRowToDataRow,
             reselect,
         ]
     );
@@ -3560,12 +3884,16 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
             if (args.kind === "cell") {
                 const [col, row] = args.location;
-                onCellContextMenu?.([adjustedCol, row], {
-                    ...args,
-                    preventDefault,
-                });
+                const publicCell = toPublicCell([col, row]);
+                const publicArgs = toPublicMouseArgs(args);
+                if (publicCell !== undefined && publicArgs !== undefined) {
+                    onCellContextMenu?.(publicCell, {
+                        ...publicArgs,
+                        preventDefault,
+                    });
+                }
 
-                if (!gridSelectionHasItem(gridSelection, args.location)) {
+                if (publicCell !== undefined && !gridSelectionHasItem(gridSelection, args.location)) {
                     updateSelectedCell(col, row, false, false);
                 }
             }
@@ -3576,6 +3904,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             onGroupHeaderContextMenu,
             onHeaderContextMenu,
             rowMarkerOffset,
+            toPublicCell,
+            toPublicMouseArgs,
             updateSelectedCell,
         ]
     );
@@ -3648,12 +3978,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             if (gridSelection.current !== undefined) {
                 target = [gridSelection.current.range.x, gridSelection.current.range.y];
             } else if (selectedColumns.length === 1) {
-                target = [selectedColumns.first() ?? 0, 0];
+                target = [selectedColumns.first() ?? 0, dataRowToVisualRow(0)];
             } else if (selectedRows.length === 1) {
                 target = [rowMarkerOffset, selectedRows.first() ?? 0];
             }
 
             if (focused && target !== undefined) {
+                const publicTarget = toPublicCell(target);
+                if (publicTarget === undefined) return;
                 let data: CopyBuffer | undefined;
                 let text: string | undefined;
 
@@ -3692,7 +4024,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     return; // I didn't want to read that paste value anyway
                 }
 
-                const [targetCol, targetRow] = target;
+                const [targetCol] = target;
 
                 const editList: EditListItem[] = [];
                 do {
@@ -3715,7 +4047,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         onPaste === false ||
                         (typeof onPaste === "function" &&
                             onPaste?.(
-                                [target[0] - rowMarkerOffset, target[1]],
+                                publicTarget,
                                 data.map(r => r.map(cb => cb.rawValue?.toString() ?? ""))
                             ) !== true)
                     ) {
@@ -3723,10 +4055,12 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     }
 
                     for (const [row, dataRow] of data.entries()) {
-                        if (row + targetRow >= rows) break;
+                        const writeDataRow = publicTarget[1] + row;
+                        if (writeDataRow >= rowsPostGrouping) break;
+                        const writeRow = dataRowToVisualRow(writeDataRow);
                         for (const [col, dataItem] of dataRow.entries()) {
-                            const index = [col + targetCol, row + targetRow] as const;
-                            const [writeCol, writeRow] = index;
+                            const index = [col + targetCol, writeRow] as const;
+                            const [writeCol] = index;
                             if (writeCol >= mangledCols.length) continue;
                             if (writeRow >= mangledRows) continue;
                             const cellData = getMangledCellContent(index);
@@ -3760,7 +4094,9 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             mangledRows,
             onPaste,
             rowMarkerOffset,
-            rows,
+            rowsPostGrouping,
+            dataRowToVisualRow,
+            toPublicCell,
         ]
     );
 
@@ -3910,9 +4246,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
     const onSearchResultsChanged = React.useCallback(
         (results: readonly Item[], navIndex: number) => {
             if (onSearchResultsChangedIn !== undefined) {
-                if (rowMarkerOffset !== 0) {
-                    results = results.map(item => [item[0] - rowMarkerOffset, item[1]]);
-                }
+                results = results.flatMap(item => {
+                    const publicCell = toPublicCell(item);
+                    return publicCell === undefined ? [] : [publicCell];
+                });
                 onSearchResultsChangedIn(results, navIndex);
                 return;
             }
@@ -3925,7 +4262,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             lastSent.current = [col, row];
             updateSelectedCell(col, row, false, false);
         },
-        [onSearchResultsChangedIn, rowMarkerOffset, updateSelectedCell]
+        [onSearchResultsChangedIn, toPublicCell, updateSelectedCell]
     );
 
     // this effects purpose in life is to scroll the newly selected cell into view when and ONLY when that cell
@@ -3943,10 +4280,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             (outCol !== expectedExternalGridSelection.current?.current?.cell[0] ||
                 outRow !== expectedExternalGridSelection.current?.current?.cell[1])
         ) {
-            scrollToRef.current(outCol, outRow);
+            scrollToRef.current(outCol, dataRowToVisualRow(outRow));
         }
         hasJustScrolled.current = false; //only allow skipping a single scroll
-    }, [outCol, outRow]);
+    }, [dataRowToVisualRow, outCol, outRow]);
 
     const selectionOutOfBounds =
         gridSelection.current !== undefined &&
@@ -3993,15 +4330,31 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const mangledFreezeColumns = Math.min(mangledCols.length, freezeColumns + (hasRowMarkers ? 1 : 0));
 
+    const scrollToPublic = React.useCallback<ScrollToFn>(
+        (col, row, dir = "both", paddingX = 0, paddingY = 0, options = undefined): void => {
+            let visualRow = row;
+            if (typeof row === "number") {
+                visualRow = dataRowToVisualRow(row);
+            } else if (row !== undefined && row.unit === "cell") {
+                visualRow = {
+                    ...row,
+                    amount: dataRowToVisualRow(row.amount),
+                };
+            }
+            scrollTo(col, visualRow, dir, paddingX, paddingY, options);
+        },
+        [dataRowToVisualRow, scrollTo]
+    );
+
     React.useImperativeHandle(
         forwardedRef,
         () => ({
             appendRow: (col: number, openOverlay?: boolean) => appendRow(col + rowMarkerOffset, openOverlay),
-            appendColumn: (row: number, openOverlay?: boolean) => appendColumn(row, openOverlay),
+            appendColumn: (row: number, openOverlay?: boolean) => appendColumn(dataRowToVisualRow(row), openOverlay),
             updateCells: damageList => {
-                if (rowMarkerOffset !== 0) {
-                    damageList = damageList.map(x => ({ cell: [x.cell[0] + rowMarkerOffset, x.cell[1]] }));
-                }
+                damageList = damageList.map(x => ({
+                    cell: [x.cell[0] + rowMarkerOffset, dataRowToVisualRow(x.cell[1])],
+                }));
                 return gridRef.current?.damage(damageList);
             },
             getBounds: (col, row) => {
@@ -4020,7 +4373,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         height: scrollRef.current.scrollHeight * scale,
                     };
                 }
-                return gridRef.current?.getBounds((col ?? 0) + rowMarkerOffset, row);
+                return gridRef.current?.getBounds(
+                    (col ?? 0) + rowMarkerOffset,
+                    row === undefined ? undefined : dataRowToVisualRow(row)
+                );
             },
             focus: () => gridRef.current?.focus(),
             emit: async e => {
@@ -4081,7 +4437,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         break;
                 }
             },
-            scrollTo,
+            scrollTo: scrollToPublic,
             remeasureColumns: cols => {
                 for (const col of cols) {
                     void normalSizeColumn(col + rowMarkerOffset);
@@ -4101,22 +4457,21 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     return undefined;
                 }
 
-                return {
-                    ...args,
-                    location: [args.location[0] - rowMarkerOffset, args.location[1]] as any,
-                };
+                return toPublicMouseArgs(args);
             },
         }),
         [
             appendRow,
             appendColumn,
+            dataRowToVisualRow,
             normalSizeColumn,
             scrollRef,
             onCopy,
             onKeyDown,
             onPasteInternal,
             rowMarkerOffset,
-            scrollTo,
+            scrollToPublic,
+            toPublicMouseArgs,
         ]
     );
 
@@ -4132,6 +4487,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
                 return;
             }
+            if (getSectionForRow(row) !== undefined) return;
 
             if (selCol === col && selRow === row) return;
             setCurrent(
@@ -4145,7 +4501,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             );
             scrollTo(col, row);
         },
-        [columnSelect, focus, scrollTo, selCol, selRow, setCurrent, setSelectedColumns]
+        [columnSelect, focus, getSectionForRow, scrollTo, selCol, selRow, setCurrent, setSelectedColumns]
     );
 
     const [isFocused, setIsFocused] = React.useState(false);
@@ -4221,7 +4577,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 style={cssStyle}
                 className={className}
                 inWidth={width ?? idealWidth}
-                inHeight={height ?? idealHeight}>
+                inHeight={height ?? idealHeight}
+            >
                 <DataGridSearch
                     fillHandle={fillHandle}
                     drawFocusRing={drawFocusRing}
@@ -4313,6 +4670,23 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     resizeIndicator={resizeIndicator}
                     setScrollDir={setScrollDir}
                 />
+                {stickySection !== undefined && (
+                    <div aria-hidden={true} style={stickySection.clipStyle}>
+                        <div
+                            data-testid="gdg-sticky-section"
+                            style={stickySection.sectionStyle}
+                            onClick={stopStickySectionEvent}
+                            onContextMenu={stopStickySectionEvent}
+                            onMouseDown={stopStickySectionEvent}
+                            onMouseUp={stopStickySectionEvent}
+                            onPointerDown={stopStickySectionEvent}
+                            onPointerUp={stopStickySectionEvent}
+                            onWheel={onStickySectionWheel}
+                        >
+                            {stickySection.title}
+                        </div>
+                    </div>
+                )}
                 {renameGroupNode}
                 {overlay !== undefined && (
                     <React.Suspense fallback={null}>

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3715,31 +3715,35 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             }
             // #endregion
 
-            const mustRestrictRow =
-                sectionRows.length > 0 || (rowGroupingNavBehavior !== undefined && rowGroupingNavBehavior !== "normal");
+            const shouldSkipGroupHeadersUp =
+                rowGroupingNavBehavior === "skip-up" ||
+                rowGroupingNavBehavior === "skip" ||
+                rowGroupingNavBehavior === "block";
+            const shouldSkipGroupHeadersDown =
+                rowGroupingNavBehavior === "skip-down" ||
+                rowGroupingNavBehavior === "skip" ||
+                rowGroupingNavBehavior === "block";
+            const mustRestrictRow = sectionRows.length > 0 || shouldSkipGroupHeadersUp || shouldSkipGroupHeadersDown;
 
             if (mustRestrictRow && row !== startRow) {
-                const skipUp =
-                    sectionRows.length > 0 ||
-                    rowGroupingNavBehavior === "skip-up" ||
-                    rowGroupingNavBehavior === "skip" ||
-                    rowGroupingNavBehavior === "block";
-                const skipDown =
-                    sectionRows.length > 0 ||
-                    rowGroupingNavBehavior === "skip-down" ||
-                    rowGroupingNavBehavior === "skip" ||
-                    rowGroupingNavBehavior === "block";
                 const didMoveUp = row < startRow;
-                if (didMoveUp && skipUp) {
-                    while (row >= 0 && (getSectionForRow(row) !== undefined || mapper(row).isGroupHeader)) {
+                if (didMoveUp) {
+                    while (
+                        row >= 0 &&
+                        (getSectionForRow(row) !== undefined || (shouldSkipGroupHeadersUp && mapper(row).isGroupHeader))
+                    ) {
                         row--;
                     }
 
                     if (row < 0) {
                         row = startRow;
                     }
-                } else if (!didMoveUp && skipDown) {
-                    while (row < rows && (getSectionForRow(row) !== undefined || mapper(row).isGroupHeader)) {
+                } else {
+                    while (
+                        row < rows &&
+                        (getSectionForRow(row) !== undefined ||
+                            (shouldSkipGroupHeadersDown && mapper(row).isGroupHeader))
+                    ) {
                         row++;
                     }
 
@@ -4264,6 +4268,10 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         },
         [onSearchResultsChangedIn, toPublicCell, updateSelectedCell]
     );
+    const mangledSearchResults = React.useMemo(() => {
+        if (searchResults === undefined) return undefined;
+        return searchResults.map(([col, row]) => [col + rowMarkerOffset, dataRowToVisualRow(row)] as const);
+    }, [dataRowToVisualRow, rowMarkerOffset, searchResults]);
 
     // this effects purpose in life is to scroll the newly selected cell into view when and ONLY when that cell
     // is from an external gridSelection change. Also note we want the unmangled out selection because scrollTo
@@ -4656,7 +4664,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     onVisibleRegionChanged={onVisibleRegionChangedImpl}
                     clientSize={clientSize}
                     rowHeight={rowHeight}
-                    searchResults={searchResults}
+                    searchResults={mangledSearchResults}
                     searchValue={searchValue}
                     onSearchValueChange={onSearchValueChange}
                     rows={mangledRows}

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -249,6 +249,10 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
      * @group Events
      */
     readonly onCellClicked?: (cell: Item, event: CellClickedEventArgs) => void;
+    /** Emitted when a section header is clicked.
+     * @group Events
+     */
+    readonly onSectionHeaderClicked?: (section: RowSection, event: CellClickedEventArgs) => void;
     /** Emitted when a cell is activated, by pressing Enter, Space or double clicking it.
      * @group Events
      */
@@ -276,6 +280,10 @@ export interface DataEditorProps extends Props, Pick<DataGridSearchProps, "image
      * @group Events
      */
     readonly onCellContextMenu?: (cell: Item, event: CellClickedEventArgs) => void;
+    /** Emitted when a section header should show a context menu. Usually right click.
+     * @group Events
+     */
+    readonly onSectionHeaderContextMenu?: (section: RowSection, event: CellClickedEventArgs) => void;
     /** Used for validating cell values during editing.
      * @group Editing
      * @param cell The cell which is being validated.
@@ -823,6 +831,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         rows: rowsIn,
         getCellContent,
         onCellClicked,
+        onSectionHeaderClicked,
         onCellActivated,
         onFillPattern,
         onFinishedEditing,
@@ -836,6 +845,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         spanRangeBehavior = "default",
         onGroupHeaderClicked,
         onCellContextMenu,
+        onSectionHeaderContextMenu,
         className,
         onHeaderContextMenu,
         getCellsForSelection: getCellsForSelectionIn,
@@ -1077,6 +1087,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             return { ...args, location: [adjustedCol, row] as any };
         },
         [rowMarkerOffset, visualRowToDataRow]
+    );
+
+    const toPublicSectionMouseArgs = React.useCallback(
+        (args: GridMouseCellEventArgs, section: RowSection): GridMouseCellEventArgs => ({
+            ...args,
+            location: [args.location[0] - rowMarkerOffset, section.row] as Item,
+        }),
+        [rowMarkerOffset]
     );
 
     const expectedExternalGridSelection = React.useRef<GridSelection | undefined>(gridSelectionOuter);
@@ -1380,6 +1398,7 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
         return {
             clipStyle,
+            section: activeSectionRow.section,
             sectionStyle,
             title: activeSectionRow.section.title,
         };
@@ -1399,6 +1418,67 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         event.preventDefault();
         event.stopPropagation();
     }, []);
+
+    const toStickySectionMouseArgs = React.useCallback(
+        (
+            event: React.MouseEvent<HTMLDivElement>,
+            section: RowSection,
+            preventDefault: () => void
+        ): CellClickedEventArgs => {
+            const bounds = event.currentTarget.getBoundingClientRect();
+            return {
+                kind: "cell",
+                location: [0, section.row] as Item,
+                bounds: {
+                    x: bounds.left,
+                    y: bounds.top,
+                    width: bounds.width,
+                    height: bounds.height,
+                },
+                localEventX: event.clientX - bounds.left,
+                localEventY: event.clientY - bounds.top,
+                isFillHandle: false,
+                shiftKey: event.shiftKey,
+                ctrlKey: event.ctrlKey,
+                metaKey: event.metaKey,
+                isTouch: false,
+                isEdge: false,
+                button: event.button,
+                buttons: event.buttons,
+                scrollEdge: [0, 0] as const,
+                preventDefault,
+            };
+        },
+        []
+    );
+
+    const activeStickySection = stickySection?.section;
+
+    const onStickySectionClick = React.useCallback(
+        (event: React.MouseEvent<HTMLDivElement>) => {
+            stopStickySectionEvent(event);
+            if (activeStickySection === undefined) return;
+
+            onSectionHeaderClicked?.(
+                activeStickySection,
+                toStickySectionMouseArgs(event, activeStickySection, () => event.preventDefault())
+            );
+        },
+        [activeStickySection, onSectionHeaderClicked, stopStickySectionEvent, toStickySectionMouseArgs]
+    );
+
+    const onStickySectionContextMenu = React.useCallback(
+        (event: React.MouseEvent<HTMLDivElement>) => {
+            stopStickySectionEvent(event);
+            if (activeStickySection === undefined) return;
+
+            onSectionHeaderContextMenu?.(
+                activeStickySection,
+                toStickySectionMouseArgs(event, activeStickySection, () => event.preventDefault())
+            );
+        },
+        [activeStickySection, onSectionHeaderContextMenu, stopStickySectionEvent, toStickySectionMouseArgs]
+    );
 
     const onStickySectionWheel = React.useCallback(
         (event: React.WheelEvent) => {
@@ -2626,6 +2706,15 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             const handleMaybeClick = (a: GridMouseCellEventArgs): boolean => {
                 const isValidClick = a.isTouch || (lastMouseDownCol === col && lastMouseDownRow === row);
                 if (isValidClick) {
+                    const section = getSectionForRow(a.location[1]);
+                    if (section !== undefined) {
+                        onSectionHeaderClicked?.(section, {
+                            ...toPublicSectionMouseArgs(a, section),
+                            preventDefault,
+                        });
+                        return true;
+                    }
+
                     const publicCell = toPublicCell([col, row]);
                     const publicArgs = toPublicMouseArgs(a);
                     if (publicCell !== undefined && publicArgs !== undefined) {
@@ -2709,6 +2798,17 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 }
                 // take care of context menus first if long pressed item is already selected
                 if (args.isLongTouch === true) {
+                    if (args.kind === "cell") {
+                        const section = getSectionForRow(args.location[1]);
+                        if (section !== undefined) {
+                            onSectionHeaderContextMenu?.(section, {
+                                ...toPublicSectionMouseArgs(args, section),
+                                preventDefault,
+                            });
+                            return;
+                        }
+                    }
+
                     if (args.kind === "cell" && itemsAreEqual(gridSelection.current?.cell, args.location)) {
                         const publicCell = toPublicCell(args.location);
                         const publicArgs = toPublicMouseArgs(args);
@@ -2793,6 +2893,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             onCellClicked,
             toPublicCell,
             toPublicMouseArgs,
+            toPublicSectionMouseArgs,
+            getSectionForRow,
             getMangledCellContent,
             getCellRenderer,
             cellActivationBehavior,
@@ -2801,6 +2903,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
             onCellActivated,
             reselect,
             onCellContextMenu,
+            onSectionHeaderClicked,
+            onSectionHeaderContextMenu,
             onHeaderContextMenu,
             onGroupHeaderContextMenu,
             handleSelect,
@@ -3888,6 +3992,15 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
             if (args.kind === "cell") {
                 const [col, row] = args.location;
+                const section = getSectionForRow(row);
+                if (section !== undefined) {
+                    onSectionHeaderContextMenu?.(section, {
+                        ...toPublicSectionMouseArgs(args, section),
+                        preventDefault,
+                    });
+                    return;
+                }
+
                 const publicCell = toPublicCell([col, row]);
                 const publicArgs = toPublicMouseArgs(args);
                 if (publicCell !== undefined && publicArgs !== undefined) {
@@ -3905,11 +4018,14 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         [
             gridSelection,
             onCellContextMenu,
+            onSectionHeaderContextMenu,
             onGroupHeaderContextMenu,
             onHeaderContextMenu,
+            getSectionForRow,
             rowMarkerOffset,
             toPublicCell,
             toPublicMouseArgs,
+            toPublicSectionMouseArgs,
             updateSelectedCell,
         ]
     );
@@ -4683,8 +4799,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                         <div
                             data-testid="gdg-sticky-section"
                             style={stickySection.sectionStyle}
-                            onClick={stopStickySectionEvent}
-                            onContextMenu={stopStickySectionEvent}
+                            onClick={onStickySectionClick}
+                            onContextMenu={onStickySectionContextMenu}
                             onMouseDown={stopStickySectionEvent}
                             onMouseUp={stopStickySectionEvent}
                             onPointerDown={stopStickySectionEvent}

--- a/packages/core/src/data-editor/row-sections.ts
+++ b/packages/core/src/data-editor/row-sections.ts
@@ -1,0 +1,274 @@
+import * as React from "react";
+import clamp from "lodash/clamp.js";
+import {
+    CompactSelection,
+    type GridSelection,
+    type Rectangle,
+    type Slice,
+} from "../internal/data-grid/data-grid-types.js";
+
+export interface RowSectionBase {
+    readonly row: number;
+}
+
+export interface RowSectionPlacement<T extends RowSectionBase> {
+    readonly section: T;
+    readonly row: number;
+}
+
+function mapCompactSelection(
+    selection: CompactSelection,
+    mapSlice: (slice: Slice) => readonly Slice[]
+): CompactSelection {
+    if (selection.length === 0) return selection;
+    return CompactSelection.create(selection.items.flatMap(mapSlice));
+}
+
+export function useRowSections<T extends RowSectionBase>(sections: readonly T[] | undefined, rowCount: number) {
+    const normalizedSections = React.useMemo(() => {
+        if (sections === undefined || sections.length === 0) return [];
+        return sections
+            .map((section, index) => ({
+                ...section,
+                row: clamp(Math.floor(section.row), 0, rowCount),
+                sourceIndex: index,
+            }))
+            .sort((a, b) => a.row - b.row || a.sourceIndex - b.sourceIndex);
+    }, [rowCount, sections]);
+
+    const sectionRows = React.useMemo<readonly RowSectionPlacement<T>[]>(
+        () =>
+            normalizedSections.map((section, index) => ({
+                section,
+                row: section.row + index,
+            })),
+        [normalizedSections]
+    );
+
+    const visualRowCount = rowCount + sectionRows.length;
+
+    const getSectionForRow = React.useCallback(
+        (row: number): T | undefined => {
+            for (const { section, row: sectionRow } of sectionRows) {
+                if (row === sectionRow) return section;
+                if (row < sectionRow) return undefined;
+            }
+            return undefined;
+        },
+        [sectionRows]
+    );
+
+    const visualRowToDataRow = React.useCallback(
+        (row: number): number | undefined => {
+            let offset = 0;
+            for (const { row: sectionRow } of sectionRows) {
+                if (row === sectionRow) return undefined;
+                if (row < sectionRow) return row - offset;
+                offset++;
+            }
+            return row - sectionRows.length;
+        },
+        [sectionRows]
+    );
+
+    const dataRowToVisualRow = React.useCallback(
+        (row: number): number => {
+            let offset = 0;
+            for (const section of normalizedSections) {
+                if (section.row > row) break;
+                offset++;
+            }
+            return row + offset;
+        },
+        [normalizedSections]
+    );
+
+    const isDataRow = React.useCallback((row: number) => visualRowToDataRow(row) !== undefined, [visualRowToDataRow]);
+
+    const visualSliceToDataSlices = React.useCallback(
+        (slice: Slice): readonly Slice[] => {
+            if (sectionRows.length === 0) return [slice];
+
+            const [start, end] = slice;
+            const slices: Slice[] = [];
+            let current = start;
+
+            for (const { row: sectionRow } of sectionRows) {
+                if (sectionRow < current) continue;
+                if (sectionRow >= end) break;
+
+                if (current < sectionRow) {
+                    const dataStart = visualRowToDataRow(current);
+                    const dataEnd = visualRowToDataRow(sectionRow - 1);
+                    if (dataStart !== undefined && dataEnd !== undefined) {
+                        slices.push([dataStart, dataEnd + 1]);
+                    }
+                }
+                current = sectionRow + 1;
+            }
+
+            if (current < end) {
+                const dataStart = visualRowToDataRow(current);
+                const dataEnd = visualRowToDataRow(end - 1);
+                if (dataStart !== undefined && dataEnd !== undefined) {
+                    slices.push([dataStart, dataEnd + 1]);
+                }
+            }
+
+            return slices;
+        },
+        [sectionRows, visualRowToDataRow]
+    );
+
+    const dataSliceToVisualSlices = React.useCallback(
+        (slice: Slice): readonly Slice[] => {
+            if (sectionRows.length === 0) return [slice];
+
+            const [start, end] = slice;
+            const slices: Slice[] = [];
+            let current = start;
+
+            for (const section of normalizedSections) {
+                if (section.row <= current) continue;
+                if (section.row >= end) break;
+
+                slices.push([dataRowToVisualRow(current), dataRowToVisualRow(section.row - 1) + 1]);
+                current = section.row;
+            }
+
+            if (current < end) {
+                slices.push([dataRowToVisualRow(current), dataRowToVisualRow(end - 1) + 1]);
+            }
+
+            return slices;
+        },
+        [dataRowToVisualRow, normalizedSections, sectionRows.length]
+    );
+
+    const visualRowsToDataRows = React.useCallback(
+        (selection: CompactSelection) => mapCompactSelection(selection, visualSliceToDataSlices),
+        [visualSliceToDataSlices]
+    );
+
+    const dataRowsToVisualRows = React.useCallback(
+        (selection: CompactSelection) => mapCompactSelection(selection, dataSliceToVisualSlices),
+        [dataSliceToVisualSlices]
+    );
+
+    const getVisualRowSelection = React.useCallback(
+        (selection: number | Slice): CompactSelection => {
+            if (sectionRows.length === 0) return CompactSelection.fromSingleSelection(selection);
+
+            const start = typeof selection === "number" ? selection : selection[0];
+            const end = typeof selection === "number" ? selection + 1 : selection[1];
+            return CompactSelection.create(visualSliceToDataSlices([start, end]).flatMap(dataSliceToVisualSlices));
+        },
+        [dataSliceToVisualSlices, sectionRows.length, visualSliceToDataSlices]
+    );
+
+    const dataRectToVisualRect = React.useCallback(
+        (rect: Rectangle): Rectangle => {
+            if (sectionRows.length === 0 || rect.height <= 0) return rect;
+            const start = dataRowToVisualRow(rect.y);
+            const end = dataRowToVisualRow(rect.y + rect.height - 1) + 1;
+            return {
+                ...rect,
+                y: start,
+                height: end - start,
+            };
+        },
+        [dataRowToVisualRow, sectionRows.length]
+    );
+
+    const visualRectToDataRect = React.useCallback(
+        (rect: Rectangle): Rectangle | undefined => {
+            if (sectionRows.length === 0) return rect;
+            if (rect.height <= 0) return undefined;
+
+            let start = rect.y;
+            const end = rect.y + rect.height;
+            while (start < end && visualRowToDataRow(start) === undefined) {
+                start++;
+            }
+            if (start >= end) return undefined;
+
+            let last = end - 1;
+            while (last >= start && visualRowToDataRow(last) === undefined) {
+                last--;
+            }
+            if (last < start) return undefined;
+
+            const dataStart = visualRowToDataRow(start);
+            const dataEnd = visualRowToDataRow(last);
+            if (dataStart === undefined || dataEnd === undefined) return undefined;
+
+            return {
+                ...rect,
+                y: dataStart,
+                height: dataEnd - dataStart + 1,
+            };
+        },
+        [sectionRows.length, visualRowToDataRow]
+    );
+
+    const dataSelectionToVisualSelection = React.useCallback(
+        (selection: GridSelection): GridSelection => {
+            if (sectionRows.length === 0) return selection;
+
+            return {
+                current:
+                    selection.current === undefined
+                        ? undefined
+                        : {
+                              cell: [selection.current.cell[0], dataRowToVisualRow(selection.current.cell[1])],
+                              range: dataRectToVisualRect(selection.current.range),
+                              rangeStack: selection.current.rangeStack.map(dataRectToVisualRect),
+                          },
+                rows: dataRowsToVisualRows(selection.rows),
+                columns: selection.columns,
+            };
+        },
+        [dataRectToVisualRect, dataRowToVisualRow, dataRowsToVisualRows, sectionRows.length]
+    );
+
+    const visualSelectionToDataSelection = React.useCallback(
+        (selection: GridSelection): GridSelection => {
+            if (sectionRows.length === 0) return selection;
+
+            const currentDataRow =
+                selection.current === undefined ? undefined : visualRowToDataRow(selection.current.cell[1]);
+            const currentRange =
+                selection.current === undefined ? undefined : visualRectToDataRect(selection.current.range);
+
+            return {
+                current:
+                    selection.current === undefined || currentDataRow === undefined || currentRange === undefined
+                        ? undefined
+                        : {
+                              cell: [selection.current.cell[0], currentDataRow],
+                              range: currentRange,
+                              rangeStack: selection.current.rangeStack.flatMap(r => {
+                                  const dataRect = visualRectToDataRect(r);
+                                  return dataRect === undefined ? [] : [dataRect];
+                              }),
+                          },
+                rows: visualRowsToDataRows(selection.rows),
+                columns: selection.columns,
+            };
+        },
+        [sectionRows.length, visualRectToDataRect, visualRowToDataRow, visualRowsToDataRows]
+    );
+
+    return {
+        dataRowToVisualRow,
+        dataSelectionToVisualSelection,
+        getSectionForRow,
+        getVisualRowSelection,
+        isDataRow,
+        sectionRows,
+        visualRectToDataRect,
+        visualRowCount,
+        visualRowToDataRow,
+        visualSelectionToDataSelection,
+    };
+}

--- a/packages/core/src/data-editor/use-cells-for-selection.ts
+++ b/packages/core/src/data-editor/use-cells-for-selection.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { DataGridSearchProps } from "../internal/data-grid-search/data-grid-search.js";
-import { type CellArray, type GridCell, GridCellKind } from "../internal/data-grid/data-grid-types.js";
+import { type CellArray, type GridCell, GridCellKind, type Rectangle } from "../internal/data-grid/data-grid-types.js";
 import type { DataEditorProps } from "./data-editor.js";
 
 type CellsForSelectionCallback = NonNullable<DataGridSearchProps["getCellsForSelection"]>;
@@ -9,7 +9,8 @@ export function useCellsForSelection(
     getCellContent: DataEditorProps["getCellContent"],
     rowMarkerOffset: number,
     abortController: AbortController,
-    rows: number
+    rows: number,
+    mapRectangleToDataRectangle: (rect: Rectangle) => Rectangle | undefined
 ) {
     const getCellsForSelectionDirectWhenValid = React.useCallback<CellsForSelectionCallback>(
         rect => {
@@ -42,9 +43,11 @@ export function useCellsForSelection(
     const getCellsForSelectionMangled = React.useCallback<CellsForSelectionCallback>(
         rect => {
             if (getCellsForSelectionDirect === undefined) return [];
+            const dataRect = mapRectangleToDataRectangle(rect);
+            if (dataRect === undefined) return [];
             const newRect = {
-                ...rect,
-                x: rect.x - rowMarkerOffset,
+                ...dataRect,
+                x: dataRect.x - rowMarkerOffset,
             };
             if (newRect.x < 0) {
                 newRect.x = 0;
@@ -63,7 +66,7 @@ export function useCellsForSelection(
             }
             return getCellsForSelectionDirect(newRect, abortController.signal);
         },
-        [abortController.signal, getCellsForSelectionDirect, rowMarkerOffset]
+        [abortController.signal, getCellsForSelectionDirect, mapRectangleToDataRectangle, rowMarkerOffset]
     );
 
     const getCellsForSelection = getCellsForSelectionIn !== undefined ? getCellsForSelectionMangled : undefined;

--- a/packages/core/src/docs/examples/sections.stories.tsx
+++ b/packages/core/src/docs/examples/sections.stories.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { DataEditorAll as DataEditor } from "../../data-editor-all.js";
+import {
+    BeautifulWrapper,
+    Description,
+    PropName,
+    useMockDataGenerator,
+    defaultProps,
+} from "../../data-editor/stories/utils.js";
+import { SimpleThemeWrapper } from "../../stories/story-utils.js";
+
+export default {
+    title: "Glide-Data-Grid/DataEditor Demos",
+
+    decorators: [
+        (Story: React.ComponentType) => (
+            <SimpleThemeWrapper>
+                <BeautifulWrapper
+                    title="Sections"
+                    description={
+                        <>
+                            <Description>
+                                Group rows into sections using the <PropName>sections</PropName> prop.
+                                Use <PropName>sticky</PropName> on a section to keep it pinned while scrolling.
+                                Set <PropName>stickyStyle</PropName> to <PropName>frosted</PropName> for a
+                                translucent sticky header.
+                            </Description>
+                        </>
+                    }
+                >
+                    <Story />
+                </BeautifulWrapper>
+            </SimpleThemeWrapper>
+        ),
+    ],
+};
+
+export const Sections: React.VFC = () => {
+    const { cols, getCellContent } = useMockDataGenerator(10, false);
+
+    return (
+        <DataEditor
+            {...defaultProps}
+            getCellContent={getCellContent}
+            verticalBorder={false}
+            rowMarkers="none"
+            smoothScrollY={true}
+            sections={[
+                { row: 0, title: "New (24)", sticky: true },
+                {
+                    row: 24,
+                    title: "In work (42)",
+                    sticky: true,
+                    stickyStyle: "frosted",
+                    themeOverride: {
+                        bgGroupHeader: "#eef7f1",
+                        textGroupHeader: "#1f5131",
+                        borderColor: "#b9dec6",
+                        headerFontStyle: "600 14px",
+                    },
+                },
+                { row: 66, title: "Agreed (33)", sticky: true },
+                { row: 99, title: "Archived (18)", sticky: true },
+            ]}
+            columns={cols}
+            rows={400}
+        />
+    );
+};

--- a/packages/core/src/docs/examples/sections.stories.tsx
+++ b/packages/core/src/docs/examples/sections.stories.tsx
@@ -20,10 +20,10 @@ export default {
                     description={
                         <>
                             <Description>
-                                Group rows into sections using the <PropName>sections</PropName> prop.
-                                Use <PropName>sticky</PropName> on a section to keep it pinned while scrolling.
-                                Set <PropName>stickyStyle</PropName> to <PropName>frosted</PropName> for a
-                                translucent sticky header.
+                                Group rows into sections using the <PropName>sections</PropName> prop. Use{" "}
+                                <PropName>sticky</PropName> on a section to keep it pinned while scrolling. Set{" "}
+                                <PropName>stickyStyle</PropName> to <PropName>frosted</PropName> for a translucent
+                                sticky header.
                             </Description>
                         </>
                     }
@@ -64,6 +64,38 @@ export const Sections: React.VFC = () => {
             ]}
             columns={cols}
             rows={400}
+        />
+    );
+};
+
+export const SectionsWithFrozenColumns: React.VFC = () => {
+    const { cols, getCellContent } = useMockDataGenerator(10, false);
+
+    return (
+        <DataEditor
+            {...defaultProps}
+            getCellContent={getCellContent}
+            freezeColumns={1}
+            verticalBorder={false}
+            rowMarkers="none"
+            smoothScrollY={true}
+            sections={[
+                {
+                    row: 0,
+                    title: "Frozen first column - this section title should continue cleanly across the scrollable columns (24)",
+                    sticky: true,
+                    themeOverride: {
+                        bgGroupHeader: "#eef4ff",
+                        textGroupHeader: "#1f3763",
+                        borderColor: "#b8c9eb",
+                        headerFontStyle: "600 14px",
+                    },
+                },
+                { row: 24, title: "In work (42)", sticky: true },
+                { row: 66, title: "Agreed (33)", sticky: true },
+            ]}
+            columns={cols}
+            rows={200}
         />
     );
 };

--- a/packages/core/src/docs/examples/sections.stories.tsx
+++ b/packages/core/src/docs/examples/sections.stories.tsx
@@ -49,7 +49,7 @@ export const Sections: React.VFC = () => {
                 { row: 0, title: "New (24)", sticky: true },
                 {
                     row: 24,
-                    title: "In work (42)",
+                    title: "In work - lots awaiting buyer review, supplier confirmation, and settlement approval (42)",
                     sticky: true,
                     stickyStyle: "frosted",
                     themeOverride: {

--- a/packages/core/src/docs/examples/sections.stories.tsx
+++ b/packages/core/src/docs/examples/sections.stories.tsx
@@ -9,6 +9,9 @@ import {
 } from "../../data-editor/stories/utils.js";
 import { SimpleThemeWrapper } from "../../stories/story-utils.js";
 
+const inWorkTitle = "In work (42)";
+const agreedTitle = "Agreed (33)";
+
 export default {
     title: "Glide-Data-Grid/DataEditor Demos",
 
@@ -59,7 +62,7 @@ export const Sections: React.VFC = () => {
                         headerFontStyle: "600 14px",
                     },
                 },
-                { row: 66, title: "Agreed (33)", sticky: true },
+                { row: 66, title: agreedTitle, sticky: true },
                 { row: 99, title: "Archived (18)", sticky: true },
             ]}
             columns={cols}
@@ -91,8 +94,41 @@ export const SectionsWithFrozenColumns: React.VFC = () => {
                         headerFontStyle: "600 14px",
                     },
                 },
-                { row: 24, title: "In work (42)", sticky: true },
-                { row: 66, title: "Agreed (33)", sticky: true },
+                { row: 24, title: inWorkTitle, sticky: true },
+                { row: 66, title: agreedTitle, sticky: true },
+            ]}
+            columns={cols}
+            rows={200}
+        />
+    );
+};
+
+export const SectionsWithFrozenColumnBorders: React.VFC = () => {
+    const { cols, getCellContent } = useMockDataGenerator(10, false);
+
+    return (
+        <DataEditor
+            {...defaultProps}
+            getCellContent={getCellContent}
+            freezeColumns={1}
+            verticalBorder={true}
+            rowMarkers="none"
+            smoothScrollX={true}
+            smoothScrollY={true}
+            sections={[
+                {
+                    row: 0,
+                    title: "Frozen first column with vertical borders - no divider should cross this section",
+                    sticky: true,
+                    themeOverride: {
+                        bgGroupHeader: "#fff5e6",
+                        textGroupHeader: "#5a3b07",
+                        borderColor: "#e0c184",
+                        headerFontStyle: "600 14px",
+                    },
+                },
+                { row: 24, title: inWorkTitle, sticky: true },
+                { row: 66, title: agreedTitle, sticky: true },
             ]}
             columns={cols}
             rows={200}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,7 +45,7 @@ export { CellSet } from "./internal/data-grid/cell-set.js";
 export { getDataEditorTheme as getDefaultTheme, useTheme } from "./common/styles.js";
 export { useColumnSizer } from "./data-editor/use-column-sizer.js";
 
-export type { DataEditorRef } from "./data-editor/data-editor.js";
+export type { DataEditorRef, RowSection } from "./data-editor/data-editor.js";
 export { DataEditorAll as DataEditor } from "./data-editor-all.js";
 export type { DataEditorAllProps as DataEditorProps } from "./data-editor-all.js";
 export { emptyGridSelection } from "./data-editor/data-editor.js";

--- a/packages/core/src/internal/data-grid/data-grid-types.ts
+++ b/packages/core/src/internal/data-grid/data-grid-types.ts
@@ -254,7 +254,11 @@ export function isTextEditableGridCell(cell: GridCell): cell is ReadWriteGridCel
 
 /** @category Cells */
 export function isInnerOnlyCell(cell: InnerGridCell): cell is InnerOnlyGridCell {
-    return cell.kind === InnerGridCellKind.Marker || cell.kind === InnerGridCellKind.NewRow;
+    return (
+        cell.kind === InnerGridCellKind.Marker ||
+        cell.kind === InnerGridCellKind.NewRow ||
+        cell.kind === InnerGridCellKind.Section
+    );
 }
 
 /** @category Cells */
@@ -284,7 +288,7 @@ export type GridCell =
     | DrilldownCell
     | CustomCell;
 
-type InnerOnlyGridCell = NewRowCell | MarkerCell;
+type InnerOnlyGridCell = NewRowCell | MarkerCell | SectionCell;
 /** @category Cells */
 export type InnerGridCell = GridCell | InnerOnlyGridCell;
 
@@ -497,6 +501,7 @@ export interface UriCell extends BaseGridCell {
 export enum InnerGridCellKind {
     NewRow = "new-row",
     Marker = "marker",
+    Section = "section",
 }
 
 export type EditListItem = { location: Item; value: EditableGridCell };
@@ -518,6 +523,13 @@ export interface MarkerCell extends BaseGridCell {
     readonly checked: boolean;
     readonly checkboxStyle: "square" | "circle";
     readonly markerKind: "checkbox" | "number" | "both" | "checkbox-visible";
+}
+
+/** @category Cells */
+export interface SectionCell extends BaseGridCell {
+    readonly kind: InnerGridCellKind.Section;
+    readonly allowOverlay: false;
+    readonly title: string;
 }
 
 /** @category Selection */

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -9,6 +9,7 @@ import {
     rectBottomRight,
     useMappedColumns,
 } from "./render/data-grid-lib.js";
+import { walkRowsInCol } from "./render/data-grid-render.walk.js";
 import {
     GridCellKind,
     type Rectangle,
@@ -332,6 +333,65 @@ const getRowData = (cell: InnerGridCell, getCellRenderer?: GetCellRendererCallba
     const r = getCellRenderer?.(cell);
     return r?.getAccessibilityString(cell) ?? "";
 };
+
+interface ShadowSegment {
+    readonly top: number;
+    readonly height: number;
+}
+
+function getStickyShadowSegments(
+    height: number,
+    totalHeaderHeight: number,
+    translateY: number,
+    cellYOffset: number,
+    rows: number,
+    getRowHeight: (row: number) => number,
+    freezeTrailingRows: number,
+    hasAppendRow: boolean,
+    getCellContent: (cell: Item, forceStrict?: boolean) => InnerGridCell
+): readonly ShadowSegment[] {
+    const excluded: { top: number; bottom: number }[] = [];
+    const sectionCell: [number, number] = [0, 0];
+
+    walkRowsInCol(
+        cellYOffset,
+        totalHeaderHeight + translateY,
+        height,
+        rows,
+        getRowHeight,
+        freezeTrailingRows,
+        hasAppendRow,
+        undefined,
+        (drawY, row, rh) => {
+            if (row < 0) return;
+
+            sectionCell[1] = row;
+            if (getCellContent(sectionCell).kind !== InnerGridCellKind.Section) return;
+
+            const top = Math.max(0, drawY);
+            const bottom = Math.min(height, drawY + rh);
+            if (bottom > top) {
+                excluded.push({ top, bottom });
+            }
+        }
+    );
+
+    if (excluded.length === 0) return [{ top: 0, height }];
+
+    const segments: ShadowSegment[] = [];
+    let top = 0;
+    for (const section of excluded) {
+        if (section.top > top) {
+            segments.push({ top, height: section.top - top });
+        }
+        top = Math.max(top, section.bottom);
+    }
+    if (top < height) {
+        segments.push({ top, height: height - top });
+    }
+
+    return segments;
+}
 
 const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p, forwardedRef) => {
     const {
@@ -1765,7 +1825,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                     role="grid"
                     aria-rowcount={rows + 1}
                     aria-multiselectable="true"
-                    aria-colcount={mappedColumns.length + colOffset}>
+                    aria-colcount={mappedColumns.length + colOffset}
+                >
                     <thead role="rowgroup">
                         <tr role="row" aria-rowindex={1}>
                             {effectiveCols.map(c => (
@@ -1778,7 +1839,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                         if (e.target === focusRef.current) return;
                                         return onCellFocused?.([c.sourceIndex, -1]);
                                     }}
-                                    key={c.sourceIndex}>
+                                    key={c.sourceIndex}
+                                >
                                     {c.title}
                                 </th>
                             ))}
@@ -1790,7 +1852,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                 role="row"
                                 aria-selected={selection.rows.hasIndex(row)}
                                 key={row}
-                                aria-rowindex={row + 2}>
+                                aria-rowindex={row + 2}
+                            >
                                 {effectiveCols.map(c => {
                                     const col = c.sourceIndex;
                                     const key = packColRowToNumber(col, row);
@@ -1844,7 +1907,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                                 return onCellFocused?.(location);
                                             }}
                                             ref={focused ? focusElement : undefined}
-                                            tabIndex={-1}>
+                                            tabIndex={-1}
+                                        >
                                             {getRowData(cellContent, getCellRenderer)}
                                         </td>
                                     );
@@ -1880,6 +1944,33 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
 
     const absoluteOffsetY = -cellYOffset * 32 + translateY;
     const opacityY = !fixedShadowY ? 0 : clamp(-absoluteOffsetY / 100, 0, 1);
+    const shadowXSegments = React.useMemo(() => {
+        if (opacityX <= 0) return [{ top: 0, height }];
+
+        const getRowHeight = typeof rowHeight === "number" ? () => rowHeight : rowHeight;
+        return getStickyShadowSegments(
+            height,
+            totalHeaderHeight,
+            translateY,
+            cellYOffset,
+            rows,
+            getRowHeight,
+            freezeTrailingRows,
+            hasAppendRow,
+            getCellContent
+        );
+    }, [
+        cellYOffset,
+        freezeTrailingRows,
+        getCellContent,
+        hasAppendRow,
+        height,
+        opacityX,
+        rowHeight,
+        rows,
+        totalHeaderHeight,
+        translateY,
+    ]);
 
     const stickyShadow = React.useMemo(() => {
         if (!opacityX && !opacityY) {
@@ -1895,6 +1986,12 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             opacity: opacityX,
             pointerEvents: "none",
             transition: !smoothScrollX ? "opacity 0.2s" : undefined,
+        };
+
+        const styleXSegment: React.CSSProperties = {
+            position: "absolute",
+            left: 0,
+            width: "100%",
             boxShadow: "inset 13px 0 10px -13px rgba(0, 0, 0, 0.2)",
         };
 
@@ -1912,11 +2009,24 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
 
         return (
             <>
-                {opacityX > 0 && <div id="shadow-x" style={styleX} />}
+                {opacityX > 0 && (
+                    <div id="shadow-x" style={styleX}>
+                        {shadowXSegments.map((segment, index) => (
+                            <div
+                                key={index}
+                                style={{
+                                    ...styleXSegment,
+                                    top: segment.top,
+                                    height: segment.height,
+                                }}
+                            />
+                        ))}
+                    </div>
+                )}
                 {opacityY > 0 && <div id="shadow-y" style={styleY} />}
             </>
         );
-    }, [opacityX, opacityY, stickyX, width, smoothScrollX, totalHeaderHeight, height, smoothScrollY]);
+    }, [opacityX, opacityY, stickyX, width, height, smoothScrollX, totalHeaderHeight, smoothScrollY, shadowXSegments]);
 
     const overlayStyle = React.useMemo<React.CSSProperties>(
         () => ({
@@ -1937,7 +2047,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                 onFocus={onCanvasFocused}
                 onBlur={onCanvasBlur}
                 ref={refImpl}
-                style={style}>
+                style={style}
+            >
                 {accessibilityTree}
             </canvas>
             <canvas ref={overlayRef} style={overlayStyle} />

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -60,6 +60,14 @@ export interface Highlight {
     readonly style?: "dashed" | "solid" | "no-outline" | "solid-outline";
 }
 
+function getSpanStartX(startCol: number, allColumns: readonly MappedGridColumn[]): number {
+    let x = 0;
+    for (let index = 0; index < startCol; index++) {
+        x += allColumns[index].width;
+    }
+    return x;
+}
+
 // preppable items:
 // - font
 // - fillStyle
@@ -234,6 +242,7 @@ export function drawCells(
                             const frozenArea = areas[0];
                             const scrollableArea = areas[1];
                             const area = c.sticky ? frozenArea : scrollableArea;
+                            const spanStartX = getSpanStartX(startCol, allColumns);
                             const splitSectionSpan =
                                 cell.kind === InnerGridCellKind.Section &&
                                 frozenArea !== undefined &&
@@ -244,10 +253,10 @@ export function drawCells(
                             if (area !== undefined) {
                                 cellX = area.x;
                                 cellWidth = area.width;
-                                if (!c.sticky && splitSectionSpan && frozenArea !== undefined) {
+                                if (!c.sticky && splitSectionSpan) {
                                     cellForDraw = {
                                         ...cell,
-                                        titleOffset: frozenArea.x - area.x,
+                                        titleOffset: spanStartX - area.x,
                                     } as InnerGridCell;
                                 }
                                 handledSpans.add(spanKey);

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -257,13 +257,14 @@ export function drawCells(
                                 ctx.beginPath();
                                 const d = Math.max(0, clipX - area.x);
                                 ctx.rect(area.x + d, drawY, area.width - d, rh);
+                                const gridLineClipOverlap = !c.sticky && splitSectionSpan ? 1 : 0;
                                 if (result === undefined) {
                                     result = [];
                                 }
                                 result.push({
-                                    x: area.x + d,
+                                    x: area.x + d - gridLineClipOverlap,
                                     y: drawY,
-                                    width: area.width - d,
+                                    width: area.width - d + gridLineClipOverlap,
                                     height: rh,
                                 });
                                 ctx.clip();

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -9,6 +9,7 @@ import {
     type Item,
     type CellList,
     GridCellKind,
+    InnerGridCellKind,
     type DrawCellCallback,
     isInnerOnlyCell,
     type GridCell,
@@ -221,6 +222,7 @@ export function drawCells(
 
                     let cellX = drawX;
                     let cellWidth = c.width;
+                    let cellForDraw = cell;
                     let drawingSpan = false;
                     let skipContents = false;
                     if (cell.span !== undefined) {
@@ -229,13 +231,25 @@ export function drawCells(
                         if (handledSpans === undefined) handledSpans = new Set();
                         if (!handledSpans.has(spanKey)) {
                             const areas = getSpanBounds(cell.span, drawX, drawY, c.width, rh, c, allColumns);
-                            const area = c.sticky ? areas[0] : areas[1];
-                            if (!c.sticky && areas[0] !== undefined) {
+                            const frozenArea = areas[0];
+                            const scrollableArea = areas[1];
+                            const area = c.sticky ? frozenArea : scrollableArea;
+                            const splitSectionSpan =
+                                cell.kind === InnerGridCellKind.Section &&
+                                frozenArea !== undefined &&
+                                scrollableArea !== undefined;
+                            if (!c.sticky && frozenArea !== undefined && !splitSectionSpan) {
                                 skipContents = true;
                             }
                             if (area !== undefined) {
                                 cellX = area.x;
                                 cellWidth = area.width;
+                                if (!c.sticky && splitSectionSpan && frozenArea !== undefined) {
+                                    cellForDraw = {
+                                        ...cell,
+                                        titleOffset: frozenArea.x - area.x,
+                                    } as InnerGridCell;
+                                }
                                 handledSpans.add(spanKey);
                                 ctx.restore();
                                 prepResult = undefined;
@@ -399,7 +413,7 @@ export function drawCells(
                         }
                         prepResult = drawCell(
                             ctx,
-                            cell,
+                            cellForDraw,
                             c.sourceIndex,
                             row,
                             isLastColumn,

--- a/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.lines.ts
@@ -1,6 +1,12 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable unicorn/no-for-loop */
-import { type Rectangle, CompactSelection } from "../data-grid-types.js";
+import {
+    type Rectangle,
+    CompactSelection,
+    InnerGridCellKind,
+    type InnerGridCell,
+    type Item,
+} from "../data-grid-types.js";
 import { CellSet } from "../cell-set.js";
 import groupBy from "lodash/groupBy.js";
 import { getStickyWidth, type MappedGridColumn, getFreezeTrailingHeight } from "./data-grid-lib.js";
@@ -111,8 +117,12 @@ export function overdrawStickyBoundaries(
     height: number,
     freezeTrailingRows: number,
     rows: number,
+    totalHeaderHeight: number,
+    translateY: number,
+    cellYOffset: number,
     verticalBorder: (col: number) => boolean,
     getRowHeight: (row: number) => number,
+    getCellContent: (cell: Item) => InnerGridCell,
     theme: FullTheme
 ) {
     let drawFreezeBorder = false;
@@ -129,8 +139,33 @@ export function overdrawStickyBoundaries(
     if (drawX !== 0) {
         vStroke = blendCache(vColor, theme.bgCell);
         ctx.beginPath();
-        ctx.moveTo(drawX + 0.5, 0);
-        ctx.lineTo(drawX + 0.5, height);
+        const x = drawX + 0.5;
+        let segmentStart = 0;
+        const drawSegment = (toY: number) => {
+            if (toY <= segmentStart) return;
+            ctx.moveTo(x, segmentStart);
+            ctx.lineTo(x, toY);
+        };
+
+        walkRowsInCol(
+            cellYOffset,
+            totalHeaderHeight + translateY,
+            height,
+            rows,
+            getRowHeight,
+            freezeTrailingRows,
+            false,
+            undefined,
+            (drawY, row, rh) => {
+                if (getCellContent([0, row]).kind !== InnerGridCellKind.Section) return;
+
+                const sectionTop = Math.max(segmentStart, drawY);
+                const sectionBottom = Math.min(height, drawY + rh);
+                drawSegment(sectionTop);
+                segmentStart = Math.max(segmentStart, sectionBottom);
+            }
+        );
+        drawSegment(height);
         ctx.strokeStyle = vStroke;
         ctx.stroke();
     }

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -443,7 +443,8 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
             const selectionCurrent = selection.current;
 
             if (
-                (fillHandle !== false && fillHandle !== undefined) &&
+                fillHandle !== false &&
+                fillHandle !== undefined &&
                 drawFocus &&
                 selectionCurrent !== undefined &&
                 damage.has(rectBottomRight(selectionCurrent.range))
@@ -561,8 +562,12 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
         height,
         freezeTrailingRows,
         rows,
+        totalHeaderHeight,
+        translateY,
+        cellYOffset,
         verticalBorder,
         getRowHeight,
+        getCellContent,
         theme
     );
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable unicorn/no-for-loop */
-import { type Rectangle } from "../data-grid-types.js";
+import { InnerGridCellKind, type Rectangle } from "../data-grid-types.js";
 import { CellSet } from "../cell-set.js";
 import { getEffectiveColumns, type MappedGridColumn, rectBottomRight } from "./data-grid-lib.js";
 import { blend } from "../color-parser.js";
@@ -110,6 +110,45 @@ function getLastRow(
         }
     );
     return result;
+}
+
+function addVisibleSectionRowsToDrawRegions(
+    drawRegions: Rectangle[],
+    width: number,
+    height: number,
+    totalHeaderHeight: number,
+    translateY: number,
+    cellYOffset: number,
+    rows: number,
+    getRowHeight: (row: number) => number,
+    freezeTrailingRows: number,
+    hasAppendRow: boolean,
+    getCellContent: DrawGridArg["getCellContent"]
+): void {
+    const cell: [number, number] = [0, 0];
+    walkRowsInCol(
+        cellYOffset,
+        totalHeaderHeight + translateY,
+        height,
+        rows,
+        getRowHeight,
+        freezeTrailingRows,
+        hasAppendRow,
+        undefined,
+        (drawY, row, rh) => {
+            if (row < 0) return;
+
+            cell[1] = row;
+            if (getCellContent(cell).kind !== InnerGridCellKind.Section) return;
+
+            drawRegions.push({
+                x: 0,
+                y: drawY,
+                width,
+                height: rh,
+            });
+        }
+    );
 }
 
 export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
@@ -516,6 +555,7 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
 
     if (canBlit === true) {
         assert(blitSource !== undefined && last !== undefined);
+        const horizontalScroll = cellXOffset !== last.cellXOffset || translateX !== last.translateX;
         const { regions } = blitLastFrame(
             targetCtx,
             blitSource,
@@ -538,6 +578,22 @@ export function drawGrid(arg: DrawGridArg, lastArg: DrawGridArg | undefined) {
             doubleBuffer
         );
         drawRegions = regions;
+        if (horizontalScroll && drawRegions.length > 0) {
+            // Section titles can be screen-anchored across frozen splits, so shifted pixels must be cleared.
+            addVisibleSectionRowsToDrawRegions(
+                drawRegions,
+                width,
+                height,
+                totalHeaderHeight,
+                translateY,
+                cellYOffset,
+                rows,
+                getRowHeight,
+                freezeTrailingRows,
+                hasAppendRow,
+                getCellContent
+            );
+        }
     } else if (canBlit !== false) {
         assert(last !== undefined);
         const resizedCol = canBlit;

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3087,6 +3087,52 @@ describe("data-editor", () => {
         expect(spy).not.toHaveBeenCalled();
     });
 
+    test("Section rows emit click and context menu callbacks", async () => {
+        const clickSpy = vi.fn();
+        const contextSpy = vi.fn();
+        const selectionSpy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                onSectionHeaderClicked={clickSpy}
+                onSectionHeaderContextMenu={contextSpy}
+                onGridSelectionChange={selectionSpy}
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep();
+        assert(scroller !== null);
+        selectionSpy.mockClear();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 22, // Section row
+        });
+
+        expect(clickSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ row: 2, title: "Section" }),
+            expect.objectContaining({ kind: "cell", location: [1, 2] })
+        );
+        expect(selectionSpy).not.toHaveBeenCalled();
+
+        fireEvent.contextMenu(scroller, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 22, // Section row
+        });
+
+        expect(contextSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ row: 2, title: "Section" }),
+            expect.objectContaining({ kind: "cell", location: [1, 2] })
+        );
+        expect(selectionSpy).not.toHaveBeenCalled();
+    });
+
     test("Rows after sections report data row indexes", async () => {
         const clickSpy = vi.fn();
         const selectionSpy = vi.fn();
@@ -3321,11 +3367,15 @@ describe("data-editor", () => {
 
     test("Sticky sections pin while scrolling", async () => {
         const spy = vi.fn();
+        const clickSpy = vi.fn();
+        const contextSpy = vi.fn();
         vi.useFakeTimers();
         render(
             <EventedDataEditor
                 {...basicProps}
                 onGridSelectionChange={spy}
+                onSectionHeaderClicked={clickSpy}
+                onSectionHeaderContextMenu={contextSpy}
                 rowMarkers="none"
                 smoothScrollY={true}
                 sections={[
@@ -3354,6 +3404,18 @@ describe("data-editor", () => {
         spy.mockClear();
         sendClick(stickySection);
 
+        expect(clickSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ row: 0, title: "Sticky A" }),
+            expect.objectContaining({ kind: "cell", location: [0, 0] })
+        );
+        expect(spy).not.toHaveBeenCalled();
+
+        fireEvent.contextMenu(stickySection);
+
+        expect(contextSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ row: 0, title: "Sticky A" }),
+            expect.objectContaining({ kind: "cell", location: [0, 0] })
+        );
         expect(spy).not.toHaveBeenCalled();
 
         act(() => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3159,6 +3159,50 @@ describe("data-editor", () => {
         expect(screen.getByTestId("glide-cell-1-2").getAttribute("aria-selected")).toBe("false");
     });
 
+    test("Controlled search results use data row indexes with sections", async () => {
+        const selectionSpy = vi.fn();
+        const ControlledSearch = () => {
+            const [results, setResults] = React.useState<readonly Item[] | undefined>();
+            React.useEffect(() => {
+                setResults([[1, 2]]);
+            }, []);
+
+            return (
+                <EventedDataEditor
+                    {...basicProps}
+                    rows={5}
+                    onGridSelectionChange={selectionSpy}
+                    sections={[{ row: 2, title: "Section" }]}
+                    showSearch={true}
+                    searchResults={results}
+                />
+            );
+        };
+
+        vi.useFakeTimers();
+        render(<ControlledSearch />, {
+            wrapper: Context,
+        });
+        prep();
+
+        const searchInput = screen.getByTestId("search-input");
+        expect((await screen.findByTestId("search-result-area")).textContent).toBe("1 result");
+
+        selectionSpy.mockClear();
+        fireEvent.keyDown(searchInput, {
+            key: "Enter",
+        });
+
+        expect(selectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                current: expect.objectContaining({
+                    cell: [1, 2],
+                    range: { x: 1, y: 2, width: 1, height: 1 },
+                }),
+            })
+        );
+    });
+
     test("Sections map edited cells and validation to data rows", async () => {
         const editSpy = vi.fn();
         const validateSpy = vi.fn(() => true);
@@ -3319,6 +3363,48 @@ describe("data-editor", () => {
         });
 
         expect(screen.getByTestId("gdg-sticky-section").textContent).toBe("Sticky B");
+    });
+
+    test("Sections do not force normal row group navigation to skip group headers", async () => {
+        const selectionSpy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={4}
+                onGridSelectionChange={selectionSpy}
+                rowGrouping={{
+                    groups: [{ headerIndex: 0, isCollapsed: false }],
+                    height: 32,
+                    navigationBehavior: "normal",
+                }}
+                sections={[{ row: 1, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 + 44 + 16, // First data row after group header and section row
+        });
+
+        selectionSpy.mockClear();
+        fireEvent.keyDown(canvas, {
+            key: "ArrowUp",
+        });
+
+        expect(selectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                current: expect.objectContaining({
+                    cell: [1, 0],
+                    range: { x: 1, y: 0, width: 1, height: 1 },
+                }),
+            })
+        );
     });
 
     test("Shift click row marker", async () => {

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -8,6 +8,7 @@ import {
     GridCellKind,
     isSizedGridColumn,
     type Item,
+    type Rectangle,
     markerCellRenderer,
     type InnerGridCell,
     type InternalCellRenderer,
@@ -3057,6 +3058,267 @@ describe("data-editor", () => {
             rows: CompactSelection.fromSingleSelection(2),
             current: undefined,
         });
+    });
+
+    test("Section rows are not selectable through row markers", async () => {
+        const spy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                onGridSelectionChange={spy}
+                rowMarkers="both"
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+        spy.mockClear();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 10, // Row marker
+            clientY: 36 + 32 * 2 + 22, // Section row
+        });
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    test("Rows after sections report data row indexes", async () => {
+        const clickSpy = vi.fn();
+        const selectionSpy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                onCellClicked={clickSpy}
+                onGridSelectionChange={selectionSpy}
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 44 + 16, // Data row 2 after the section row
+        });
+
+        expect(clickSpy).toHaveBeenCalledWith([1, 2], expect.anything());
+        expect(selectionSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                current: expect.objectContaining({
+                    cell: [1, 2],
+                    range: { x: 1, y: 2, width: 1, height: 1 },
+                }),
+            })
+        );
+
+        clickSpy.mockClear();
+        selectionSpy.mockClear();
+        sendClick(canvas, {
+            clientX: 300,
+            clientY: 36 + 32 * 2 + 22, // Section row
+        });
+
+        expect(clickSpy).not.toHaveBeenCalled();
+        expect(selectionSpy).not.toHaveBeenCalled();
+    });
+
+    test("Controlled selections use data row indexes with sections", async () => {
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                sections={[{ row: 2, title: "Section" }]}
+                gridSelection={{
+                    current: {
+                        cell: [1, 2],
+                        range: { x: 1, y: 2, width: 1, height: 1 },
+                        rangeStack: [],
+                    },
+                    rows: CompactSelection.empty(),
+                    columns: CompactSelection.empty(),
+                }}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep(false);
+
+        expect(screen.getByTestId("glide-cell-1-3").getAttribute("aria-selected")).toBe("true");
+        expect(screen.getByTestId("glide-cell-1-2").getAttribute("aria-selected")).toBe("false");
+    });
+
+    test("Sections map edited cells and validation to data rows", async () => {
+        const editSpy = vi.fn();
+        const validateSpy = vi.fn(() => true);
+        vi.useFakeTimers();
+        render(
+            <DataEditor
+                {...basicProps}
+                rows={5}
+                onCellEdited={editSpy}
+                validateCell={validateSpy}
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 44 + 16, // Data row 2 after the section row
+        });
+
+        fireEvent.keyDown(canvas, {
+            keyCode: 74,
+            key: "j",
+        });
+
+        await act(() => new Promise(r => window.setTimeout(r, 500)));
+
+        const overlay = screen.getByDisplayValue("j");
+
+        vi.useFakeTimers();
+        fireEvent.keyDown(overlay, {
+            key: "Enter",
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        expect(validateSpy).toHaveBeenCalledWith(
+            [1, 2],
+            expect.objectContaining({ data: "j" }),
+            expect.objectContaining({ data: "j" })
+        );
+        expect(editSpy).toHaveBeenCalledWith([1, 2], expect.objectContaining({ data: "j" }));
+    });
+
+    test("Sections map copied ranges to data rows", async () => {
+        const getCellsForSelection = vi.fn((rect: Rectangle) => [
+            [
+                {
+                    kind: GridCellKind.Text,
+                    allowOverlay: true,
+                    data: `${rect.x}, ${rect.y}`,
+                    displayData: `${rect.x}, ${rect.y}`,
+                } satisfies GridCell,
+            ],
+        ]);
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                getCellsForSelection={getCellsForSelection}
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        vi.spyOn(document, "activeElement", "get").mockImplementation(() => canvas);
+        sendClick(canvas, {
+            clientX: 300, // Col B
+            clientY: 36 + 32 * 2 + 44 + 16, // Data row 2 after the section row
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        getCellsForSelection.mockClear();
+        fireEvent.copy(window);
+
+        expect(getCellsForSelection).toHaveBeenCalledWith({ x: 1, y: 2, width: 1, height: 1 }, expect.anything());
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith("1, 2");
+    });
+
+    test("Sections do not call getCellContent as data rows", async () => {
+        const getCellContent: typeof basicProps.getCellContent = vi.fn(cell => {
+            expect(cell[1]).toBeLessThan(5);
+            return basicProps.getCellContent(cell);
+        });
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                rows={5}
+                getCellContent={getCellContent}
+                sections={[{ row: 2, title: "Section" }]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        prep();
+
+        expect(getCellContent).toHaveBeenCalledWith([0, 2]);
+        expect(getCellContent).toHaveBeenCalledWith([0, 4]);
+    });
+
+    test("Sticky sections pin while scrolling", async () => {
+        const spy = vi.fn();
+        vi.useFakeTimers();
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                onGridSelectionChange={spy}
+                rowMarkers="none"
+                smoothScrollY={true}
+                sections={[
+                    { row: 0, title: "Sticky A", sticky: true, stickyStyle: "frosted" },
+                    { row: 3, title: "Sticky B", sticky: true },
+                ]}
+            />,
+            {
+                wrapper: Context,
+            }
+        );
+        const scroller = prep(false);
+        assert(scroller !== null);
+        vi.spyOn(scroller, "scrollLeft", "get").mockImplementation(() => 0);
+        const scrollTop = vi.spyOn(scroller, "scrollTop", "get");
+
+        act(() => {
+            scrollTop.mockImplementation(() => 60);
+            fireEvent.scroll(scroller);
+            vi.runAllTimers();
+        });
+
+        const stickySection = screen.getByTestId("gdg-sticky-section");
+        expect(stickySection.textContent).toBe("Sticky A");
+        expect(stickySection.style.backgroundColor).toMatch(/^rgba/);
+        spy.mockClear();
+        sendClick(stickySection);
+
+        expect(spy).not.toHaveBeenCalled();
+
+        act(() => {
+            scrollTop.mockImplementation(() => 170);
+            fireEvent.scroll(scroller);
+            vi.runAllTimers();
+        });
+
+        expect(screen.getByTestId("gdg-sticky-section").textContent).toBe("Sticky B");
     });
 
     test("Shift click row marker", async () => {

--- a/packages/core/test/data-grid-render-cells.test.ts
+++ b/packages/core/test/data-grid-render-cells.test.ts
@@ -4,9 +4,11 @@ import { RenderStateProvider } from "../src/common/render-state-provider.js";
 import { mergeAndRealizeTheme } from "../src/common/styles.js";
 import { CompactSelection, getDefaultTheme, GridCellKind } from "../src/index.js";
 import { type InnerGridCell, InnerGridCellKind, type Rectangle } from "../src/internal/data-grid/data-grid-types.js";
-import type { SpriteManager } from "../src/internal/data-grid/data-grid-sprites.js";
+import { SpriteManager } from "../src/internal/data-grid/data-grid-sprites.js";
 import type { ImageWindowLoader } from "../src/internal/data-grid/image-window-loader-interface.js";
 import { drawCells } from "../src/internal/data-grid/render/data-grid-render.cells.js";
+import { drawGrid } from "../src/internal/data-grid/render/data-grid-render.js";
+import type { DrawGridArg } from "../src/internal/data-grid/render/draw-grid-arg.js";
 import type { MappedGridColumn } from "../src/internal/data-grid/render/data-grid-lib.js";
 import { overdrawStickyBoundaries } from "../src/internal/data-grid/render/data-grid-render.lines.js";
 
@@ -58,6 +60,77 @@ function makeColumn(sourceIndex: number, sticky: boolean): MappedGridColumn {
     } as MappedGridColumn;
 }
 
+function makeDrawGridArg(
+    contexts: {
+        readonly canvasCtx: CanvasRenderingContext2D;
+        readonly headerCanvasCtx: CanvasRenderingContext2D;
+        readonly bufferACtx: CanvasRenderingContext2D;
+        readonly bufferBCtx: CanvasRenderingContext2D;
+    },
+    translateX: number,
+    columns: readonly MappedGridColumn[],
+    getCellContent: DrawGridArg["getCellContent"],
+    lastBlitData: DrawGridArg["lastBlitData"],
+    theme: DrawGridArg["theme"],
+    selection: DrawGridArg["selection"]
+): DrawGridArg {
+    return {
+        ...contexts,
+        width: 240,
+        height: 160,
+        cellXOffset: 0,
+        cellYOffset: 0,
+        translateX,
+        translateY: 0,
+        mappedColumns: columns,
+        enableGroups: false,
+        freezeColumns: 1,
+        dragAndDropState: undefined,
+        theme,
+        headerHeight: 36,
+        groupHeaderHeight: 0,
+        disabledRows: CompactSelection.empty(),
+        rowHeight: row => (row === 0 ? 44 : 32),
+        verticalBorder: () => true,
+        isResizing: false,
+        resizeCol: undefined,
+        isFocused: true,
+        drawFocus: true,
+        selection,
+        fillHandle: false,
+        freezeTrailingRows: 0,
+        hasAppendRow: false,
+        hyperWrapping: false,
+        rows: 3,
+        getCellContent,
+        overrideCursor: () => undefined,
+        getGroupDetails: () => ({ name: "" }),
+        getRowThemeOverride: undefined,
+        drawHeaderCallback: undefined,
+        drawCellCallback: undefined,
+        prelightCells: undefined,
+        highlightRegions: undefined,
+        imageLoader: {
+            loadOrGetImage: () => undefined,
+            setCallback: () => undefined,
+            setWindow: () => undefined,
+        } as ImageWindowLoader,
+        lastBlitData,
+        damage: undefined,
+        hoverValues: [],
+        hoverInfo: undefined,
+        spriteManager: new SpriteManager(undefined, () => undefined),
+        maxScaleFactor: 1,
+        touchMode: false,
+        renderStrategy: "single-buffer",
+        enqueue: () => undefined,
+        renderStateProvider: new RenderStateProvider(),
+        getCellRenderer: cell => (cell.kind === InnerGridCellKind.Section ? sectionCellRenderer : undefined),
+        minimumCellWidth: 0,
+        resizeIndicator: "none",
+    };
+}
+
 describe("drawCells", () => {
     it("draws split section spans on both sides of frozen columns", () => {
         const ctx = get2dContext();
@@ -76,7 +149,7 @@ describe("drawCells", () => {
             columns,
             140,
             36,
-            0,
+            -24,
             0,
             0,
             1,
@@ -123,6 +196,10 @@ describe("drawCells", () => {
             );
 
         expect(textCalls).toHaveLength(2);
+        expect(textCalls.map(call => call.props.text)).toEqual([
+            "Frozen section title that should continue across columns",
+            "Frozen section title that should continue across columns",
+        ]);
         expect(textCalls.map(call => call.props.x)).toEqual([
             theme.cellHorizontalPadding * 2,
             theme.cellHorizontalPadding * 2,
@@ -130,7 +207,7 @@ describe("drawCells", () => {
         expect(backgroundCalls.map(call => call.props.width)).toEqual([80, 160]);
         expect(spans).toEqual([
             { x: 0, y: 36, width: 80, height: 44 },
-            { x: 79, y: 36, width: 161, height: 44 },
+            { x: 79, y: 36, width: 137, height: 44 },
         ]);
     });
 
@@ -172,6 +249,57 @@ describe("drawCells", () => {
             expect.objectContaining({ type: "lineTo", props: { x: 80.5, y: 80 } }),
             expect.objectContaining({ type: "moveTo", props: { x: 80.5, y: 124 } }),
             expect.objectContaining({ type: "lineTo", props: { x: 80.5, y: 180 } }),
+        ]);
+    });
+
+    it("redraws section rows after horizontal blits", () => {
+        const canvasCtx = get2dContext();
+        const theme = mergeAndRealizeTheme(getDefaultTheme());
+        const columns = [makeColumn(0, true), makeColumn(1, false), makeColumn(2, false), makeColumn(3, false)];
+        const sectionCell: InnerGridCell = {
+            kind: InnerGridCellKind.Section,
+            allowOverlay: false,
+            title: "Frozen section title that should repaint after horizontal scroll",
+            span: [0, 3],
+        };
+        const loadingCell: InnerGridCell = {
+            kind: GridCellKind.Loading,
+            allowOverlay: false,
+        };
+        const getCellContent: DrawGridArg["getCellContent"] = ([, row]) => (row === 0 ? sectionCell : loadingCell);
+        const lastBlitData: DrawGridArg["lastBlitData"] = { current: undefined };
+        const selection: DrawGridArg["selection"] = {
+            columns: CompactSelection.empty(),
+            rows: CompactSelection.empty(),
+            current: undefined,
+        };
+        const contexts = {
+            canvasCtx,
+            headerCanvasCtx: get2dContext(),
+            bufferACtx: get2dContext(),
+            bufferBCtx: get2dContext(),
+        };
+
+        const firstArg = makeDrawGridArg(contexts, 0, columns, getCellContent, lastBlitData, theme, selection);
+        drawGrid(firstArg, undefined);
+
+        const drawCallCount = canvasCtx.__getDrawCalls().length;
+        const secondArg = makeDrawGridArg(contexts, -24, columns, getCellContent, lastBlitData, theme, selection);
+        drawGrid(secondArg, firstArg);
+
+        const textCalls = canvasCtx
+            .__getDrawCalls()
+            .slice(drawCallCount)
+            .filter(
+                call =>
+                    call.type === "fillText" &&
+                    call.props.text === "Frozen section title that should repaint after horizontal scroll"
+            );
+
+        expect(textCalls).toHaveLength(2);
+        expect(textCalls.map(call => call.props.x)).toEqual([
+            theme.cellHorizontalPadding * 2,
+            theme.cellHorizontalPadding * 2,
         ]);
     });
 });

--- a/packages/core/test/data-grid-render-cells.test.ts
+++ b/packages/core/test/data-grid-render-cells.test.ts
@@ -63,7 +63,7 @@ describe("drawCells", () => {
             span: [0, 2],
         };
 
-        drawCells(
+        const spans = drawCells(
             ctx,
             columns,
             columns,
@@ -121,5 +121,9 @@ describe("drawCells", () => {
             theme.cellHorizontalPadding * 2,
         ]);
         expect(backgroundCalls.map(call => call.props.width)).toEqual([80, 160]);
+        expect(spans).toEqual([
+            { x: 0, y: 36, width: 80, height: 44 },
+            { x: 79, y: 36, width: 161, height: 44 },
+        ]);
     });
 });

--- a/packages/core/test/data-grid-render-cells.test.ts
+++ b/packages/core/test/data-grid-render-cells.test.ts
@@ -2,19 +2,23 @@ import { describe, expect, it } from "vitest";
 import { sectionCellRenderer } from "../src/cells/section-cell.js";
 import { RenderStateProvider } from "../src/common/render-state-provider.js";
 import { mergeAndRealizeTheme } from "../src/common/styles.js";
-import { CompactSelection, getDefaultTheme } from "../src/index.js";
+import { CompactSelection, getDefaultTheme, GridCellKind } from "../src/index.js";
 import { type InnerGridCell, InnerGridCellKind, type Rectangle } from "../src/internal/data-grid/data-grid-types.js";
 import type { SpriteManager } from "../src/internal/data-grid/data-grid-sprites.js";
 import type { ImageWindowLoader } from "../src/internal/data-grid/image-window-loader-interface.js";
 import { drawCells } from "../src/internal/data-grid/render/data-grid-render.cells.js";
 import type { MappedGridColumn } from "../src/internal/data-grid/render/data-grid-lib.js";
+import { overdrawStickyBoundaries } from "../src/internal/data-grid/render/data-grid-render.lines.js";
 
 type CanvasDrawCall = {
     readonly type: string;
     readonly props: Record<string, unknown>;
 };
 
-function get2dContext(): CanvasRenderingContext2D & { __getDrawCalls(): CanvasDrawCall[] } {
+function get2dContext(): CanvasRenderingContext2D & {
+    __getDrawCalls(): CanvasDrawCall[];
+    __getEvents(): CanvasDrawCall[];
+} {
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
 
@@ -22,7 +26,10 @@ function get2dContext(): CanvasRenderingContext2D & { __getDrawCalls(): CanvasDr
         throw new Error("Cannot get a 2d context");
     }
 
-    return ctx as CanvasRenderingContext2D & { __getDrawCalls(): CanvasDrawCall[] };
+    return ctx as CanvasRenderingContext2D & {
+        __getDrawCalls(): CanvasDrawCall[];
+        __getEvents(): CanvasDrawCall[];
+    };
 }
 
 function makeColumn(sourceIndex: number, sticky: boolean): MappedGridColumn {
@@ -124,6 +131,47 @@ describe("drawCells", () => {
         expect(spans).toEqual([
             { x: 0, y: 36, width: 80, height: 44 },
             { x: 79, y: 36, width: 161, height: 44 },
+        ]);
+    });
+
+    it("does not overdraw frozen boundaries through section rows", () => {
+        const ctx = get2dContext();
+        const theme = mergeAndRealizeTheme(getDefaultTheme());
+        const columns = [makeColumn(0, true), makeColumn(1, false)];
+        const loadingCell: InnerGridCell = {
+            kind: GridCellKind.Loading,
+            allowOverlay: false,
+        };
+        const sectionCell: InnerGridCell = {
+            kind: InnerGridCellKind.Section,
+            allowOverlay: false,
+            title: "Section",
+            span: [0, 1],
+        };
+
+        overdrawStickyBoundaries(
+            ctx,
+            columns,
+            160,
+            180,
+            0,
+            3,
+            36,
+            0,
+            0,
+            () => true,
+            () => 44,
+            ([, row]) => (row === 1 ? sectionCell : loadingCell),
+            theme
+        );
+
+        const lineCalls = ctx.__getEvents().filter(call => call.type === "moveTo" || call.type === "lineTo");
+
+        expect(lineCalls).toEqual([
+            expect.objectContaining({ type: "moveTo", props: { x: 80.5, y: 0 } }),
+            expect.objectContaining({ type: "lineTo", props: { x: 80.5, y: 80 } }),
+            expect.objectContaining({ type: "moveTo", props: { x: 80.5, y: 124 } }),
+            expect.objectContaining({ type: "lineTo", props: { x: 80.5, y: 180 } }),
         ]);
     });
 });

--- a/packages/core/test/data-grid-render-cells.test.ts
+++ b/packages/core/test/data-grid-render-cells.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { sectionCellRenderer } from "../src/cells/section-cell.js";
+import { RenderStateProvider } from "../src/common/render-state-provider.js";
+import { mergeAndRealizeTheme } from "../src/common/styles.js";
+import { CompactSelection, getDefaultTheme } from "../src/index.js";
+import { type InnerGridCell, InnerGridCellKind, type Rectangle } from "../src/internal/data-grid/data-grid-types.js";
+import type { SpriteManager } from "../src/internal/data-grid/data-grid-sprites.js";
+import type { ImageWindowLoader } from "../src/internal/data-grid/image-window-loader-interface.js";
+import { drawCells } from "../src/internal/data-grid/render/data-grid-render.cells.js";
+import type { MappedGridColumn } from "../src/internal/data-grid/render/data-grid-lib.js";
+
+type CanvasDrawCall = {
+    readonly type: string;
+    readonly props: Record<string, unknown>;
+};
+
+function get2dContext(): CanvasRenderingContext2D & { __getDrawCalls(): CanvasDrawCall[] } {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+
+    if (ctx === null) {
+        throw new Error("Cannot get a 2d context");
+    }
+
+    return ctx as CanvasRenderingContext2D & { __getDrawCalls(): CanvasDrawCall[] };
+}
+
+function makeColumn(sourceIndex: number, sticky: boolean): MappedGridColumn {
+    return {
+        sourceIndex,
+        sticky,
+        width: 80,
+        title: "",
+        id: `${sourceIndex}`,
+        group: "",
+        grow: 0,
+        hasMenu: false,
+        icon: undefined,
+        menuIcon: undefined,
+        overlayIcon: undefined,
+        indicatorIcon: undefined,
+        style: undefined,
+        themeOverride: undefined,
+        trailingRowOptions: undefined,
+        growOffset: 0,
+        rowMarker: undefined,
+        rowMarkerChecked: undefined,
+        headerRowMarkerTheme: undefined,
+        headerRowMarkerAlwaysVisible: false,
+        headerRowMarkerDisabled: false,
+    } as MappedGridColumn;
+}
+
+describe("drawCells", () => {
+    it("draws split section spans on both sides of frozen columns", () => {
+        const ctx = get2dContext();
+        const theme = mergeAndRealizeTheme(getDefaultTheme());
+        const columns = [makeColumn(0, true), makeColumn(1, false), makeColumn(2, false)];
+        const sectionCell: InnerGridCell = {
+            kind: InnerGridCellKind.Section,
+            allowOverlay: false,
+            title: "Frozen section title that should continue across columns",
+            span: [0, 2],
+        };
+
+        drawCells(
+            ctx,
+            columns,
+            columns,
+            140,
+            36,
+            0,
+            0,
+            0,
+            1,
+            () => 44,
+            () => sectionCell,
+            () => ({ name: "" }),
+            undefined,
+            CompactSelection.empty(),
+            true,
+            true,
+            0,
+            false,
+            [],
+            undefined,
+            {
+                columns: CompactSelection.empty(),
+                rows: CompactSelection.empty(),
+                current: undefined,
+            },
+            undefined,
+            undefined,
+            {} as ImageWindowLoader,
+            {} as SpriteManager,
+            [],
+            undefined,
+            undefined,
+            false,
+            theme,
+            () => undefined,
+            new RenderStateProvider(),
+            () => sectionCellRenderer,
+            () => undefined,
+            0
+        );
+
+        const textCalls = ctx.__getDrawCalls().filter(call => call.type === "fillText");
+        const backgroundCalls = ctx
+            .__getDrawCalls()
+            .filter(
+                call =>
+                    call.type === "fillRect" &&
+                    (call.props as Rectangle).y === 36 &&
+                    (call.props as Rectangle).height === 44
+            );
+
+        expect(textCalls).toHaveLength(2);
+        expect(textCalls.map(call => call.props.x)).toEqual([
+            theme.cellHorizontalPadding * 2,
+            theme.cellHorizontalPadding * 2,
+        ]);
+        expect(backgroundCalls.map(call => call.props.width)).toEqual([80, 160]);
+    });
+});

--- a/packages/core/test/data-grid.test.tsx
+++ b/packages/core/test/data-grid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render, fireEvent, screen, cleanup } from "@testing-library/react";
 import DataGrid, { type DataGridProps, type DataGridRef } from "../src/internal/data-grid/data-grid.js";
-import { CompactSelection, GridCellKind } from "../src/internal/data-grid/data-grid-types.js";
+import { CompactSelection, GridCellKind, InnerGridCellKind } from "../src/internal/data-grid/data-grid-types.js";
 import { getDefaultTheme } from "../src/index.js";
 import { AllCellRenderers } from "../src/cells/index.js";
 import { vi, expect, describe, test, beforeEach, afterEach } from "vitest";
@@ -133,6 +133,41 @@ describe("data-grid", () => {
 
     afterEach(() => {
         cleanup();
+    });
+
+    test("Clips frozen column shadow around section rows", () => {
+        render(
+            <DataGrid
+                {...basicProps}
+                freezeColumns={1}
+                translateX={-24}
+                getCellContent={([col, row]) =>
+                    row === 1
+                        ? {
+                              kind: InnerGridCellKind.Section,
+                              allowOverlay: false,
+                              title: "Section",
+                              span: [0, basicProps.columns.length - 1],
+                          }
+                        : {
+                              kind: GridCellKind.Text,
+                              allowOverlay: false,
+                              data: `${col},${row}`,
+                              displayData: `${col},${row}`,
+                          }
+                }
+            />
+        );
+
+        const shadow = document.querySelector("#shadow-x");
+        expect(shadow).not.toBeNull();
+        const segments = Array.from(shadow?.children ?? []) as HTMLElement[];
+
+        expect(segments).toHaveLength(2);
+        expect(segments[0].style.top).toBe("0px");
+        expect(segments[0].style.height).toBe("68px");
+        expect(segments[1].style.top).toBe("100px");
+        expect(segments[1].style.height).toBe("900px");
     });
 
     test("Emits mouse down", () => {


### PR DESCRIPTION
A way to add section headers over groups of rows. 

Sections are visual, non-selectable full-width rows inserted before data row indexes through the `sections` prop. 

Section headers can be sticky, staying on the page as you scroll through the section, or not. They're also themeable.

<img width="2828" height="2150" alt="Screenshot 2026-05-21 at 23 52 11" src="https://github.com/user-attachments/assets/8dfe465d-0519-40c3-8eb6-aa021a41527d" />
