### PR TITLE
fix: reset isActivelyDraggingHeader and scrollDir on native dragend

### DIFF
--- a/packages/core/src/data-editor/data-editor.tsx
+++ b/packages/core/src/data-editor/data-editor.tsx
@@ -2701,6 +2701,8 @@ const DataEditorImpl: React.ForwardRefRenderFunction<DataEditorRef, DataEditorPr
 
     const onDragEnd = React.useCallback(() => {
         isActivelyDragging.current = false;
+        isActivelyDraggingHeader.current = false;
+        setScrollDir(undefined);
     }, []);
 
     const rowGroupingSelectionBehavior = rowGrouping?.selectionBehavior;


### PR DESCRIPTION
## Summary

Dragging a column header (via the native HTML5 drag-and-drop reorder flow) leaves the grid auto-scrolling horizontally forever afterward, whenever the mouse moves near either edge — with no mouse button held. It only stops once the user clicks somewhere else on the grid.

## Root cause

`isActivelyDraggingHeader` is set `true` on `mousedown` for header cells, but is only ever cleared in `onMouseUp`. When the header press turns into a native HTML5 drag (as it does when a consumer implements column reordering via `onDragStart`/`setDragImage`/native `dragstart`), the browser delivers `dragend` to the drag source on release — not `mouseup`. So `isActivelyDraggingHeader` never gets reset.

From then on, every `mousemove` re-arms `scrollDir` from the live cursor position in `onMouseMoveImpl` (since it unconditionally does `if (isActivelyDraggingHeader.current) return [args.scrollEdge[0], 0];`), which keeps feeding the autoscroll RAF loop in `useAutoscroll` indefinitely. A subsequent click fixes it only because a real `mousedown`→`mouseup` cycle finally resets the ref.

## Fix

`onDragEnd` already fires unconditionally on the native `dragend` event. This resets `isActivelyDraggingHeader` and clears `scrollDir` there too, alongside the existing `isActivelyDragging` reset — since a `dragend` firing always means the header gesture (however it started) is over.

## Test plan

- [x] All existing tests in `packages/core` pass (154/154 in `data-editor.test.tsx` + `data-grid.test.tsx`, including the pre-existing "Dragging header disables vertical autoscroll" test)
- [x] Manually verified: dragging a column header to reorder it, then moving the mouse near an edge, no longer triggers runaway autoscroll after the drag ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)