### PR TITLE
feat(data-grid): add cell/row accessibility prop callbacks

### DIFF
--- a/packages/core/src/cells/cell-types.ts
+++ b/packages/core/src/cells/cell-types.ts
@@ -113,6 +113,7 @@ export interface InternalCellRenderer<T extends InnerGridCell> extends BaseCellR
 export interface CustomRenderer<T extends CustomCell = CustomCell> extends BaseCellRenderer<T> {
     readonly isMatch: (cell: CustomCell) => cell is T;
     readonly onPaste?: (val: string, cellData: T["data"]) => T["data"] | undefined;
+    readonly getAccessibilityString?: (cell: T) => string;
 }
 
 /** @category Renderers */

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -799,6 +799,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
         columns: columnsIn,
         rows: rowsIn,
         getCellContent,
+        getCellAccessibilityProps,
+        getRowAccessibilityProps,
         onCellClicked,
         onCellActivated,
         onFillPattern,
@@ -4263,6 +4265,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     lockColumns={rowMarkerOffset}
                     firstColAccessible={rowMarkerOffset === 0}
                     getCellContent={getMangledCellContent}
+                    getCellAccessibilityProps={getCellAccessibilityProps}
+                    getRowAccessibilityProps={getRowAccessibilityProps}
                     minColumnWidth={minColumnWidth}
                     maxColumnWidth={maxColumnWidth}
                     searchInputRef={searchInputRef}

