### PR TITLE
fix: don't block editOnType for cells inside frozen regions

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3518,7 +3518,20 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                     (!showTrailingBlankRow || row !== rows) &&
                     (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width)
                 ) {
-                    return;
+                    // Frozen columns/rows are always rendered regardless of scroll position, so
+                    // being outside the tracked scrollable region doesn't mean they're off-screen.
+                    let isInFreezeArea = false;
+                    if (vr.extras?.freezeRegions !== undefined) {
+                        for (const fr of vr.extras.freezeRegions) {
+                            if (pointInRect(fr, col, row)) {
+                                isInFreezeArea = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!isInFreezeArea) {
+                        return;
+                    }
                 }
                 const activationEvent: CellActivatedEventArgs = {
                     inputType: "keyboard",

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3514,24 +3514,23 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 event.bounds !== undefined &&
                 isReadWriteCell(getCellContent([col - rowMarkerOffset, Math.max(0, Math.min(row, rows - 1))]))
             ) {
-                if (
-                    (!showTrailingBlankRow || row !== rows) &&
-                    (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width)
-                ) {
-                    // Frozen columns/rows are always rendered regardless of scroll position, so
-                    // being outside the tracked scrollable region doesn't mean they're off-screen.
-                    let isInFreezeArea = false;
-                    if (vr.extras?.freezeRegions !== undefined) {
-                        for (const fr of vr.extras.freezeRegions) {
-                            if (pointInRect(fr, col, row)) {
-                                isInFreezeArea = true;
-                                break;
-                            }
+                // Frozen columns/rows are always rendered regardless of scroll position, so being
+                // outside the tracked scrollable region doesn't mean they're off-screen.
+                let isInFreezeArea = false;
+                if (vr.extras?.freezeRegions !== undefined) {
+                    for (const fr of vr.extras.freezeRegions) {
+                        if (pointInRect(fr, col, row)) {
+                            isInFreezeArea = true;
+                            break;
                         }
                     }
-                    if (!isInFreezeArea) {
-                        return;
-                    }
+                }
+                if (
+                    (!showTrailingBlankRow || row !== rows) &&
+                    (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width) &&
+                    !isInFreezeArea
+                ) {
+                    return;
                 }
                 const activationEvent: CellActivatedEventArgs = {
                     inputType: "keyboard",

--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -3514,23 +3514,24 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
                 event.bounds !== undefined &&
                 isReadWriteCell(getCellContent([col - rowMarkerOffset, Math.max(0, Math.min(row, rows - 1))]))
             ) {
-                // Frozen columns/rows are always rendered regardless of scroll position, so being
-                // outside the tracked scrollable region doesn't mean they're off-screen.
-                let isInFreezeArea = false;
-                if (vr.extras?.freezeRegions !== undefined) {
-                    for (const fr of vr.extras.freezeRegions) {
-                        if (pointInRect(fr, col, row)) {
-                            isInFreezeArea = true;
-                            break;
-                        }
-                    }
-                }
                 if (
                     (!showTrailingBlankRow || row !== rows) &&
-                    (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width) &&
-                    !isInFreezeArea
+                    (vr.y > row || row > vr.y + vr.height || vr.x > col || col > vr.x + vr.width)
                 ) {
-                    return;
+                    // Frozen columns/rows are always rendered regardless of scroll position, so
+                    // being outside the tracked scrollable region doesn't mean they're off-screen.
+                    let isInFreezeArea = false;
+                    if (vr.extras?.freezeRegions !== undefined) {
+                        for (const fr of vr.extras.freezeRegions) {
+                            if (pointInRect(fr, col, row)) {
+                                isInFreezeArea = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!isInFreezeArea) {
+                        return;
+                    }
                 }
                 const activationEvent: CellActivatedEventArgs = {
                     inputType: "keyboard",

--- a/packages/core/test/data-editor.test.tsx
+++ b/packages/core/test/data-editor.test.tsx
@@ -705,6 +705,34 @@ describe("data-editor", () => {
         expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
     });
 
+    test("Emits activated event when typing on a frozen column outside the tracked scroll region", async () => {
+        const spy = vi.fn();
+
+        vi.useFakeTimers();
+        render(<DataEditor {...basicProps} freezeColumns={2} onCellActivated={spy} />, {
+            wrapper: Context,
+        });
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+        const [x, y] = getCellCenterPositionForDefaultGrid([1, 1]);
+        sendClick(canvas, {
+            clientX: x, // Col B, frozen (freezeColumns=2 covers cols 0 and 1)
+            clientY: y,
+        });
+
+        fireEvent.keyDown(canvas, {
+            key: "A",
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith([1, 1], expect.anything());
+    });
+
     test("keyDown and keyUp events include the cell location", async () => {
         let keyDownEvent: GridKeyEventArgs | undefined;
         let keyUpEvent: GridKeyEventArgs | undefined;


### PR DESCRIPTION
Pressing a character key to start editing a cell (`editOnType`) silently does nothing if the selected cell is inside a frozen column or row region. Enter-to-edit and click-to-edit both work fine — only the "just start typing" shortcut is affected, because it's the only activation path that consults `visibleRegionRef`, which by design excludes frozen regions from the tracked scrollable area (`vr.x`/`vr.width` end up equal to the frozen-column count, so any column with `index < freezeColumns` fails the `vr.x > col` check).

This exempts cells inside `vr.extras.freezeRegions` from that check, using the same `isInFreezeArea` pattern already established in `getMangledCellContent`'s strict-mode branch elsewhere in this file.

## Test plan
- Added a regression test confirming type-to-edit activates a cell inside a frozen column outside the tracked scroll region (`freezeColumns={2}`, second frozen column).
- Manually verified the same failure/fix behavior holds for a single frozen column (`freezeColumns={1}`) as well, confirming the bug isn't specific to 2+ frozen columns.
- Verified the new test fails without the fix and passes with it.
- Full existing suite passes (155/155 across `data-editor.test.tsx` and `data-grid.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)