### PR TITLE
fix: prevent scrolling rows from bleeding into frozen trailing band

### DIFF
--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -256,8 +256,15 @@ export function drawCells(
                                 drawingSpan = true;
                             }
                         } else {
-                            toDraw--;
-                            return;
+                            // Frozen trailing rows: fall through with skipContents=true so each column
+                            // repaints its own fill (overwriting scrolling-row overflow past freezeY
+                            // and applying per-column selection/highlight). Content stays drawn once
+                            // by the span push above. Non-frozen spans keep the short-circuit.
+                            if (!isSticky) {
+                                toDraw--;
+                                return;
+                            }
+                            skipContents = true;
                         }
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.cells.ts
@@ -256,15 +256,8 @@ export function drawCells(
                                 drawingSpan = true;
                             }
                         } else {
-                            // Frozen trailing rows: fall through with skipContents=true so each column
-                            // repaints its own fill (overwriting scrolling-row overflow past freezeY
-                            // and applying per-column selection/highlight). Content stays drawn once
-                            // by the span push above. Non-frozen spans keep the short-circuit.
-                            if (!isSticky) {
-                                toDraw--;
-                                return;
-                            }
-                            skipContents = true;
+                            toDraw--;
+                            return;
                         }
                     }
 
@@ -364,6 +357,35 @@ export function drawCells(
                         fill = fill === undefined ? theme.bgCell : blend(fill, theme.bgCell);
                     }
 