--- a/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
+++ b/packages/core/src/internal/data-grid-dnd/data-grid-dnd.tsx
@@ -430,6 +430,8 @@ const DataGridDnd: React.FunctionComponent<DataGridDndProps> = p => {
             verticalBorder={p.verticalBorder}
             width={p.width}
             getCellContent={getMangledCellContent}
+            getCellAccessibilityProps={p.getCellAccessibilityProps}
+            getRowAccessibilityProps={p.getRowAccessibilityProps}
             isResizing={resizeCol !== undefined}
             onHeaderMenuClick={onHeaderMenuClickMangled}
             onHeaderIndicatorClick={onHeaderIndicatorClickMangled}

--- a/packages/core/src/internal/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/internal/data-grid-search/data-grid-search.tsx
@@ -505,6 +505,8 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                 fixedShadowY={p.fixedShadowY}
                 freezeColumns={p.freezeColumns}
                 getCellContent={p.getCellContent}
+                getCellAccessibilityProps={p.getCellAccessibilityProps}
+                getRowAccessibilityProps={p.getRowAccessibilityProps}
                 getCellRenderer={p.getCellRenderer}
                 getGroupDetails={p.getGroupDetails}
                 getRowThemeOverride={p.getRowThemeOverride}

--- a/packages/core/src/internal/data-grid/data-grid.tsx
+++ b/packages/core/src/internal/data-grid/data-grid.tsx
@@ -113,6 +113,18 @@ export interface DataGridProps {
 
     readonly getCellContent: (cell: Item, forceStrict?: boolean) => InnerGridCell;
     /**
+     * Provides additional HTML attributes to apply to the accessibility `<td>` element rendered for a cell. Useful
+     * for attaching custom `aria-*` attributes to individual cells in the hidden accessibility tree.
+     * @group Accessibility
+     */
+    readonly getCellAccessibilityProps?: (cell: Item) => React.TdHTMLAttributes<HTMLTableCellElement>;
+    /**
+     * Provides additional HTML attributes to apply to the accessibility `<tr>` element rendered for a row. Useful
+     * for attaching custom `aria-*` attributes to individual rows in the hidden accessibility tree.
+     * @group Accessibility
+     */
+    readonly getRowAccessibilityProps?: (row: number) => React.HTMLAttributes<HTMLTableRowElement>;
+    /**
      * Provides additional details about groups to extend group functionality.
      * @group Data
      */
@@ -328,8 +340,8 @@ export interface DataGridRef {
 }
 
 const getRowData = (cell: InnerGridCell, getCellRenderer?: GetCellRendererCallback) => {
-    if (cell.kind === GridCellKind.Custom) return cell.copyData;
     const r = getCellRenderer?.(cell);
+    if (cell.kind === GridCellKind.Custom) return r?.getAccessibilityString?.(cell) ?? cell.copyData;
     return r?.getAccessibilityString(cell) ?? "";
 };
 
@@ -347,6 +359,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
         rowHeight,
         rows,
         getCellContent,
+        getCellAccessibilityProps,
+        getRowAccessibilityProps,
         getRowThemeOverride,
         onHeaderMenuClick,
         onHeaderIndicatorClick,
@@ -1790,7 +1804,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                 role="row"
                                 aria-selected={selection.rows.hasIndex(row)}
                                 key={row}
-                                aria-rowindex={row + 2}>
+                                aria-rowindex={row + 2}
+                                {...getRowAccessibilityProps?.(row)}>
                                 {effectiveCols.map(c => {
                                     const col = c.sourceIndex;
                                     const key = packColRowToNumber(col, row);
@@ -1813,6 +1828,7 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
                                             aria-readonly={
                                                 isInnerOnlyCell(cellContent) || !isReadWriteCell(cellContent)
                                             }
+                                            {...getCellAccessibilityProps?.(location)}
                                             id={id}
                                             data-testid={id}
                                             onClick={() => {
@@ -1867,6 +1883,8 @@ const DataGrid: React.ForwardRefRenderFunction<DataGridRef, DataGridProps> = (p,
             selection,
             focusElement,
             getCellContent,
+            getCellAccessibilityProps,
+            getRowAccessibilityProps,
             canvasRef,
             onKeyDown,
             getBoundsForItem,

--- a/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
+++ b/packages/core/src/internal/scrolling-data-grid/scrolling-data-grid.tsx
@@ -284,6 +284,8 @@ const GridScroller: React.FunctionComponent<ScrollingDataGridProps> = p => {
                 fixedShadowY={p.fixedShadowY}
                 freezeColumns={p.freezeColumns}
                 getCellContent={p.getCellContent}
+                getCellAccessibilityProps={p.getCellAccessibilityProps}
+                getRowAccessibilityProps={p.getRowAccessibilityProps}
                 getCellRenderer={p.getCellRenderer}
                 getGroupDetails={p.getGroupDetails}
                 getRowThemeOverride={p.getRowThemeOverride}

--- a/packages/core/test/data-grid.test.tsx
+++ b/packages/core/test/data-grid.test.tsx
@@ -4,6 +4,7 @@ import DataGrid, { type DataGridProps, type DataGridRef } from "../src/internal/
 import { CompactSelection, GridCellKind } from "../src/internal/data-grid/data-grid-types.js";
 import { getDefaultTheme } from "../src/index.js";
 import { AllCellRenderers } from "../src/cells/index.js";
+import type { CustomRenderer } from "../src/cells/cell-types.js";
 import { vi, expect, describe, test, beforeEach, afterEach } from "vitest";
 import ImageWindowLoaderImpl from "../src/common/image-window-loader.js";
 import { mergeAndRealizeTheme } from "../src/common/styles.js";
@@ -394,5 +395,109 @@ describe("data-grid", () => {
             }),
             false
         );
+    });
+
+    test("getCellAccessibilityProps adds and overrides built-in attributes on the a11y td", () => {
+        render(
+            <DataGrid
+                {...basicProps}
+                getCellAccessibilityProps={([col, row]) => ({
+                    "aria-label": `custom-${col}-${row}`,
+                    "aria-readonly": false,
+                })}
+            />
+        );
+
+        const cell = screen.getByTestId("glide-cell-1-1");
+        expect(cell.getAttribute("aria-label")).toBe("custom-1-1");
+        // basicProps cells have allowOverlay: false, so aria-readonly would default to "true".
+        // Confirm the caller supplied value wins.
+        expect(cell.getAttribute("aria-readonly")).toBe("false");
+        expect(cell.getAttribute("role")).toBe("gridcell");
+    });
+
+    test("getRowAccessibilityProps adds and overrides built-in attributes on the a11y tr", () => {
+        render(
+            <DataGrid
+                {...basicProps}
+                getRowAccessibilityProps={row => ({
+                    "aria-label": `row-${row}`,
+                    "aria-rowindex": 999,
+                })}
+            />
+        );
+
+        const cell = screen.getByTestId("glide-cell-0-3");
+        const row = cell.closest("tr");
+        expect(row).not.toBeNull();
+        expect(row?.getAttribute("aria-label")).toBe("row-3");
+        // built-in aria-rowindex would be 5 (row + 2), confirm the caller supplied value wins.
+        expect(row?.getAttribute("aria-rowindex")).toBe("999");
+        expect(row?.getAttribute("role")).toBe("row");
+    });
+
+    test("Custom cell a11y string uses renderer's getAccessibilityString when available", () => {
+        const customRenderer: CustomRenderer<any> = {
+            kind: GridCellKind.Custom,
+            isMatch: (c): c is any => c.data?.type === "with-a11y",
+            draw: () => undefined,
+            getAccessibilityString: c => `a11y:${c.data.value}`,
+        };
+
+        render(
+            <DataGrid
+                {...basicProps}
+                getCellContent={([col, row]) => {
+                    if (col === 0 && row === 0) {
+                        return {
+                            kind: GridCellKind.Custom,
+                            allowOverlay: false,
+                            copyData: "copy-data",
+                            data: { type: "with-a11y", value: "hello" },
+                        };
+                    }
+                    return basicProps.getCellContent([col, row]);
+                }}
+                getCellRenderer={cell => {
+                    if (cell.kind === GridCellKind.Custom) return customRenderer as any;
+                    return AllCellRenderers.find(x => x.kind === cell.kind) as any;
+                }}
+            />
+        );
+
+        const cell = screen.getByTestId("glide-cell-0-0");
+        expect(cell.textContent).toBe("a11y:hello");
+    });
+
+    test("Custom cell a11y string falls back to copyData when renderer has no getAccessibilityString", () => {
+        const customRenderer: CustomRenderer<any> = {
+            kind: GridCellKind.Custom,
+            isMatch: (c): c is any => c.data?.type === "no-a11y",
+            draw: () => undefined,
+        };
+
+        render(
+            <DataGrid
+                {...basicProps}
+                getCellContent={([col, row]) => {
+                    if (col === 0 && row === 0) {
+                        return {
+                            kind: GridCellKind.Custom,
+                            allowOverlay: false,
+                            copyData: "copy-data-fallback",
+                            data: { type: "no-a11y" },
+                        };
+                    }
+                    return basicProps.getCellContent([col, row]);
+                }}
+                getCellRenderer={cell => {
+                    if (cell.kind === GridCellKind.Custom) return customRenderer as any;
+                    return AllCellRenderers.find(x => x.kind === cell.kind) as any;
+                }}
+            />
+        );
+
+        const cell = screen.getByTestId("glide-cell-0-0");
+        expect(cell.textContent).toBe("copy-data-fallback");
     });
 });


### PR DESCRIPTION
## Problem
The hidden accessibility `<table>` tree rendered alongside the canvas (used by screen readers) offered no way to customize its markup per cell/row, and had an unrelated correctness bug for custom cells:

1. **No a11y customization hooks.** The `<td>`/`<tr>` elements in the accessibility tree only ever got the grid's built-in attributes (`role`, `aria-selected`, `aria-readonly`, `aria-rowindex`, etc.). There was no way for consumers to add supplemental `aria-*` attributes (e.g. `aria-label`, `aria-describedby`) to a specific cell or row.
2. **Custom cells never used their renderer's accessibility string.** `getRowData` special-cased `GridCellKind.Custom` to always return `cell.copyData`, without ever asking the resolved `CustomRenderer` for a proper accessible description — and `CustomRenderer` didn't even expose a `getAccessibilityString` field to ask for.

## Repro
- Register a `CustomRenderer` with a `getAccessibilityString` implementation and render a `Custom` cell → the accessibility `<td>` text content is always `copyData`, the renderer's string is silently ignored.
- Try to attach an `aria-label` to an individual cell or row → no prop exists for it; `DataGridProps` only exposes grid-wide callbacks (`getCellContent`, `getRowThemeOverride`, etc.), none scoped to a11y markup.

## Fix
1. **Add `getCellAccessibilityProps?: (cell: Item) => React.TdHTMLAttributes<HTMLTableCellElement>`** and **`getRowAccessibilityProps?: (row: number) => React.HTMLAttributes<HTMLTableRowElement>`** to `DataGridProps`, threaded through the full render chain: `DataGridDnd` → `ScrollingDataGrid` → `DataGridSearch` → `DataEditor`.
2. **Spread order matters.** Caller-supplied props are spread *after* the grid's built-ins (`role`, `aria-selected`, `aria-readonly`, `aria-rowindex`) so consumers can override defaults, while props required for grid interactivity (`id`, `onClick`, `onFocusCapture`, `ref`, `tabIndex`) stay locked in after the spread.
3. **Custom cell accessibility string fix.** Added optional `getAccessibilityString?: (cell: T) => string` to the `CustomRenderer` interface. `getRowData` now resolves the renderer first and uses its `getAccessibilityString` when defined, falling back to `cell.copyData` otherwise.

## Test
New tests in `test/data-grid.test.tsx`:
- `getCellAccessibilityProps` adds custom attributes and overrides a built-in (`aria-readonly`) on the a11y `<td>`.
- `getRowAccessibilityProps` adds custom attributes and overrides a built-in (`aria-rowindex`) on the a11y `<tr>`.
- Custom cell a11y string uses the renderer's `getAccessibilityString` when provided.
- Custom cell a11y string falls back to `copyData` when the renderer has no `getAccessibilityString`.