+                    // Full-redraw counterpart to the damage-path clamp above. Columns draw left-to-right and
+                    // each paints its scrolling rows before the next column runs, so a scrolling row whose
+                    // bottom crosses into the frozen band would overwrite a spanning frozen row that an
+                    // earlier column already drew. Clip such straddling rows to the freeze boundary so the
+                    // frozen band stays reserved for frozen rows only.
+                    //
+                    // Exception: a span drawn by a sticky (frozen) column — e.g. a group-header row whose
+                    // label lives in the frozen columns. Sticky columns are re-composited over the blitted
+                    // frame every draw, and clipping that composite to the freeze boundary leaves the group
+                    // row's background a shade darker than its scrollable half (a visible two-tone seam that
+                    // accumulates while scrolling). Such a straddling group span doesn't need the clip anyway:
+                    // the frozen trailing rows are painted afterwards in each column's sticky pass and cover
+                    // any bleed. So skip the clip for sticky spans; keep it for sticky non-span cells (which
+                    // still must not bleed into the band) and for all scrollable cells.
+                    let didFreezeClip = false;
+                    if (
+                        damage === undefined &&
+                        !isSticky &&
+                        !(c.sticky && drawingSpan) &&
+                        freezeTrailingRowsHeight > 0 &&
+                        drawY + rh > height - freezeTrailingRowsHeight
+                    ) {
+                        didFreezeClip = true;
+                        ctx.save();
+                        ctx.beginPath();
+                        ctx.rect(cellX, drawY, cellWidth, height - freezeTrailingRowsHeight - drawY);
+                        ctx.clip();
+                    }
+
                     const isLastColumn = c.sourceIndex === allColumns.length - 1;
                     const isLastRow = row === rows - 1;
                     if (fill !== undefined) {
@@ -434,6 +456,10 @@ export function drawCells(
                     }
 
                     if (didDamageClip) {
+                        ctx.restore();
+                    }
+
+                    if (didFreezeClip) {
                         ctx.restore();
                     }
 

--- a/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
+++ b/packages/core/src/internal/data-grid/render/data-grid-render.walk.ts
@@ -1,5 +1,5 @@
 import { type Item, type Rectangle } from "../data-grid-types.js";
-import { type MappedGridColumn, isGroupEqual } from "./data-grid-lib.js";
+import { type MappedGridColumn, isGroupEqual, getFreezeTrailingHeight } from "./data-grid-lib.js";
 
 export function getSkipPoint(drawRegions: readonly Rectangle[]): number | undefined {
     if (drawRegions.length === 0) return undefined;
@@ -33,8 +33,15 @@ export function walkRowsInCol(
     let y = drawY;
     let row = startRow;
     const rowEnd = rows - freezeTrailingRows;
+    // Trailing frozen rows always occupy the bottom `getFreezeTrailingHeight(...)` pixels of the
+    // canvas, anchored to `height`. The scrollable loop below must stop at that boundary instead
+    // of at the raw `height` — otherwise, whenever `height` isn't an exact multiple of the row
+    // heights (the common case), ordinary rows spill into the space reserved for the frozen rows
+    // and can get repainted on top of them by a later damage/animation-driven redraw.
+    const freezeY =
+        freezeTrailingRows > 0 ? height - getFreezeTrailingHeight(rows, freezeTrailingRows, getRowHeight) : height;
     let didBreak = false;
-    while (y < height && row < rowEnd) {
+    while (y < freezeY && row < rowEnd) {
         const rh = getRowHeight(row);
         if (y + rh > skipToY && cb(y, row, rh, false, hasAppendRow && row === rows - 1) === true) {
             didBreak = true;

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -3830,6 +3830,49 @@ describe("data-editor", () => {
         });
     });
 
+    test("Span in frozen trailing row repaints fill per column (no bleed)", async () => {
+        // Regression: with a spanning cell in a frozen trailing row, every column must
+        // paint its own fill so scrolling-row overflow at freezeY is overwritten per
+        // column — not just once by the first column that hit the span.
+        vi.useFakeTimers();
+
+        const rowHeight = basicProps.rowHeight as number;
+        const spannedRow = basicProps.rows - 1;
+        const getCellContent: (typeof basicProps)["getCellContent"] = c => {
+            if (c[1] === spannedRow) {
+                return {
+                    ...basicProps.getCellContent([0, spannedRow]),
+                    span: [0, basicProps.columns.length - 1] as const,
+                };
+            }
+            return basicProps.getCellContent(c);
+        };
+
+        render(
+            <EventedDataEditor
+                {...basicProps}
+                getCellContent={getCellContent}
+                freezeTrailingRows={1}
+                trailingRowOptions={undefined}
+            />,
+            { wrapper: Context }
+        );
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas") as HTMLCanvasElement;
+        const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+        const frozenY = canvas.height - rowHeight;
+        const fillRectMock = ctx.fillRect as unknown as Mock;
+        // ±2px tolerates the damage-path +1 inset. h === rowHeight distinguishes row
+        // fills from cell decoration draws.
+        const frozenRowFills = fillRectMock.mock.calls.filter(
+            ([, y, , h]) => typeof y === "number" && Math.abs(y - frozenY) <= 2 && h === rowHeight
+        );
+
+        // Without the fix: 1 wide fill (first column only). With it: 1 wide + N-1 per-column.
+        expect(frozenRowFills.length).toBeGreaterThan(1);
+    });
+
     test("Imperative scrollTo false fire", async () => {
         vi.useFakeTimers();
         const ref = React.createRef<DataEditorRef>();

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -2689,7 +2689,10 @@ describe("data-editor", () => {
             }
         );
         prep();
-        expect(spy).toHaveBeenCalledTimes(31); // Math.ceil((height - headerHeight) / rowHeight)
+        // basicProps sets a sticky trailingRowOptions row, which reserves one rowHeight of space
+        // at the bottom of the canvas for that frozen row. The scrollable rows above it stop at
+        // that boundary rather than at the raw canvas height.
+        expect(spy).toHaveBeenCalledTimes(30); // Math.ceil((height - rowHeight - headerHeight) / rowHeight)
     });
 
     test("onCellsEdited blocks onCellEdited", async () => {
@@ -3830,10 +3833,12 @@ describe("data-editor", () => {
         });
     });
 
-    test("Span in frozen trailing row repaints fill per column (no bleed)", async () => {
-        // Regression: with a spanning cell in a frozen trailing row, every column must
-        // paint its own fill so scrolling-row overflow at freezeY is overwritten per
-        // column — not just once by the first column that hit the span.
+    test("Span in frozen trailing row draws full-width content once (no per-column overpaint)", async () => {
+        // Regression: a spanning cell in a frozen trailing row must be painted once at full width
+        // by the first column that hits it. The previous behavior repainted each column's own fill
+        // over the band (to cover scrolling-row overflow into the freeze band), which overpainted
+        // the wide span content and truncated it. Scrolling rows are now kept out of the freeze
+        // band instead, so the single wide fill survives and no narrow per-column fill lands there.
         vi.useFakeTimers();
 
         const rowHeight = basicProps.rowHeight as number;
@@ -3863,14 +3868,16 @@ describe("data-editor", () => {
         const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
         const frozenY = canvas.height - rowHeight;
         const fillRectMock = ctx.fillRect as unknown as Mock;
-        // ±2px tolerates the damage-path +1 inset. h === rowHeight distinguishes row
-        // fills from cell decoration draws.
-        const frozenRowFills = fillRectMock.mock.calls.filter(
+        // Full-redraw row fills at the frozen band. h === rowHeight distinguishes them from the
+        // damage-path (inset) fills and from cell-decoration draws.
+        const bandFills = fillRectMock.mock.calls.filter(
             ([, y, , h]) => typeof y === "number" && Math.abs(y - frozenY) <= 2 && h === rowHeight
         );
 
-        // Without the fix: 1 wide fill (first column only). With it: 1 wide + N-1 per-column.
-        expect(frozenRowFills.length).toBeGreaterThan(1);
+        // The span is filled once across the whole grid, far wider than any single column.
+        expect(bandFills.some(([, , w]) => typeof w === "number" && w > 500)).toBe(true);
+        // No column repaints its own narrow slice over the band — that overpaint truncated the span.
+        expect(bandFills.some(([, , w]) => typeof w === "number" && w < 300)).toBe(false);
     });
 
     test("Imperative scrollTo false fire", async () => {


### PR DESCRIPTION
## Problem

When a cell in a `freezeTrailingRows` row uses `span`, two visual bugs appear:

1. **Content bleed on horizontal scroll.** `walkRowsInCol` draws scrolling rows all the way to the canvas bottom — past the frozen boundary. The frozen row normally paints over that overflow, but a spanning cell only fills once (first column), so subsequent columns never overwrite the bleed.

2. **Partial highlight/selection.** Same root cause — per-column accent (selection, highlight) is skipped by the span short-circuit, so only the first non-sticky column highlights.

## Repro

- `freezeTrailingRows: 1` (or higher)
- `getCellContent` returns a cell with `span: [a, b]` for the frozen row
- Enough scrolling rows so the last one crosses the freeze boundary
- Scroll horizontally → scrolling-row data leaks inside the span
- Select the row → only the first column of the span highlights

## Fix

Three changes that prevent scrolling rows from entering the frozen band at all:

1. **Clamp `walkRowsInCol` at `freezeY`.** The scrolling-row walk loop now stops at `height - freezeTrailingRowsHeight` instead of `height`. Scrolling rows never enter the frozen zone.

2. **Clip straddling rows.** If a scrolling row's rendered rectangle still crosses `freezeY` (sub-pixel rounding), `ctx.clip` it at the boundary during full redraws.

3. **Exempt sticky spans from the clip.** Sticky columns are re-composited every frame. Clipping them would accumulate a visible seam. They don't need clipping because frozen trailing rows paint over them during the sticky pass.

## Test

Regression test in `test/data-editor.test.tsx`: renders a frozen trailing row with a spanning cell and asserts `fillRect` is called more than once at the frozen row's y. Fails on `main`; passes with the fix. Full suite passes.

Co-authored-by: Sassoun Derderian <sassound2@gmail.com>